### PR TITLE
Add settings view and split practice routes

### DIFF
--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -1,3 +1,4 @@
+// Codex change: Guarded DevTools opening behind an environment flag.
 import { app, BrowserWindow } from 'electron';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -21,10 +22,13 @@ function createWindow() {
 
   if (isDev) {
     win.loadURL(devUrl);
-    win.webContents.openDevTools({ mode: 'detach' });
   } else {
     const indexPath = path.join(__dirname, '../renderer/dist/index.html');
     win.loadFile(indexPath);
+  }
+
+  if (process.env.ELECTRON_OPEN_DEVTOOLS === '1') {
+    win.webContents.openDevTools({ mode: 'detach' });
   }
 }
 

--- a/app/renderer/App.tsx
+++ b/app/renderer/App.tsx
@@ -1,14 +1,90 @@
+// Codex change: Rebuilt the app shell with hash-based navigation and global accessibility sync.
 import React, { useEffect } from "react";
-import { Tabs } from "@components/UI/Tabs";
 import { Today } from "@components/Today";
 import { TanakhReader } from "@components/TanakhReader/Index";
 import { SiddurView } from "@components/Siddur/SiddurView";
 import { PracticeView } from "@components/Practice";
+import { AlefBetLab } from "@components/Practice/AlefBet";
+import { NiqqudBuilder } from "@components/Practice/NiqqudBuilder";
+import { WordGarden } from "@components/Practice/WordGarden";
+import { FAQ } from "@components/Practice/FAQ";
+import { TropeCoach } from "@components/Practice/TropeCoach";
+import { KabbalahOverview } from "@components/Practice/KabbalahOverview";
+import { SettingsView } from "@components/Settings/SettingsView";
+import { Tabs } from "@components/UI/Tabs";
 import { copy } from "@/copy";
 import { useSettings } from "@stores/useSettings";
 import { useContent } from "@stores/useContent";
 
-const TextsPanel: React.FC = () => (
+interface PageSectionProps {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}
+
+const practiceNavItems = [
+  { path: "/practice", label: "Overview" },
+  { path: "/alefbet", label: "Alef-Bet" },
+  { path: "/kabbalah", label: "Kabbalah" },
+  { path: "/faq", label: "Curious Questions" },
+  { path: "/vocab", label: "Word Garden" },
+  { path: "/syllables", label: "Compose a syllable" },
+  { path: "/trope", label: "Trope" }
+] as const;
+
+const primaryNavItems = [
+  { path: "/", label: copy.tabs.today },
+  { path: "/texts", label: copy.tabs.texts },
+  { path: "/practice", label: copy.tabs.practice },
+  { path: "/settings", label: "Settings" }
+] as const;
+
+const validPaths = new Set<string>([
+  ...primaryNavItems.map((item) => item.path),
+  ...practiceNavItems.map((item) => item.path)
+]);
+
+function getPathFromHash(): string {
+  const raw = window.location.hash ?? "";
+  const withoutHash = raw.startsWith("#") ? raw.slice(1) : raw;
+  if (!withoutHash || withoutHash === "/") {
+    return "/";
+  }
+  return withoutHash.startsWith("/") ? withoutHash : `/${withoutHash}`;
+}
+
+function useHashNavigation() {
+  const [path, setPath] = React.useState<string>(() => getPathFromHash());
+
+  useEffect(() => {
+    const handleHashChange = () => {
+      setPath(getPathFromHash());
+    };
+    window.addEventListener("hashchange", handleHashChange);
+    return () => window.removeEventListener("hashchange", handleHashChange);
+  }, []);
+
+  const navigate = React.useCallback((nextPath: string) => {
+    const normalized = nextPath.startsWith("/") ? nextPath : `/${nextPath}`;
+    if (window.location.hash === `#${normalized}`) return;
+    window.location.hash = normalized;
+    setPath(normalized);
+  }, []);
+
+  return { path, navigate };
+}
+
+const PageSection: React.FC<PageSectionProps> = ({ title, description, children }) => (
+  <section className="space-y-4">
+    <header className="space-y-1">
+      <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">{title}</h2>
+      {description ? <p className="text-sm text-slate-600 dark:text-slate-300">{description}</p> : null}
+    </header>
+    <div>{children}</div>
+  </section>
+);
+
+const TextsView: React.FC = () => (
   <Tabs
     tabs={[
       { id: "tanakh", label: "Tanakh", panel: <TanakhReader /> },
@@ -18,15 +94,12 @@ const TextsPanel: React.FC = () => (
 );
 
 export const App: React.FC = () => {
-  const {
-    darkMode,
-    setDarkMode,
-    largeText,
-    setLargeText,
-    dyslexiaFriendlyHebrew,
-    setDyslexiaFriendlyHebrew
-  } = useSettings();
+  const darkMode = useSettings((state) => state.darkMode);
+  const setDarkMode = useSettings((state) => state.setDarkMode);
+  const largeText = useSettings((state) => state.largeText);
+  const dyslexiaFriendlyHebrew = useSettings((state) => state.dyslexiaFriendlyHebrew);
   const hydrateContent = useContent((state) => state.hydrate);
+  const { path, navigate } = useHashNavigation();
 
   useEffect(() => {
     hydrateContent();
@@ -44,60 +117,125 @@ export const App: React.FC = () => {
   }, [darkMode]);
 
   useEffect(() => {
-    document.body.classList.toggle("large-text", largeText);
-  }, [largeText]);
+    const root = document.documentElement;
+    root.dataset.fontScale = largeText ? "large" : "base";
+    root.dataset.dyslexiaHebrew = dyslexiaFriendlyHebrew ? "true" : "false";
+  }, [largeText, dyslexiaFriendlyHebrew]);
+
+  const currentPath = path || "/";
 
   useEffect(() => {
-    document.body.classList.toggle("font-dyslexia", dyslexiaFriendlyHebrew);
-  }, [dyslexiaFriendlyHebrew]);
+    if (!validPaths.has(currentPath)) {
+      navigate("/");
+    }
+  }, [currentPath, navigate]);
+  const isPracticeSection = practiceNavItems.some((item) => item.path === currentPath);
+
+  let content: React.ReactNode;
+  switch (currentPath) {
+    case "/":
+      content = <Today />;
+      break;
+    case "/texts":
+      content = <TextsView />;
+      break;
+    case "/practice":
+      content = <PracticeView practiceNavItems={practiceNavItems} />;
+      break;
+    case "/alefbet":
+      content = (
+        <PageSection
+          title="Alef-Bet Lab"
+          description="Explore each Hebrew letter, pronunciation tips, and optional kabbalistic correspondences."
+        >
+          <AlefBetLab />
+        </PageSection>
+      );
+      break;
+    case "/kabbalah":
+      content = <KabbalahOverview />;
+      break;
+    case "/faq":
+      content = (
+        <PageSection title="Curious Questions" description="Gentle answers to common beginner questions.">
+          <FAQ />
+        </PageSection>
+      );
+      break;
+    case "/vocab":
+      content = (
+        <PageSection title="Word Garden" description="Practice vocabulary with a light-touch spaced repetition queue.">
+          <WordGarden />
+        </PageSection>
+      );
+      break;
+    case "/syllables":
+      content = (
+        <PageSection title="Compose a syllable" description="Build confidence by pairing Hebrew letters with vowel marks.">
+          <NiqqudBuilder />
+        </PageSection>
+      );
+      break;
+    case "/trope":
+      content = (
+        <PageSection title="Trope Lab" description="Cantillation trainer coming soon.">
+          <TropeCoach />
+        </PageSection>
+      );
+      break;
+    case "/settings":
+      content = <SettingsView />;
+      break;
+    default:
+      content = <Today />;
+  }
+
+  const renderNavLink = (item: { path: string; label: string }) => {
+    const active = currentPath === item.path;
+    return (
+      <a
+        key={item.path}
+        href={`#${item.path}`}
+        className={`rounded-full border px-4 py-2 text-sm font-medium transition focus:outline-none focus-visible:ring focus-visible:ring-pomegranate ${
+          active
+            ? "border-pomegranate text-pomegranate shadow"
+            : "border-slate-300 text-slate-600 hover:border-pomegranate hover:text-pomegranate dark:border-slate-600 dark:text-slate-200"
+        }`}
+      >
+        {item.label}
+      </a>
+    );
+  };
 
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900 transition dark:bg-slate-950 dark:text-slate-100">
       <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-8">
-        <header className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <h1 className="text-4xl font-extrabold text-pomegranate">{copy.appName}</h1>
-            <p className="text-sm text-slate-600 dark:text-slate-300">A gentle path into Jewish learning.</p>
-          </div>
-          <div className="flex flex-wrap items-center gap-4 text-sm">
+        <header className="space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h1 className="text-4xl font-extrabold text-pomegranate">{copy.appName}</h1>
+              <p className="text-sm text-slate-600 dark:text-slate-300">A gentle path into Jewish learning.</p>
+            </div>
             <button
               type="button"
               onClick={() => setDarkMode(!darkMode)}
-              className="rounded-full border border-slate-300 px-4 py-2 shadow-sm transition hover:border-pomegranate hover:text-pomegranate focus:outline-none focus-visible:ring focus-visible:ring-pomegranate dark:border-slate-600"
+              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium shadow-sm transition hover:border-pomegranate hover:text-pomegranate focus:outline-none focus-visible:ring focus-visible:ring-pomegranate dark:border-slate-600"
             >
               {darkMode ? "Switch to light mode" : "Switch to dark mode"}
             </button>
-            <button
-              type="button"
-              onClick={() => setLargeText(!largeText)}
-              className="rounded-full border border-slate-300 px-4 py-2 shadow-sm transition hover:border-pomegranate hover:text-pomegranate focus:outline-none focus-visible:ring focus-visible:ring-pomegranate dark:border-slate-600"
-            >
-              {largeText ? "Standard text" : "Large text"}
-            </button>
-            <button
-              type="button"
-              onClick={() => setDyslexiaFriendlyHebrew(!dyslexiaFriendlyHebrew)}
-              className="rounded-full border border-slate-300 px-4 py-2 shadow-sm transition hover:border-pomegranate hover:text-pomegranate focus:outline-none focus-visible:ring focus-visible:ring-pomegranate dark:border-slate-600"
-            >
-              {dyslexiaFriendlyHebrew ? "Default font" : "Dyslexia-friendly font"}
-            </button>
           </div>
+          <nav className="flex flex-wrap gap-2">{primaryNavItems.map(renderNavLink)}</nav>
+          {isPracticeSection ? (
+            <nav className="flex flex-wrap gap-2 text-sm">{practiceNavItems.map(renderNavLink)}</nav>
+          ) : null}
         </header>
         <main
           id="main"
           className="rounded-3xl bg-white p-6 shadow-xl ring-1 ring-slate-100 dark:bg-slate-900 dark:ring-slate-800"
         >
-          <Tabs
-            tabs={[
-              { id: "today", label: copy.tabs.today, panel: <Today /> },
-              { id: "texts", label: copy.tabs.texts, panel: <TextsPanel /> },
-              { id: "practice", label: copy.tabs.practice, panel: <PracticeView /> }
-            ]}
-          />
+          {content}
         </main>
-        <footer className="text-xs text-slate-500">
-          {copy.footerDisclaimer}
-        </footer>
+        <footer className="text-xs text-slate-500">{copy.footerDisclaimer}</footer>
       </div>
     </div>
   );

--- a/app/renderer/components/Practice/AlefBet.tsx
+++ b/app/renderer/components/Practice/AlefBet.tsx
@@ -1,3 +1,4 @@
+// Codex change: Expose Alef-Bet lab details for dedicated practice routing.
 import React from "react";
 import { useContent } from "@stores/useContent";
 import { useSettings } from "@stores/useSettings";
@@ -5,7 +6,7 @@ import { getLetterMapping, getSystemDisplayName } from "../../lib/kabbalah";
 
 export const AlefBetLab: React.FC = () => {
   const letters = useContent((state) => state.registry?.alefbet ?? []);
-  const system = useSettings((s) => s.kabbalahSystem);
+  const system = useSettings((s) => s.kabbalahSystem ?? "none");
   const systemName = getSystemDisplayName(system);
 
   return (

--- a/app/renderer/components/Practice/KabbalahOverview.tsx
+++ b/app/renderer/components/Practice/KabbalahOverview.tsx
@@ -1,0 +1,31 @@
+// Codex change: Added a placeholder Kabbalah overview page that reflects the selected system.
+import React from "react";
+import { getSystemDisplayName } from "../../lib/kabbalah";
+import { useSettings } from "@stores/useSettings";
+
+export const KabbalahOverview: React.FC = () => {
+  const system = useSettings((state) => state.kabbalahSystem);
+  const displayName = getSystemDisplayName(system);
+
+  return (
+    <section className="space-y-4">
+      <header className="space-y-1">
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">Kabbalah Mappings</h2>
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          Preview how mystical correspondences shift across traditions. Choose a system in Settings and explore the Alef-Bet lab
+          for detailed letter cards.
+        </p>
+      </header>
+      <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-6 text-sm text-slate-600 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-300">
+        <p>
+          Current system: <strong>{displayName}</strong>.
+        </p>
+        <p className="mt-2">
+          Future releases will show interactive Tree-of-Life diagrams, elemental groupings, and study notes. For now, switch
+          systems in <a className="text-pomegranate underline" href="#/settings">Settings</a> and compare how the Alef-Bet lab
+          updates.
+        </p>
+      </div>
+    </section>
+  );
+};

--- a/app/renderer/components/Practice/index.tsx
+++ b/app/renderer/components/Practice/index.tsx
@@ -1,25 +1,48 @@
+// Codex change: Converted Practice landing into a hub linking to dedicated practice routes.
 import React from "react";
-import { AlefBetLab } from "./AlefBet";
-import { NiqqudBuilder } from "./NiqqudBuilder";
-import { WordGarden } from "./WordGarden";
-import { FAQ } from "./FAQ";
-import { TropeCoach } from "./TropeCoach";
 
-export const PracticeView: React.FC = () => {
+interface PracticeNavItem {
+  path: string;
+  label: string;
+}
+
+interface PracticeViewProps {
+  practiceNavItems: readonly PracticeNavItem[];
+}
+
+const descriptions: Record<string, string> = {
+  "/practice": "Start here to see what to explore today.",
+  "/alefbet": "Study the letters with pronunciation guides and optional mystical overlays.",
+  "/kabbalah": "Preview how different kabbalah systems map to the alef-bet.",
+  "/faq": "Browse gentle answers to curious beginner questions.",
+  "/vocab": "Tend the Word Garden spaced-repetition queue.",
+  "/syllables": "Compose syllables by pairing consonants and vowels.",
+  "/trope": "Future home for cantillation training exercises."
+};
+
+export const PracticeView: React.FC<PracticeViewProps> = ({ practiceNavItems }) => {
   return (
     <div className="space-y-6">
-      <section>
-        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Alef-Bet & Reading Lab</h2>
-        <p className="text-sm text-slate-600">Explore letters, build syllables, and celebrate progress with positive reinforcement.</p>
-        <AlefBetLab />
+      <section className="space-y-2">
+        <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">Practice Lab</h2>
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          Choose an area to focus on—letters, vocabulary, mystical correspondences, or questions that arise along the way.
+        </p>
       </section>
-      <NiqqudBuilder />
-      <WordGarden />
-      <section>
-        <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Curious Questions</h2>
-        <FAQ />
-      </section>
-      <TropeCoach />
+      <div className="grid gap-4 md:grid-cols-2">
+        {practiceNavItems
+          .filter((item) => item.path !== "/practice")
+          .map((item) => (
+          <a
+            key={item.path}
+            href={`#${item.path}`}
+            className="block rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-pomegranate hover:shadow-lg focus:outline-none focus-visible:ring focus-visible:ring-pomegranate dark:border-slate-700 dark:bg-slate-900"
+          >
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{item.label}</h3>
+            <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{descriptions[item.path] ?? "Jump in and learn."}</p>
+          </a>
+        ))}
+      </div>
     </div>
   );
 };

--- a/app/renderer/components/Settings/KabbalahSystemSelector.tsx
+++ b/app/renderer/components/Settings/KabbalahSystemSelector.tsx
@@ -1,4 +1,6 @@
+// Codex change: Styled the kabbalah system selector with the shared Select wrapper.
 import React from "react";
+import { Select } from "@components/UI/Select";
 import { useSettings } from "@stores/useSettings";
 
 const OPTIONS = [
@@ -16,15 +18,11 @@ export function KabbalahSystemSelector() {
   return (
     <label className="block space-y-2">
       <span className="text-sm font-medium">Kabbalah system</span>
-      <select
-        value={system}
-        onChange={(e) => setSystem(e.target.value as any)}
-        className="rounded border px-2 py-1"
-      >
+      <Select value={system} onChange={(e) => setSystem(e.target.value as any)}>
         {OPTIONS.map((o) => (
           <option key={o.id} value={o.id}>{o.label}</option>
         ))}
-      </select>
+      </Select>
       <p className="text-xs text-slate-500">
         Traditions differ; choose with a qualified teacher. (Golden Dawn is shown for comparison.)
       </p>

--- a/app/renderer/components/Settings/SettingsView.tsx
+++ b/app/renderer/components/Settings/SettingsView.tsx
@@ -1,0 +1,100 @@
+// Codex change: Introduced a consolidated Settings page for preferences and accessibility.
+import React from "react";
+import { Select } from "@components/UI/Select";
+import { NusachSelector } from "@components/Siddur/NusachSelector";
+import { KabbalahSystemSelector } from "./KabbalahSystemSelector";
+import { useSettings } from "@stores/useSettings";
+
+const transliterationLabels = {
+  ashkenazi: "Ashkenazi",
+  sephardi: "Sephardi",
+  none: "Hide transliteration"
+} as const;
+
+type TransliterationKey = keyof typeof transliterationLabels;
+
+export const SettingsView: React.FC = () => {
+  const transliterationMode = useSettings((state) => state.transliterationMode);
+  const setTransliterationMode = useSettings((state) => state.setTransliterationMode);
+  const largeText = useSettings((state) => state.largeText);
+  const setLargeText = useSettings((state) => state.setLargeText);
+  const dyslexiaFriendlyHebrew = useSettings((state) => state.dyslexiaFriendlyHebrew);
+  const setDyslexiaFriendlyHebrew = useSettings((state) => state.setDyslexiaFriendlyHebrew);
+
+  return (
+    <div className="space-y-8">
+      <section className="space-y-4">
+        <header>
+          <h2 className="text-3xl font-bold text-slate-900 dark:text-slate-100">Settings</h2>
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            Tailor Derech for your community’s practice and personal comfort. Changes apply instantly.
+          </p>
+        </header>
+        <div className="grid gap-6 md:grid-cols-2">
+          <div className="space-y-3 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Prayer customs</h3>
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              Choose the nusach and transliteration style that matches your teacher or community.
+            </p>
+            <div className="space-y-4">
+              <NusachSelector />
+              <label className="block space-y-2 text-sm">
+                <span className="font-medium">Transliteration</span>
+                <Select
+                  value={transliterationMode}
+                  onChange={(event) => setTransliterationMode(event.target.value as TransliterationKey)}
+                >
+                  {(Object.keys(transliterationLabels) as TransliterationKey[]).map((key) => (
+                    <option key={key} value={key}>
+                      {transliterationLabels[key]}
+                    </option>
+                  ))}
+                </Select>
+              </label>
+            </div>
+          </div>
+          <div className="space-y-3 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Mystical overlays</h3>
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              Show or hide kabbalistic correspondences when studying the Alef-Bet.
+            </p>
+            <KabbalahSystemSelector />
+          </div>
+        </div>
+      </section>
+      <section className="space-y-4">
+        <h3 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">Accessibility</h3>
+        <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+          <label className="flex items-start gap-3">
+            <input
+              type="checkbox"
+              checked={largeText}
+              onChange={(event) => setLargeText(event.target.checked)}
+              className="mt-1 h-4 w-4 rounded border-slate-300 text-pomegranate focus:outline-none focus:ring-pomegranate"
+            />
+            <span>
+              <span className="block font-medium text-slate-900 dark:text-slate-100">Large text</span>
+              <span className="text-sm text-slate-600 dark:text-slate-300">
+                Increase the overall font scale for easier reading.
+              </span>
+            </span>
+          </label>
+          <label className="flex items-start gap-3">
+            <input
+              type="checkbox"
+              checked={dyslexiaFriendlyHebrew}
+              onChange={(event) => setDyslexiaFriendlyHebrew(event.target.checked)}
+              className="mt-1 h-4 w-4 rounded border-slate-300 text-pomegranate focus:outline-none focus:ring-pomegranate"
+            />
+            <span>
+              <span className="block font-medium text-slate-900 dark:text-slate-100">Dyslexia-friendly Hebrew</span>
+              <span className="text-sm text-slate-600 dark:text-slate-300">
+                Add spacing and disable ligatures for Hebrew text blocks across the app.
+              </span>
+            </span>
+          </label>
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/app/renderer/components/Siddur/NusachSelector.tsx
+++ b/app/renderer/components/Siddur/NusachSelector.tsx
@@ -1,4 +1,6 @@
+// Codex change: Routed nusach selection through the styled Select component.
 import React from "react";
+import { Select } from "@components/UI/Select";
 import { useSettings, type Nusach } from "@stores/useSettings";
 
 const NUSACH_LABELS: Record<Nusach, string> = {
@@ -14,9 +16,8 @@ export const NusachSelector: React.FC = () => {
       <label htmlFor="nusach" className="text-sm font-medium">
         Nusach
       </label>
-      <select
+      <Select
         id="nusach"
-        className="rounded-lg border border-slate-300 px-3 py-1 text-sm focus:border-pomegranate focus:outline-none focus:ring focus:ring-pomegranate/30 dark:border-slate-600 dark:bg-slate-900"
         value={nusach}
         onChange={(event) => setNusach(event.target.value as Nusach)}
       >
@@ -25,7 +26,7 @@ export const NusachSelector: React.FC = () => {
             {label}
           </option>
         ))}
-      </select>
+      </Select>
     </div>
   );
 };

--- a/app/renderer/components/Siddur/SiddurView.tsx
+++ b/app/renderer/components/Siddur/SiddurView.tsx
@@ -1,8 +1,7 @@
+// Codex change: Streamlined Siddur view to read settings and link to the dedicated Settings page.
 import React, { useMemo } from "react";
 import { useSettings } from "@stores/useSettings";
-import { NusachSelector } from "./NusachSelector";
 import { useContent } from "@stores/useContent";
-import { KabbalahSystemSelector } from "../Settings/KabbalahSystemSelector";
 
 const SECTION_LABELS: Record<string, string> = {
   morning: "Morning",
@@ -12,7 +11,7 @@ const SECTION_LABELS: Record<string, string> = {
 };
 
 export const SiddurView: React.FC = () => {
-  const { transliterationMode, setTransliterationMode } = useSettings();
+  const transliterationMode = useSettings((state) => state.transliterationMode);
   const registry = useContent((state) => state.registry);
   const prayers = registry?.siddur.basic ?? [];
 
@@ -26,27 +25,9 @@ export const SiddurView: React.FC = () => {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-center gap-4">
-        <NusachSelector />
-
-        <div className="flex items-center gap-2 text-sm">
-          <label htmlFor="translit-mode" className="font-medium">
-            Transliteration
-          </label>
-          <select
-            id="translit-mode"
-            className="rounded-lg border border-slate-300 px-3 py-1 focus:border-pomegranate focus:outline-none focus:ring focus:ring-pomegranate/30 dark:border-slate-600 dark:bg-slate-900"
-            value={transliterationMode}
-            onChange={(event) => setTransliterationMode(event.target.value as typeof transliterationMode)}
-          >
-            <option value="ashkenazi">Ashkenazi</option>
-            <option value="sephardi">Sephardi</option>
-            <option value="none">Hide transliteration</option>
-          </select>
-        </div>
-
-        {/* NEW: Kabbalah system selector */}
-        <KabbalahSystemSelector />
+      <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300">
+        Prayer preferences now live in <a className="font-medium text-pomegranate underline" href="#/settings">Settings</a>.
+        Adjust nusach, transliteration style, and kabbalah overlays there.
       </div>
 
       {Object.entries(grouped).map(([section, sectionPrayers]) => (

--- a/app/renderer/components/UI/Select.tsx
+++ b/app/renderer/components/UI/Select.tsx
@@ -1,0 +1,24 @@
+// Codex change: Added a themed select wrapper for consistent light/dark styling.
+import React from "react";
+import clsx from "clsx";
+
+export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>;
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <select
+        ref={ref}
+        className={clsx(
+          "rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-pomegranate focus:outline-none focus:ring focus:ring-pomegranate/30 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </select>
+    );
+  }
+);
+
+Select.displayName = "Select";

--- a/app/renderer/main.tsx
+++ b/app/renderer/main.tsx
@@ -1,7 +1,9 @@
+// Codex change: Bootstrapped global accessibility styles for renderer startup.
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./main.css";
+import "./styles/a11y.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/app/renderer/stores/useSettings.ts
+++ b/app/renderer/stores/useSettings.ts
@@ -1,3 +1,4 @@
+// Codex change: Ensured settings expose accessibility and kabbalah preferences for new views.
 import { create } from "zustand";
 
 export type Nusach = "ashkenaz" | "sefard" | "edot-mizrach";
@@ -20,6 +21,7 @@ export interface SettingsState {
   dyslexiaFriendlyHebrew: boolean;
   nusach: Nusach;
   transliterationMode: TransliterationMode;
+  kabbalahSystem: "none" | "gra" | "ari" | "ramak" | "kircher";
   location: LocationSettings;
   zmanimOffsets: ZmanimOffsets;
   minhagProfile?: string; // reserved for future customisations
@@ -28,6 +30,7 @@ export interface SettingsState {
   setDyslexiaFriendlyHebrew: (value: boolean) => void;
   setNusach: (nusach: Nusach) => void;
   setTransliterationMode: (mode: TransliterationMode) => void;
+  setKabbalahSystem: (system: "none" | "gra" | "ari" | "ramak" | "kircher") => void;
   setLocation: (location: LocationSettings) => void;
   setZmanimOffsets: (offsets: ZmanimOffsets) => void;
 }
@@ -44,6 +47,7 @@ export const useSettings = create<SettingsState>((set) => ({
   dyslexiaFriendlyHebrew: false,
   nusach: "ashkenaz",
   transliterationMode: "ashkenazi",
+  kabbalahSystem: "none",
   location: defaultLocation,
   zmanimOffsets: {
     dawnOffsetMinutes: -72,
@@ -54,6 +58,7 @@ export const useSettings = create<SettingsState>((set) => ({
   setDyslexiaFriendlyHebrew: (value) => set({ dyslexiaFriendlyHebrew: value }),
   setNusach: (nusach) => set({ nusach }),
   setTransliterationMode: (mode) => set({ transliterationMode: mode }),
+  setKabbalahSystem: (system) => set({ kabbalahSystem: system }),
   setLocation: (location) => set({ location }),
   setZmanimOffsets: (offsets) => set({ zmanimOffsets: offsets })
 }));

--- a/app/renderer/styles/a11y.css
+++ b/app/renderer/styles/a11y.css
@@ -1,0 +1,28 @@
+/* // Codex change: Provide global accessibility theming for font scaling and dyslexia-friendly Hebrew. */
+:root {
+  --codex-font-scale: 100%;
+}
+
+html {
+  font-size: var(--codex-font-scale);
+}
+
+[data-font-scale="large"] {
+  --codex-font-scale: 112%;
+}
+
+[data-font-scale="large"] body {
+  line-height: 1.7;
+}
+
+[data-dyslexia-hebrew="true"] [dir="rtl"],
+[data-dyslexia-hebrew="true"] .hebrew {
+  letter-spacing: 0.05em;
+  line-height: 1.8;
+  font-variant-ligatures: none;
+  font-feature-settings: "liga" 0, "rlig" 0;
+}
+
+[data-dyslexia-hebrew="true"] [dir="rtl"] {
+  word-spacing: 0.1em;
+}


### PR DESCRIPTION
## Summary
- rebuild the renderer shell with hash-based navigation, primary/practice navs, and document-level accessibility attributes
- add a consolidated settings view with styled selects plus global CSS for large text and dyslexia-friendly Hebrew
- split practice content into dedicated routes, including a placeholder Kabbalah overview, and guard Electron devtools behind an env flag

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc9a835a808333aad2850660ca4b7c