### PR TITLE
Remove community Tanakh translation

### DIFF
--- a/app/renderer/components/Texts/ChapterView.tsx
+++ b/app/renderer/components/Texts/ChapterView.tsx
@@ -13,7 +13,6 @@ import {
 
 const translationOptions: { id: TanakhTranslationId; label: string }[] = [
   { id: "he-taamei", label: "Hebrew (Ta'amei Hamikra)" },
-  { id: "en-sct", label: "English (Sefaria Community)" },
   { id: "en-jps1917", label: "English (JPS 1917)" },
   { id: "ar-onqelos", label: "Targum Onqelos (Aramaic)" }
 ];
@@ -37,8 +36,7 @@ export const ChapterView: React.FC<ChapterViewProps> = ({ sectionSlug, bookSlug,
   const availability = React.useMemo(() => {
     return {
       "he-taamei": Boolean(book?.available?.he ?? hasTranslation(bookSlug, "he-taamei")),
-      "en-sct": Boolean(book?.available?.en?.sct ?? hasTranslation(bookSlug, "en-sct")),
-      "en-jps1917": Boolean(book?.available?.en?.jps1917 ?? hasTranslation(bookSlug, "en-jps1917")),
+      "en-jps1917": Boolean(book?.available?.en ?? hasTranslation(bookSlug, "en-jps1917")),
       "ar-onqelos": Boolean(book?.available?.onqelos ?? hasTranslation(bookSlug, "ar-onqelos"))
     };
   }, [book?.available, bookSlug]);
@@ -46,7 +44,6 @@ export const ChapterView: React.FC<ChapterViewProps> = ({ sectionSlug, bookSlug,
   const defaultTranslation = React.useMemo<TanakhTranslationId>(() => {
     const preferredOrder: TanakhTranslationId[] = [
       "he-taamei",
-      "en-sct",
       "en-jps1917",
       "ar-onqelos"
     ];

--- a/app/renderer/components/Texts/ParshaView.tsx
+++ b/app/renderer/components/Texts/ParshaView.tsx
@@ -14,7 +14,6 @@ import type { ParshaRangeEntry } from "@/types";
 
 const translationOptions: { id: TanakhTranslationId; label: string }[] = [
   { id: "he-taamei", label: "Hebrew (Ta'amei Hamikra)" },
-  { id: "en-sct", label: "English (Sefaria Community)" },
   { id: "en-jps1917", label: "English (JPS 1917)" },
   { id: "ar-onqelos", label: "Targum Onqelos (Aramaic)" }
 ];
@@ -102,21 +101,19 @@ export const ParshaView: React.FC<ParshaViewProps> = ({ parshaSlug }) => {
   const availability = React.useMemo(() => {
     const fallback = {
       "he-taamei": parshaRange ? hasTranslation(parshaRange.book, "he-taamei") : false,
-      "en-sct": parshaRange ? hasTranslation(parshaRange.book, "en-sct") : false,
       "en-jps1917": parshaRange ? hasTranslation(parshaRange.book, "en-jps1917") : false,
       "ar-onqelos": parshaRange ? hasTranslation(parshaRange.book, "ar-onqelos") : false
     };
     if (!book?.book) return fallback;
     return {
       "he-taamei": book.book.available.he ?? fallback["he-taamei"],
-      "en-sct": book.book.available.en?.sct ?? fallback["en-sct"],
-      "en-jps1917": book.book.available.en?.jps1917 ?? fallback["en-jps1917"],
+      "en-jps1917": book.book.available.en ?? fallback["en-jps1917"],
       "ar-onqelos": book.book.available.onqelos ?? fallback["ar-onqelos"]
     };
   }, [book?.book, parshaRange]);
 
   const defaultTranslation = React.useMemo<TanakhTranslationId>(() => {
-    const order: TanakhTranslationId[] = ["he-taamei", "en-sct", "en-jps1917", "ar-onqelos"];
+    const order: TanakhTranslationId[] = ["he-taamei", "en-jps1917", "ar-onqelos"];
     for (const option of order) {
       if (availability[option]) {
         return option;

--- a/app/renderer/data/metadata/tanakh.manifest.json
+++ b/app/renderer/data/metadata/tanakh.manifest.json
@@ -8,10 +8,7 @@
       "chapters": 50,
       "available": {
         "he": true,
-        "en": {
-          "sct": true,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": true
       }
     },
@@ -22,10 +19,7 @@
       "chapters": 40,
       "available": {
         "he": true,
-        "en": {
-          "sct": true,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": true
       }
     },
@@ -36,10 +30,7 @@
       "chapters": 27,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -50,10 +41,7 @@
       "chapters": 36,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -64,10 +52,7 @@
       "chapters": 34,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -78,10 +63,7 @@
       "chapters": 24,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -92,10 +74,7 @@
       "chapters": 31,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -106,10 +85,7 @@
       "chapters": 24,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -120,10 +96,7 @@
       "chapters": 22,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -134,10 +107,7 @@
       "chapters": 25,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -148,10 +118,7 @@
       "chapters": 66,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -162,10 +129,7 @@
       "chapters": 52,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -176,10 +140,7 @@
       "chapters": 48,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -190,10 +151,7 @@
       "chapters": 14,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -204,10 +162,7 @@
       "chapters": 4,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -218,10 +173,7 @@
       "chapters": 9,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -232,10 +184,7 @@
       "chapters": 1,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -246,10 +195,7 @@
       "chapters": 4,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -260,10 +206,7 @@
       "chapters": 7,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -274,10 +217,7 @@
       "chapters": 3,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -288,10 +228,7 @@
       "chapters": 3,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -302,10 +239,7 @@
       "chapters": 3,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -316,10 +250,7 @@
       "chapters": 2,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -330,10 +261,7 @@
       "chapters": 14,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -344,10 +272,7 @@
       "chapters": 3,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -358,10 +283,7 @@
       "chapters": 150,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -372,10 +294,7 @@
       "chapters": 1,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -386,10 +305,7 @@
       "chapters": 42,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -400,10 +316,7 @@
       "chapters": 8,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -414,10 +327,7 @@
       "chapters": 4,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -428,10 +338,7 @@
       "chapters": 5,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -442,10 +349,7 @@
       "chapters": 12,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -456,10 +360,7 @@
       "chapters": 10,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -470,10 +371,7 @@
       "chapters": 12,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -484,10 +382,7 @@
       "chapters": 10,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -498,10 +393,7 @@
       "chapters": 13,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -512,10 +404,7 @@
       "chapters": 29,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     },
@@ -526,10 +415,7 @@
       "chapters": 36,
       "available": {
         "he": true,
-        "en": {
-          "sct": false,
-          "jps1917": true
-        },
+        "en": true,
         "onqelos": false
       }
     }

--- a/app/renderer/data/packs/tanakh/en/books/exodus.json
+++ b/app/renderer/data/packs/tanakh/en/books/exodus.json
@@ -7,178 +7,112 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": "These are Israel's sons' names, the travelers to Egypt, with Jacob a man and his family came.",
-            "jps1917": "NOW THESE are the names of the sons of Israel, who came into Egypt with Jacob; every man came with his household:"
-          },
+          "en": "NOW THESE are the names of the sons of Israel, who came into Egypt with Jacob; every man came with his household:",
           "ref": "exodus 1:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "Reuben, Simeon, Levi, and Judah;"
-          },
+          "en": "Reuben, Simeon, Levi, and Judah;",
           "ref": "exodus 1:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "Issachar, Zebulun, and Benjamin;"
-          },
+          "en": "Issachar, Zebulun, and Benjamin;",
           "ref": "exodus 1:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "Dan and Naphtali, Gad and Asher."
-          },
+          "en": "Dan and Naphtali, Gad and Asher.",
           "ref": "exodus 1:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And all the souls that came out of the loins of Jacob were seventy souls; and Joseph was in Egypt already."
-          },
+          "en": "And all the souls that came out of the loins of Jacob were seventy souls; and Joseph was in Egypt already.",
           "ref": "exodus 1:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph died, and all his brethren, and all that generation."
-          },
+          "en": "And Joseph died, and all his brethren, and all that generation.",
           "ref": "exodus 1:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And the children of Israel were fruitful, and increased abundantly, and multiplied, and waxed exceeding mighty; and the land was filled with them."
-          },
+          "en": "And the children of Israel were fruitful, and increased abundantly, and multiplied, and waxed exceeding mighty; and the land was filled with them.",
           "ref": "exodus 1:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "Now there arose a new king over Egypt, who knew not Joseph."
-          },
+          "en": "Now there arose a new king over Egypt, who knew not Joseph.",
           "ref": "exodus 1:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto his people: ‘Behold, the people of the children of Israel are too many and too mighty for us;"
-          },
+          "en": "And he said unto his people: ‘Behold, the people of the children of Israel are too many and too mighty for us;",
           "ref": "exodus 1:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "come, let us deal wisely with them, lest they multiply, and it come to pass, that, when there befalleth us any war, they also join themselves unto our enemies, and fight against us, and get them up out of the land.’"
-          },
+          "en": "come, let us deal wisely with them, lest they multiply, and it come to pass, that, when there befalleth us any war, they also join themselves unto our enemies, and fight against us, and get them up out of the land.’",
           "ref": "exodus 1:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "Therefore they did set over them taskmasters to afflict them with their burdens. And they built for Pharaoh store-cities, Pithom and Raamses."
-          },
+          "en": "Therefore they did set over them taskmasters to afflict them with their burdens. And they built for Pharaoh store-cities, Pithom and Raamses.",
           "ref": "exodus 1:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "But the more they afflicted them, the more they multiplied and the more they spread abroad. And they were adread because of the children of Israel."
-          },
+          "en": "But the more they afflicted them, the more they multiplied and the more they spread abroad. And they were adread because of the children of Israel.",
           "ref": "exodus 1:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And the Egyptians made the children of Israel to serve with rigour."
-          },
+          "en": "And the Egyptians made the children of Israel to serve with rigour.",
           "ref": "exodus 1:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And they made their lives bitter with hard service, in mortar and in brick, and in all manner of service in the field; in all their service, wherein they made them serve with rigour."
-          },
+          "en": "And they made their lives bitter with hard service, in mortar and in brick, and in all manner of service in the field; in all their service, wherein they made them serve with rigour.",
           "ref": "exodus 1:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And the king of Egypt spoke to the Hebrew midwives, of whom the name of the one was Shiphrah, and the name of the other Puah;"
-          },
+          "en": "And the king of Egypt spoke to the Hebrew midwives, of whom the name of the one was Shiphrah, and the name of the other Puah;",
           "ref": "exodus 1:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "and he said: ‘When ye do the office of a midwife to the Hebrew women, ye shall look upon the birthstool: if it be a son, then ye shall kill him; but if it be a daughter, then she shall live.’"
-          },
+          "en": "and he said: ‘When ye do the office of a midwife to the Hebrew women, ye shall look upon the birthstool: if it be a son, then ye shall kill him; but if it be a daughter, then she shall live.’",
           "ref": "exodus 1:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "But the midwives feared God, and did not as the king of Egypt commanded them, but saved the men-children alive."
-          },
+          "en": "But the midwives feared God, and did not as the king of Egypt commanded them, but saved the men-children alive.",
           "ref": "exodus 1:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And the king of Egypt called for the midwives, and said unto them: ‘Why have ye done this thing, and have saved the men-children alive?’"
-          },
+          "en": "And the king of Egypt called for the midwives, and said unto them: ‘Why have ye done this thing, and have saved the men-children alive?’",
           "ref": "exodus 1:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And the midwives said unto Pharaoh: ‘Because the Hebrew women are not as the Egyptian women; for they are lively, and are delivered ere the midwife come unto them.’"
-          },
+          "en": "And the midwives said unto Pharaoh: ‘Because the Hebrew women are not as the Egyptian women; for they are lively, and are delivered ere the midwife come unto them.’",
           "ref": "exodus 1:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And God dealt well with the midwives; and the people multiplied, and waxed very mighty."
-          },
+          "en": "And God dealt well with the midwives; and the people multiplied, and waxed very mighty.",
           "ref": "exodus 1:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, because the midwives feared God, that He made them houses."
-          },
+          "en": "And it came to pass, because the midwives feared God, that He made them houses.",
           "ref": "exodus 1:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh charged all his people, saying: ‘Every son that is born ye shall cast into the river, and every daughter ye shall save alive.’"
-          },
+          "en": "And Pharaoh charged all his people, saying: ‘Every son that is born ye shall cast into the river, and every daughter ye shall save alive.’",
           "ref": "exodus 1:22"
         }
       ]
@@ -188,202 +122,127 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And there went a man of the house of Levi, and took to wife a daughter of Levi."
-          },
+          "en": "And there went a man of the house of Levi, and took to wife a daughter of Levi.",
           "ref": "exodus 2:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And the woman conceived, and bore a son; and when she saw him that he was a goodly child, she hid him three months."
-          },
+          "en": "And the woman conceived, and bore a son; and when she saw him that he was a goodly child, she hid him three months.",
           "ref": "exodus 2:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And when she could not longer hide him, she took for him an ark of bulrushes, and daubed it with slime and with pitch; and she put the child therein, and laid it in the flags by the river’s brink."
-          },
+          "en": "And when she could not longer hide him, she took for him an ark of bulrushes, and daubed it with slime and with pitch; and she put the child therein, and laid it in the flags by the river’s brink.",
           "ref": "exodus 2:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And his sister stood afar off, to know what would be done to him."
-          },
+          "en": "And his sister stood afar off, to know what would be done to him.",
           "ref": "exodus 2:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And the daughter of Pharaoh came down to bathe in the river; and her maidens walked along by the river-side; and she saw the ark among the flags, and sent her handmaid to fetch it."
-          },
+          "en": "And the daughter of Pharaoh came down to bathe in the river; and her maidens walked along by the river-side; and she saw the ark among the flags, and sent her handmaid to fetch it.",
           "ref": "exodus 2:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And she opened it, and saw it, even the child; and behold a boy that wept. And she had compassion on him, and said: ‘This is one of the Hebrews’children.’"
-          },
+          "en": "And she opened it, and saw it, even the child; and behold a boy that wept. And she had compassion on him, and said: ‘This is one of the Hebrews’children.’",
           "ref": "exodus 2:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "Then said his sister to Pharaoh’s daughter: ‘Shall I go and call thee a nurse of the Hebrew women, that she may nurse the child for thee?’"
-          },
+          "en": "Then said his sister to Pharaoh’s daughter: ‘Shall I go and call thee a nurse of the Hebrew women, that she may nurse the child for thee?’",
           "ref": "exodus 2:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh’s daughter said to her: ‘Go.’ And the maiden went and called the child’s mother."
-          },
+          "en": "And Pharaoh’s daughter said to her: ‘Go.’ And the maiden went and called the child’s mother.",
           "ref": "exodus 2:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh’s daughter said unto her: ‘Take this child away, and nurse it for me, and I will give thee thy wages.’ And the woman took the child, and nursed it."
-          },
+          "en": "And Pharaoh’s daughter said unto her: ‘Take this child away, and nurse it for me, and I will give thee thy wages.’ And the woman took the child, and nursed it.",
           "ref": "exodus 2:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And the child grew, and she brought him unto Pharaoh’s daughter, and he became her son. And she called his name Moses, and said: ‘Because I drew him out of the water.’"
-          },
+          "en": "And the child grew, and she brought him unto Pharaoh’s daughter, and he became her son. And she called his name Moses, and said: ‘Because I drew him out of the water.’",
           "ref": "exodus 2:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass in those days, when Moses was grown up, that he went out unto his brethren, and looked on their burdens; and he saw an Egyptian smiting a Hebrew, one of his brethren."
-          },
+          "en": "And it came to pass in those days, when Moses was grown up, that he went out unto his brethren, and looked on their burdens; and he saw an Egyptian smiting a Hebrew, one of his brethren.",
           "ref": "exodus 2:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And he looked this way and that way, and when he saw that there was no man, he smote the Egyptian, and hid him in the sand."
-          },
+          "en": "And he looked this way and that way, and when he saw that there was no man, he smote the Egyptian, and hid him in the sand.",
           "ref": "exodus 2:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And he went out the second day, and, behold, two men of the Hebrews were striving together; and he said to him that did the wrong: ‘Wherefore smitest thou thy fellow?’"
-          },
+          "en": "And he went out the second day, and, behold, two men of the Hebrews were striving together; and he said to him that did the wrong: ‘Wherefore smitest thou thy fellow?’",
           "ref": "exodus 2:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Who made thee a ruler and a judge over us? thinkest thou to kill me, as thou didst kill the Egyptian?’ And Moses feared, and said: ‘Surely the thing is known.’"
-          },
+          "en": "And he said: ‘Who made thee a ruler and a judge over us? thinkest thou to kill me, as thou didst kill the Egyptian?’ And Moses feared, and said: ‘Surely the thing is known.’",
           "ref": "exodus 2:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "Now when Pharaoh heard this thing, he sought to slay Moses. But Moses fled from the face of Pharaoh, and dwelt in the land of Midian; and he sat down by a well."
-          },
+          "en": "Now when Pharaoh heard this thing, he sought to slay Moses. But Moses fled from the face of Pharaoh, and dwelt in the land of Midian; and he sat down by a well.",
           "ref": "exodus 2:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "Now the priest of Midian had seven daughters; and they came and drew water, and filled the troughs to water their father’s flock."
-          },
+          "en": "Now the priest of Midian had seven daughters; and they came and drew water, and filled the troughs to water their father’s flock.",
           "ref": "exodus 2:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And the shepherds came and drove them away; but Moses stood up and helped them, and watered their flock."
-          },
+          "en": "And the shepherds came and drove them away; but Moses stood up and helped them, and watered their flock.",
           "ref": "exodus 2:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And when they came to Reuel their father, he said: ‘How is it that ye are come so soon to-day?’"
-          },
+          "en": "And when they came to Reuel their father, he said: ‘How is it that ye are come so soon to-day?’",
           "ref": "exodus 2:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said: ‘An Egyptian delivered us out of the hand of the shepherds, and moreover he drew water for us, and watered the flock.’"
-          },
+          "en": "And they said: ‘An Egyptian delivered us out of the hand of the shepherds, and moreover he drew water for us, and watered the flock.’",
           "ref": "exodus 2:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto his daughters: ‘And where is he? Why is it that ye have left the man? call him, that he may eat bread.’"
-          },
+          "en": "And he said unto his daughters: ‘And where is he? Why is it that ye have left the man? call him, that he may eat bread.’",
           "ref": "exodus 2:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses was content to dwell with the man; and he gave Moses Zipporah his daughter."
-          },
+          "en": "And Moses was content to dwell with the man; and he gave Moses Zipporah his daughter.",
           "ref": "exodus 2:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And she bore a son, and he called his name Gershom; for he said: ‘I have been a stranger in a strange land.’"
-          },
+          "en": "And she bore a son, and he called his name Gershom; for he said: ‘I have been a stranger in a strange land.’",
           "ref": "exodus 2:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass in the course of those many days that the king of Egypt died; and the children of Israel sighed by reason of the bondage, and they cried, and their cry came up unto God by reason of the bondage."
-          },
+          "en": "And it came to pass in the course of those many days that the king of Egypt died; and the children of Israel sighed by reason of the bondage, and they cried, and their cry came up unto God by reason of the bondage.",
           "ref": "exodus 2:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And God heard their groaning, and God remembered His covenant with Abraham, with Isaac, and with Jacob."
-          },
+          "en": "And God heard their groaning, and God remembered His covenant with Abraham, with Isaac, and with Jacob.",
           "ref": "exodus 2:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And God saw the children of Israel, and God took cognizance of them."
-          },
+          "en": "And God saw the children of Israel, and God took cognizance of them.",
           "ref": "exodus 2:25"
         }
       ]
@@ -393,178 +252,112 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "Now Moses was keeping the flock of Jethro his father-in-law, the priest of Midian; and he led the flock to the farthest end of the wilderness, and came to the mountain of God, unto Horeb."
-          },
+          "en": "Now Moses was keeping the flock of Jethro his father-in-law, the priest of Midian; and he led the flock to the farthest end of the wilderness, and came to the mountain of God, unto Horeb.",
           "ref": "exodus 3:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And the angel of the LORD appeared unto him in a flame of fire out of the midst of a bush; and he looked, and, behold, the bush burned with fire, and the bush was not consumed."
-          },
+          "en": "And the angel of the LORD appeared unto him in a flame of fire out of the midst of a bush; and he looked, and, behold, the bush burned with fire, and the bush was not consumed.",
           "ref": "exodus 3:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said: ‘I will turn aside now, and see this great sight, why the bush is not burnt.’"
-          },
+          "en": "And Moses said: ‘I will turn aside now, and see this great sight, why the bush is not burnt.’",
           "ref": "exodus 3:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And when the LORD saw that he turned aside to see, God called unto him out of the midst of the bush, and said: ‘Moses, Moses.’ And he said: ‘Here am I.’"
-          },
+          "en": "And when the LORD saw that he turned aside to see, God called unto him out of the midst of the bush, and said: ‘Moses, Moses.’ And he said: ‘Here am I.’",
           "ref": "exodus 3:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And He said: ‘Draw not nigh hither; put off thy shoes from off thy feet, for the place whereon thou standest is holy ground.’"
-          },
+          "en": "And He said: ‘Draw not nigh hither; put off thy shoes from off thy feet, for the place whereon thou standest is holy ground.’",
           "ref": "exodus 3:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "Moreover He said: ‘I am the God of thy father, the God of Abraham, the God of Isaac, and the God of Jacob.’ And Moses hid his face; for he was afraid to look upon God."
-          },
+          "en": "Moreover He said: ‘I am the God of thy father, the God of Abraham, the God of Isaac, and the God of Jacob.’ And Moses hid his face; for he was afraid to look upon God.",
           "ref": "exodus 3:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said: ‘I have surely seen the affliction of My people that are in Egypt, and have heard their cry by reason of their taskmasters; for I know their pains;"
-          },
+          "en": "And the LORD said: ‘I have surely seen the affliction of My people that are in Egypt, and have heard their cry by reason of their taskmasters; for I know their pains;",
           "ref": "exodus 3:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "and I am come down to deliver them out of the hand of the Egyptians, and to bring them up out of that land unto a good land and a large, unto a land flowing with milk and honey; unto the place of the Canaanite, and the Hittite, and the Amorite, and the Perizzite, and the Hivite, and the Jebusite."
-          },
+          "en": "and I am come down to deliver them out of the hand of the Egyptians, and to bring them up out of that land unto a good land and a large, unto a land flowing with milk and honey; unto the place of the Canaanite, and the Hittite, and the Amorite, and the Perizzite, and the Hivite, and the Jebusite.",
           "ref": "exodus 3:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And now, behold, the cry of the children of Israel is come unto Me; moreover I have seen the oppression wherewith the Egyptians oppress them."
-          },
+          "en": "And now, behold, the cry of the children of Israel is come unto Me; moreover I have seen the oppression wherewith the Egyptians oppress them.",
           "ref": "exodus 3:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "Come now therefore, and I will send thee unto Pharaoh, that thou mayest bring forth My people the children of Israel out of Egypt.’"
-          },
+          "en": "Come now therefore, and I will send thee unto Pharaoh, that thou mayest bring forth My people the children of Israel out of Egypt.’",
           "ref": "exodus 3:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto God: ‘Who am I, that I should go unto Pharaoh, and that I should bring forth the children of Israel out of Egypt?’"
-          },
+          "en": "And Moses said unto God: ‘Who am I, that I should go unto Pharaoh, and that I should bring forth the children of Israel out of Egypt?’",
           "ref": "exodus 3:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And He said: ‘Certainly I will be with thee; and this shall be the token unto thee, that I have sent thee: when thou hast brought forth the people out of Egypt, ye shall serve God upon this mountain.’"
-          },
+          "en": "And He said: ‘Certainly I will be with thee; and this shall be the token unto thee, that I have sent thee: when thou hast brought forth the people out of Egypt, ye shall serve God upon this mountain.’",
           "ref": "exodus 3:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto God: ‘Behold, when I come unto the children of Israel, and shall say unto them: The God of your fathers hath sent me unto you; and they shall say to me: What is His name? what shall I say unto them?’"
-          },
+          "en": "And Moses said unto God: ‘Behold, when I come unto the children of Israel, and shall say unto them: The God of your fathers hath sent me unto you; and they shall say to me: What is His name? what shall I say unto them?’",
           "ref": "exodus 3:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said unto Moses: ‘I AM THAT I AM’; and He said: ‘Thus shalt thou say unto the children of Israel: I AM hath sent me unto you.’"
-          },
+          "en": "And God said unto Moses: ‘I AM THAT I AM’; and He said: ‘Thus shalt thou say unto the children of Israel: I AM hath sent me unto you.’",
           "ref": "exodus 3:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said moreover unto Moses: ‘Thus shalt thou say unto the children of Israel: The LORD, the God of your fathers, the God of Abraham, the God of Isaac, and the God of Jacob, hath sent me unto you; this is My name for ever, and this is My memorial unto all generations."
-          },
+          "en": "And God said moreover unto Moses: ‘Thus shalt thou say unto the children of Israel: The LORD, the God of your fathers, the God of Abraham, the God of Isaac, and the God of Jacob, hath sent me unto you; this is My name for ever, and this is My memorial unto all generations.",
           "ref": "exodus 3:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "Go, and gather the elders of Israel together, and say unto them: The LORD, the God of your fathers, the God of Abraham, of Isaac, and of Jacob, hath appeared unto me, saying: I have surely remembered you, and seen that which is done to you in Egypt."
-          },
+          "en": "Go, and gather the elders of Israel together, and say unto them: The LORD, the God of your fathers, the God of Abraham, of Isaac, and of Jacob, hath appeared unto me, saying: I have surely remembered you, and seen that which is done to you in Egypt.",
           "ref": "exodus 3:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And I have said: I will bring you up out of the affliction of Egypt unto the land of the Canaanite, and the Hittite, and the Amorite, and the Perizzite, and the Hivite, and the Jebusite, unto a land flowing with milk and honey."
-          },
+          "en": "And I have said: I will bring you up out of the affliction of Egypt unto the land of the Canaanite, and the Hittite, and the Amorite, and the Perizzite, and the Hivite, and the Jebusite, unto a land flowing with milk and honey.",
           "ref": "exodus 3:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And they shall hearken to thy voice. And thou shalt come, thou and the elders of Israel, unto the king of Egypt, and ye shall say unto him: The LORD, the God of the Hebrews, hath met with us. And now let us go, we pray thee, three days’journey into the wilderness, that we may sacrifice to the LORD our God."
-          },
+          "en": "And they shall hearken to thy voice. And thou shalt come, thou and the elders of Israel, unto the king of Egypt, and ye shall say unto him: The LORD, the God of the Hebrews, hath met with us. And now let us go, we pray thee, three days’journey into the wilderness, that we may sacrifice to the LORD our God.",
           "ref": "exodus 3:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And I know that the king of Egypt will not give you leave to go, except by a mighty hand."
-          },
+          "en": "And I know that the king of Egypt will not give you leave to go, except by a mighty hand.",
           "ref": "exodus 3:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will put forth My hand, and smite Egypt with all My wonders which I will do in the midst thereof. And after that he will let you go."
-          },
+          "en": "And I will put forth My hand, and smite Egypt with all My wonders which I will do in the midst thereof. And after that he will let you go.",
           "ref": "exodus 3:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will give this people favour in the sight of the Egyptians. And it shall come to pass, that, when ye go, ye shall not go empty;"
-          },
+          "en": "And I will give this people favour in the sight of the Egyptians. And it shall come to pass, that, when ye go, ye shall not go empty;",
           "ref": "exodus 3:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "but every woman shall ask of her neighbour, and of her that sojourneth in her house, jewels of silver, and jewels of gold, and raiment; and ye shall put them upon your sons, and upon your daughters; and ye shall spoil the Egyptians.’"
-          },
+          "en": "but every woman shall ask of her neighbour, and of her that sojourneth in her house, jewels of silver, and jewels of gold, and raiment; and ye shall put them upon your sons, and upon your daughters; and ye shall spoil the Egyptians.’",
           "ref": "exodus 3:22"
         }
       ]
@@ -574,250 +367,157 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses answered and said: ‘But, behold, they will not believe me, nor hearken unto my voice; for they will say: The LORD hath not appeared unto thee.’"
-          },
+          "en": "And Moses answered and said: ‘But, behold, they will not believe me, nor hearken unto my voice; for they will say: The LORD hath not appeared unto thee.’",
           "ref": "exodus 4:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto him: ‘What is that in thy hand?’ And he said: ‘A rod.’"
-          },
+          "en": "And the LORD said unto him: ‘What is that in thy hand?’ And he said: ‘A rod.’",
           "ref": "exodus 4:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And He said: ‘Cast it on the ground.’ And he cast it on the ground, and it became a serpent; and Moses fled from before it."
-          },
+          "en": "And He said: ‘Cast it on the ground.’ And he cast it on the ground, and it became a serpent; and Moses fled from before it.",
           "ref": "exodus 4:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Put forth thy hand, and take it by the tail—and he put forth his hand, and laid hold of it, and it became a rod in his hand—"
-          },
+          "en": "And the LORD said unto Moses: ‘Put forth thy hand, and take it by the tail—and he put forth his hand, and laid hold of it, and it became a rod in his hand—",
           "ref": "exodus 4:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "that they may believe that the LORD, the God of their fathers, the God of Abraham, the God of Isaac, and the God of Jacob, hath appeared unto thee.’"
-          },
+          "en": "that they may believe that the LORD, the God of their fathers, the God of Abraham, the God of Isaac, and the God of Jacob, hath appeared unto thee.’",
           "ref": "exodus 4:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said furthermore unto him: ‘Put now thy hand into thy bosom.’ And he put his hand into his bosom; and when he took it out, behold, his hand was leprous, as white as snow."
-          },
+          "en": "And the LORD said furthermore unto him: ‘Put now thy hand into thy bosom.’ And he put his hand into his bosom; and when he took it out, behold, his hand was leprous, as white as snow.",
           "ref": "exodus 4:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And He said: ‘Put thy hand back into thy bosom.—And he put his hand back into his bosom; and when he took it out of his bosom, behold, it was turned again as his other flesh.—"
-          },
+          "en": "And He said: ‘Put thy hand back into thy bosom.—And he put his hand back into his bosom; and when he took it out of his bosom, behold, it was turned again as his other flesh.—",
           "ref": "exodus 4:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall come to pass, if they will not believe thee, neither hearken to the voice of the first sign, that they will believe the voice of the latter sign."
-          },
+          "en": "And it shall come to pass, if they will not believe thee, neither hearken to the voice of the first sign, that they will believe the voice of the latter sign.",
           "ref": "exodus 4:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall come to pass, if they will not believe even these two signs, neither hearken unto thy voice, that thou shalt take of the water of the river, and pour it upon the dry land; and the water which thou takest out of the river shall become blood upon the dry land.’"
-          },
+          "en": "And it shall come to pass, if they will not believe even these two signs, neither hearken unto thy voice, that thou shalt take of the water of the river, and pour it upon the dry land; and the water which thou takest out of the river shall become blood upon the dry land.’",
           "ref": "exodus 4:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto the LORD: ‘Oh Lord, I am not a man of words, neither heretofore, nor since Thou hast spoken unto Thy servant; for I am slow of speech, and of a slow tongue.’"
-          },
+          "en": "And Moses said unto the LORD: ‘Oh Lord, I am not a man of words, neither heretofore, nor since Thou hast spoken unto Thy servant; for I am slow of speech, and of a slow tongue.’",
           "ref": "exodus 4:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto him: ‘Who hath made man’s mouth? or who maketh a man dumb, or deaf, or seeing, or blind? is it not I the LORD?"
-          },
+          "en": "And the LORD said unto him: ‘Who hath made man’s mouth? or who maketh a man dumb, or deaf, or seeing, or blind? is it not I the LORD?",
           "ref": "exodus 4:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "Now therefore go, and I will be with thy mouth, and teach thee what thou shalt speak.’"
-          },
+          "en": "Now therefore go, and I will be with thy mouth, and teach thee what thou shalt speak.’",
           "ref": "exodus 4:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Oh Lord, send, I pray Thee, by the hand of him whom Thou wilt send.’"
-          },
+          "en": "And he said: ‘Oh Lord, send, I pray Thee, by the hand of him whom Thou wilt send.’",
           "ref": "exodus 4:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And the anger of the LORD was kindled against Moses, and He said: ‘Is there not Aaron thy brother the Levite? I know that he can speak well. And also, behold, he cometh forth to meet thee; and when he seeth thee, he will be glad in his heart."
-          },
+          "en": "And the anger of the LORD was kindled against Moses, and He said: ‘Is there not Aaron thy brother the Levite? I know that he can speak well. And also, behold, he cometh forth to meet thee; and when he seeth thee, he will be glad in his heart.",
           "ref": "exodus 4:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt speak unto him, and put the words in his mouth; and I will be with thy mouth, and with his mouth, and will teach you what ye shall do."
-          },
+          "en": "And thou shalt speak unto him, and put the words in his mouth; and I will be with thy mouth, and with his mouth, and will teach you what ye shall do.",
           "ref": "exodus 4:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And he shall be thy spokesman unto the people; and it shall come to pass, that he shall be to thee a mouth, and thou shalt be to him in God’s stead."
-          },
+          "en": "And he shall be thy spokesman unto the people; and it shall come to pass, that he shall be to thee a mouth, and thou shalt be to him in God’s stead.",
           "ref": "exodus 4:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt take in thy hand this rod, wherewith thou shalt do the signs.’"
-          },
+          "en": "And thou shalt take in thy hand this rod, wherewith thou shalt do the signs.’",
           "ref": "exodus 4:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses went and returned to Jethro his father-in-law, and said unto him: ‘Let me go, I pray thee, and unto my brethren that are in Egypt, and see whether they be yet alive.’ And Jethro said to Moses: ‘Go in peace.’"
-          },
+          "en": "And Moses went and returned to Jethro his father-in-law, and said unto him: ‘Let me go, I pray thee, and unto my brethren that are in Egypt, and see whether they be yet alive.’ And Jethro said to Moses: ‘Go in peace.’",
           "ref": "exodus 4:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses in Midian: ‘Go, return into Egypt; for all the men are dead that sought thy life.’"
-          },
+          "en": "And the LORD said unto Moses in Midian: ‘Go, return into Egypt; for all the men are dead that sought thy life.’",
           "ref": "exodus 4:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses took his wife and his sons, and set them upon an ass, and he returned to the land of Egypt; and Moses took the rod of God in his hand."
-          },
+          "en": "And Moses took his wife and his sons, and set them upon an ass, and he returned to the land of Egypt; and Moses took the rod of God in his hand.",
           "ref": "exodus 4:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘When thou goest back into Egypt, see that thou do before Pharaoh all the wonders which I have put in thy hand; but I will harden his heart, and he will not let the people go."
-          },
+          "en": "And the LORD said unto Moses: ‘When thou goest back into Egypt, see that thou do before Pharaoh all the wonders which I have put in thy hand; but I will harden his heart, and he will not let the people go.",
           "ref": "exodus 4:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt say unto Pharaoh: Thus saith the LORD: Israel is My son, My first-born."
-          },
+          "en": "And thou shalt say unto Pharaoh: Thus saith the LORD: Israel is My son, My first-born.",
           "ref": "exodus 4:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And I have said unto thee: Let My son go, that he may serve Me; and thou hast refused to let him go. ‘Behold, I will slay thy first-born.’"
-          },
+          "en": "And I have said unto thee: Let My son go, that he may serve Me; and thou hast refused to let him go. ‘Behold, I will slay thy first-born.’",
           "ref": "exodus 4:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass on the way at the lodging-place, that the LORD met him, and sought to kill him."
-          },
+          "en": "And it came to pass on the way at the lodging-place, that the LORD met him, and sought to kill him.",
           "ref": "exodus 4:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Zipporah took a flint, and cut off the foreskin of her son, and cast it at his feet; and she said: ‘Surely a bridegroom of blood art thou to me.’"
-          },
+          "en": "Then Zipporah took a flint, and cut off the foreskin of her son, and cast it at his feet; and she said: ‘Surely a bridegroom of blood art thou to me.’",
           "ref": "exodus 4:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "So He let him alone. Then she said: ‘A bridegroom of blood in regard of the circumcision.’"
-          },
+          "en": "So He let him alone. Then she said: ‘A bridegroom of blood in regard of the circumcision.’",
           "ref": "exodus 4:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said to Aaron: ‘Go into the wilderness to meet Moses.’ And he went, and met him in the mountain of God, and kissed him."
-          },
+          "en": "And the LORD said to Aaron: ‘Go into the wilderness to meet Moses.’ And he went, and met him in the mountain of God, and kissed him.",
           "ref": "exodus 4:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses told Aaron all the words of the LORD wherewith He had sent him, and all the signs wherewith He had charged him."
-          },
+          "en": "And Moses told Aaron all the words of the LORD wherewith He had sent him, and all the signs wherewith He had charged him.",
           "ref": "exodus 4:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses and Aaron went and gathered together all the elders of the children of Israel."
-          },
+          "en": "And Moses and Aaron went and gathered together all the elders of the children of Israel.",
           "ref": "exodus 4:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And Aaron spoke all the words which the LORD had spoken unto Moses, and did the signs in the sight of the people."
-          },
+          "en": "And Aaron spoke all the words which the LORD had spoken unto Moses, and did the signs in the sight of the people.",
           "ref": "exodus 4:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And the people believed; and when they heard that the LORD had remembered the children of Israel, and that He had seen their affliction, then they bowed their heads and worshipped."
-          },
+          "en": "And the people believed; and when they heard that the LORD had remembered the children of Israel, and that He had seen their affliction, then they bowed their heads and worshipped.",
           "ref": "exodus 4:31"
         }
       ]
@@ -827,186 +527,117 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And afterward Moses and Aaron came, and said unto Pharaoh: ‘Thus saith the LORD, the God of Israel: Let My people go, that they may hold a feast unto Me in the wilderness.’"
-          },
+          "en": "And afterward Moses and Aaron came, and said unto Pharaoh: ‘Thus saith the LORD, the God of Israel: Let My people go, that they may hold a feast unto Me in the wilderness.’",
           "ref": "exodus 5:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh said: ‘Who is the LORD, that I should hearken unto His voice to let Israel go? I know not the LORD, and moreover I will not let Israel go.’"
-          },
+          "en": "And Pharaoh said: ‘Who is the LORD, that I should hearken unto His voice to let Israel go? I know not the LORD, and moreover I will not let Israel go.’",
           "ref": "exodus 5:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said: ‘The God of the Hebrews hath met with us. Let us go, we pray thee, three days’journey into the wilderness, and sacrifice unto the LORD our God; lest He fall upon us with pestilence, or with the sword.’"
-          },
+          "en": "And they said: ‘The God of the Hebrews hath met with us. Let us go, we pray thee, three days’journey into the wilderness, and sacrifice unto the LORD our God; lest He fall upon us with pestilence, or with the sword.’",
           "ref": "exodus 5:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And the king of Egypt said unto them: ‘Wherefore do ye, Moses and Aaron, cause the people to break loose from their work? get you unto your burdens.’"
-          },
+          "en": "And the king of Egypt said unto them: ‘Wherefore do ye, Moses and Aaron, cause the people to break loose from their work? get you unto your burdens.’",
           "ref": "exodus 5:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh said: ‘Behold, the people of the land are now many, and will ye make them rest from their burdens?’"
-          },
+          "en": "And Pharaoh said: ‘Behold, the people of the land are now many, and will ye make them rest from their burdens?’",
           "ref": "exodus 5:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And the same day Pharaoh commanded the taskmasters of the people, and their officers, saying:"
-          },
+          "en": "And the same day Pharaoh commanded the taskmasters of the people, and their officers, saying:",
           "ref": "exodus 5:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "’Ye shall no more give the people straw to make brick, as heretofore. Let them go and gather straw for themselves."
-          },
+          "en": "’Ye shall no more give the people straw to make brick, as heretofore. Let them go and gather straw for themselves.",
           "ref": "exodus 5:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And the tale of the bricks, which they did make heretofore, ye shall lay upon them; ye shall not diminish aught thereof; for they are idle; therefore they cry, saying: Let us go and sacrifice to our God."
-          },
+          "en": "And the tale of the bricks, which they did make heretofore, ye shall lay upon them; ye shall not diminish aught thereof; for they are idle; therefore they cry, saying: Let us go and sacrifice to our God.",
           "ref": "exodus 5:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "Let heavier work be laid upon the men, that they may labour therein; and let them not regard lying words.’"
-          },
+          "en": "Let heavier work be laid upon the men, that they may labour therein; and let them not regard lying words.’",
           "ref": "exodus 5:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And the taskmasters of the people went out, and their officers, and they spoke to the people, saying: ‘Thus saith Pharaoh: I will not give you straw."
-          },
+          "en": "And the taskmasters of the people went out, and their officers, and they spoke to the people, saying: ‘Thus saith Pharaoh: I will not give you straw.",
           "ref": "exodus 5:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "Go yourselves, get you straw where ye can find it; for nought of your work shall be diminished.’"
-          },
+          "en": "Go yourselves, get you straw where ye can find it; for nought of your work shall be diminished.’",
           "ref": "exodus 5:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "So the people were scattered abroad throughout all the land of Egypt to gather stubble for straw."
-          },
+          "en": "So the people were scattered abroad throughout all the land of Egypt to gather stubble for straw.",
           "ref": "exodus 5:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And the taskmasters were urgent, saying: ‘Fulfil your work, your daily task, as when there was straw.’"
-          },
+          "en": "And the taskmasters were urgent, saying: ‘Fulfil your work, your daily task, as when there was straw.’",
           "ref": "exodus 5:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And the officers of the children of Israel, whom Pharaoh’s taskmasters had set over them, were beaten, saying: ‘Wherefore have ye not fulfilled your appointed task in making brick both yesterday and today as heretofore?’"
-          },
+          "en": "And the officers of the children of Israel, whom Pharaoh’s taskmasters had set over them, were beaten, saying: ‘Wherefore have ye not fulfilled your appointed task in making brick both yesterday and today as heretofore?’",
           "ref": "exodus 5:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "Then the officers of the children of Israel came and cried unto Pharaoh, saying: ‘Wherefore dealest thou thus with thy servants?"
-          },
+          "en": "Then the officers of the children of Israel came and cried unto Pharaoh, saying: ‘Wherefore dealest thou thus with thy servants?",
           "ref": "exodus 5:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "There is no straw given unto thy servants, and they say to us: Make brick; and, behold, thy servants are beaten, but the fault is in thine own people.’"
-          },
+          "en": "There is no straw given unto thy servants, and they say to us: Make brick; and, behold, thy servants are beaten, but the fault is in thine own people.’",
           "ref": "exodus 5:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "But he said: ‘Ye are idle, ye are idle; therefore ye say: Let us go and sacrifice to the LORD."
-          },
+          "en": "But he said: ‘Ye are idle, ye are idle; therefore ye say: Let us go and sacrifice to the LORD.",
           "ref": "exodus 5:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "Go therefore now, and work; for there shall no straw be given you, yet shall ye deliver the tale of bricks.’"
-          },
+          "en": "Go therefore now, and work; for there shall no straw be given you, yet shall ye deliver the tale of bricks.’",
           "ref": "exodus 5:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And the officers of the children of Israel did see that they were set on mischief, when they said: ‘Ye shall not diminish aught from your bricks, your daily task.’"
-          },
+          "en": "And the officers of the children of Israel did see that they were set on mischief, when they said: ‘Ye shall not diminish aught from your bricks, your daily task.’",
           "ref": "exodus 5:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And they met Moses and Aaron, who stood in the way, as they came forth from Pharaoh;"
-          },
+          "en": "And they met Moses and Aaron, who stood in the way, as they came forth from Pharaoh;",
           "ref": "exodus 5:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "and they said unto them: ‘The LORD look upon you, and judge; because ye have made our savour to be abhorred in the eyes of Pharaoh, and in the eyes of his servants, to put a sword in their hand to slay us.’"
-          },
+          "en": "and they said unto them: ‘The LORD look upon you, and judge; because ye have made our savour to be abhorred in the eyes of Pharaoh, and in the eyes of his servants, to put a sword in their hand to slay us.’",
           "ref": "exodus 5:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses returned unto the LORD, and said: ‘Lord, wherefore hast Thou dealt ill with this people? why is it that Thou hast sent me?"
-          },
+          "en": "And Moses returned unto the LORD, and said: ‘Lord, wherefore hast Thou dealt ill with this people? why is it that Thou hast sent me?",
           "ref": "exodus 5:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "For since I came to Pharaoh to speak in Thy name, he hath dealt ill with this people; neither hast Thou delivered Thy people at all.’"
-          },
+          "en": "For since I came to Pharaoh to speak in Thy name, he hath dealt ill with this people; neither hast Thou delivered Thy people at all.’",
           "ref": "exodus 5:23"
         }
       ]
@@ -1016,242 +647,152 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Now shalt thou see what I will do to Pharaoh; for by a strong hand shall he let them go, and by a strong hand shall he drive them out of his land.’"
-          },
+          "en": "And the LORD said unto Moses: ‘Now shalt thou see what I will do to Pharaoh; for by a strong hand shall he let them go, and by a strong hand shall he drive them out of his land.’",
           "ref": "exodus 6:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And God spoke unto Moses, and said unto him: ‘I am the LORD;"
-          },
+          "en": "And God spoke unto Moses, and said unto him: ‘I am the LORD;",
           "ref": "exodus 6:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "and I appeared unto Abraham, unto Isaac, and unto Jacob, as God Almighty, but by My name יהוה I made Me not known to them."
-          },
+          "en": "and I appeared unto Abraham, unto Isaac, and unto Jacob, as God Almighty, but by My name יהוה I made Me not known to them.",
           "ref": "exodus 6:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And I have also established My covenant with them, to give them the land of Canaan, the land of their sojournings, wherein they sojourned."
-          },
+          "en": "And I have also established My covenant with them, to give them the land of Canaan, the land of their sojournings, wherein they sojourned.",
           "ref": "exodus 6:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And moreover I have heard the groaning of the children of Israel, whom the Egyptians keep in bondage; and I have remembered My covenant."
-          },
+          "en": "And moreover I have heard the groaning of the children of Israel, whom the Egyptians keep in bondage; and I have remembered My covenant.",
           "ref": "exodus 6:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "Wherefore say unto the children of Israel: I am the LORD, and I will bring you out from under the burdens of the Egyptians, and I will deliver you from their bondage, and I will redeem you with an outstretched arm, and with great judgments;"
-          },
+          "en": "Wherefore say unto the children of Israel: I am the LORD, and I will bring you out from under the burdens of the Egyptians, and I will deliver you from their bondage, and I will redeem you with an outstretched arm, and with great judgments;",
           "ref": "exodus 6:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "and I will take you to Me for a people, and I will be to you a God; and ye shall know that I am the LORD your God, who brought you out from under the burdens of the Egyptians."
-          },
+          "en": "and I will take you to Me for a people, and I will be to you a God; and ye shall know that I am the LORD your God, who brought you out from under the burdens of the Egyptians.",
           "ref": "exodus 6:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will bring you in unto the land, concerning which I lifted up My hand to give it to Abraham, to Isaac, and to Jacob; and I will give it you for a heritage: I am the LORD.’"
-          },
+          "en": "And I will bring you in unto the land, concerning which I lifted up My hand to give it to Abraham, to Isaac, and to Jacob; and I will give it you for a heritage: I am the LORD.’",
           "ref": "exodus 6:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses spoke so unto the children of Israel; but they hearkened not unto Moses for impatience of spirit, and for cruel bondage."
-          },
+          "en": "And Moses spoke so unto the children of Israel; but they hearkened not unto Moses for impatience of spirit, and for cruel bondage.",
           "ref": "exodus 6:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses, saying:"
-          },
+          "en": "And the LORD spoke unto Moses, saying:",
           "ref": "exodus 6:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "’Go in, speak unto Pharaoh king of Egypt, that he let the children of Israel go out of his land.’"
-          },
+          "en": "’Go in, speak unto Pharaoh king of Egypt, that he let the children of Israel go out of his land.’",
           "ref": "exodus 6:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses spoke before the LORD, saying: ‘Behold, the children of Israel have not hearkened unto me; how then shall Pharaoh hear me, who am of uncircumcised lips?’"
-          },
+          "en": "And Moses spoke before the LORD, saying: ‘Behold, the children of Israel have not hearkened unto me; how then shall Pharaoh hear me, who am of uncircumcised lips?’",
           "ref": "exodus 6:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses and unto Aaron, and gave them a charge unto the children of Israel, and unto Pharaoh king of Egypt, to bring the children of Israel out of the land of Egypt."
-          },
+          "en": "And the LORD spoke unto Moses and unto Aaron, and gave them a charge unto the children of Israel, and unto Pharaoh king of Egypt, to bring the children of Israel out of the land of Egypt.",
           "ref": "exodus 6:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the heads of their fathers’houses: the sons of Reuben the first-born of Israel: Hanoch, and Pallu, Hezron, and Carmi. These are the families of Reuben."
-          },
+          "en": "These are the heads of their fathers’houses: the sons of Reuben the first-born of Israel: Hanoch, and Pallu, Hezron, and Carmi. These are the families of Reuben.",
           "ref": "exodus 6:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Simeon: Jemuel, and Jamin, and Ohad, and Jachin, and Zohar, and Shaul the son of a Canaanitish woman. These are the families of Simeon."
-          },
+          "en": "And the sons of Simeon: Jemuel, and Jamin, and Ohad, and Jachin, and Zohar, and Shaul the son of a Canaanitish woman. These are the families of Simeon.",
           "ref": "exodus 6:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the names of the sons of Levi according to their generations: Gershon and Kohath, and Merari. And the years of the life of Levi were a hundred thirty and seven years."
-          },
+          "en": "And these are the names of the sons of Levi according to their generations: Gershon and Kohath, and Merari. And the years of the life of Levi were a hundred thirty and seven years.",
           "ref": "exodus 6:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "The sons of Gershon: Libni and Shimei, according to their families."
-          },
+          "en": "The sons of Gershon: Libni and Shimei, according to their families.",
           "ref": "exodus 6:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Kohath: Amram, and Izhar, and Hebron, and Uzziel. And the years of the life of Kohath were a hundred thirty and three years."
-          },
+          "en": "And the sons of Kohath: Amram, and Izhar, and Hebron, and Uzziel. And the years of the life of Kohath were a hundred thirty and three years.",
           "ref": "exodus 6:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Merari: Mahli and Mushi. These are the families of the Levites according to their generations."
-          },
+          "en": "And the sons of Merari: Mahli and Mushi. These are the families of the Levites according to their generations.",
           "ref": "exodus 6:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Amram took him Jochebed his father’s sister to wife; and she bore him Aaron and Moses. And the years of the life of Amram were a hundred and thirty and seven years."
-          },
+          "en": "And Amram took him Jochebed his father’s sister to wife; and she bore him Aaron and Moses. And the years of the life of Amram were a hundred and thirty and seven years.",
           "ref": "exodus 6:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Izhar: Korah, and Nepheg, and Zichri."
-          },
+          "en": "And the sons of Izhar: Korah, and Nepheg, and Zichri.",
           "ref": "exodus 6:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Uzziel: Mishael, and Elzaphan, and Sithri."
-          },
+          "en": "And the sons of Uzziel: Mishael, and Elzaphan, and Sithri.",
           "ref": "exodus 6:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And Aaron took him Elisheba, the daughter of Amminadab, the sister of Nahshon, to wife; and she bore him Nadab and Abihu, Eleazar and Ithamar."
-          },
+          "en": "And Aaron took him Elisheba, the daughter of Amminadab, the sister of Nahshon, to wife; and she bore him Nadab and Abihu, Eleazar and Ithamar.",
           "ref": "exodus 6:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Korah: Assir, and Elkanah, and Abiasaph; these are the families of the Korahites."
-          },
+          "en": "And the sons of Korah: Assir, and Elkanah, and Abiasaph; these are the families of the Korahites.",
           "ref": "exodus 6:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And Eleazar Aaron’s son took him one of the daughters of Putiel to wife; and she bore him Phinehas. These are the heads of the fathers’houses of the Levites according to their families."
-          },
+          "en": "And Eleazar Aaron’s son took him one of the daughters of Putiel to wife; and she bore him Phinehas. These are the heads of the fathers’houses of the Levites according to their families.",
           "ref": "exodus 6:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "These are that Aaron and Moses, to whom the LORD said: ‘Bring out the children of Israel from the land of Egypt according to their hosts.’"
-          },
+          "en": "These are that Aaron and Moses, to whom the LORD said: ‘Bring out the children of Israel from the land of Egypt according to their hosts.’",
           "ref": "exodus 6:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "These are they that spoke to Pharaoh king of Egypt, to bring out the children of Israel from Egypt. These are that Moses and Aaron."
-          },
+          "en": "These are they that spoke to Pharaoh king of Egypt, to bring out the children of Israel from Egypt. These are that Moses and Aaron.",
           "ref": "exodus 6:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass on the day when the LORD spoke unto Moses in the land of Egypt,"
-          },
+          "en": "And it came to pass on the day when the LORD spoke unto Moses in the land of Egypt,",
           "ref": "exodus 6:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "that the LORD spoke unto Moses, saying: ‘I am the LORD; speak thou unto Pharaoh king of Egypt all that I speak unto thee.’"
-          },
+          "en": "that the LORD spoke unto Moses, saying: ‘I am the LORD; speak thou unto Pharaoh king of Egypt all that I speak unto thee.’",
           "ref": "exodus 6:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said before the LORD: ‘Behold, I am of uncircumcised lips, and how shall Pharaoh hearken unto me?’"
-          },
+          "en": "And Moses said before the LORD: ‘Behold, I am of uncircumcised lips, and how shall Pharaoh hearken unto me?’",
           "ref": "exodus 6:30"
         }
       ]
@@ -1261,234 +802,147 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘See, I have set thee in God’s stead to Pharaoh; and Aaron thy brother shall be thy prophet."
-          },
+          "en": "And the LORD said unto Moses: ‘See, I have set thee in God’s stead to Pharaoh; and Aaron thy brother shall be thy prophet.",
           "ref": "exodus 7:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt speak all that I command thee; and Aaron thy brother shall speak unto Pharaoh, that he let the children of Israel go out of his land."
-          },
+          "en": "Thou shalt speak all that I command thee; and Aaron thy brother shall speak unto Pharaoh, that he let the children of Israel go out of his land.",
           "ref": "exodus 7:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will harden Pharaoh’s heart, and multiply My signs and My wonders in the land of Egypt."
-          },
+          "en": "And I will harden Pharaoh’s heart, and multiply My signs and My wonders in the land of Egypt.",
           "ref": "exodus 7:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "But Pharaoh will not hearken unto you, and I will lay My hand upon Egypt, and bring forth My hosts, My people the children of Israel, out of the land of Egypt, by great judgments."
-          },
+          "en": "But Pharaoh will not hearken unto you, and I will lay My hand upon Egypt, and bring forth My hosts, My people the children of Israel, out of the land of Egypt, by great judgments.",
           "ref": "exodus 7:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And the Egyptians shall know that I am the LORD, when I stretch forth My hand upon Egypt, and bring out the children of Israel from among them.’"
-          },
+          "en": "And the Egyptians shall know that I am the LORD, when I stretch forth My hand upon Egypt, and bring out the children of Israel from among them.’",
           "ref": "exodus 7:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses and Aaron did so; as the LORD commanded them, so did they."
-          },
+          "en": "And Moses and Aaron did so; as the LORD commanded them, so did they.",
           "ref": "exodus 7:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses was fourscore years old, and Aaron fourscore and three years old, when they spoke unto Pharaoh."
-          },
+          "en": "And Moses was fourscore years old, and Aaron fourscore and three years old, when they spoke unto Pharaoh.",
           "ref": "exodus 7:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses and unto Aaron, saying:"
-          },
+          "en": "And the LORD spoke unto Moses and unto Aaron, saying:",
           "ref": "exodus 7:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "’When Pharaoh shall speak unto you, saying: Show a wonder for you; then thou shalt say unto Aaron: Take thy rod, and cast it down before Pharaoh, that it become a serpent.’"
-          },
+          "en": "’When Pharaoh shall speak unto you, saying: Show a wonder for you; then thou shalt say unto Aaron: Take thy rod, and cast it down before Pharaoh, that it become a serpent.’",
           "ref": "exodus 7:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses and Aaron went in unto Pharaoh, and they did so, as the LORD had commanded; and Aaron cast down his rod before Pharaoh and before his servants, and it became a serpent."
-          },
+          "en": "And Moses and Aaron went in unto Pharaoh, and they did so, as the LORD had commanded; and Aaron cast down his rod before Pharaoh and before his servants, and it became a serpent.",
           "ref": "exodus 7:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Pharaoh also called for the wise men and the sorcerers; and they also, the magicians of Egypt, did in like manner with their secret arts."
-          },
+          "en": "Then Pharaoh also called for the wise men and the sorcerers; and they also, the magicians of Egypt, did in like manner with their secret arts.",
           "ref": "exodus 7:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "For they cast down every man his rod, and they became serpents; but Aaron’s rod swallowed up their rods."
-          },
+          "en": "For they cast down every man his rod, and they became serpents; but Aaron’s rod swallowed up their rods.",
           "ref": "exodus 7:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh’s heart was hardened, and he hearkened not unto them; as the LORD had spoken."
-          },
+          "en": "And Pharaoh’s heart was hardened, and he hearkened not unto them; as the LORD had spoken.",
           "ref": "exodus 7:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Pharaoh’s heart is stubborn, he refuseth to let the people go."
-          },
+          "en": "And the LORD said unto Moses: ‘Pharaoh’s heart is stubborn, he refuseth to let the people go.",
           "ref": "exodus 7:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "Get thee unto Pharaoh in the morning; lo, he goeth out unto the water; and thou shalt stand by the river’s brink to meet him; and the rod which was turned to a serpent shalt thou take in thy hand."
-          },
+          "en": "Get thee unto Pharaoh in the morning; lo, he goeth out unto the water; and thou shalt stand by the river’s brink to meet him; and the rod which was turned to a serpent shalt thou take in thy hand.",
           "ref": "exodus 7:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt say unto him: The LORD, the God of the Hebrews, hath sent me unto thee, saying: Let My people go, that they may serve Me in the wilderness; and, behold, hitherto thou hast not hearkened;"
-          },
+          "en": "And thou shalt say unto him: The LORD, the God of the Hebrews, hath sent me unto thee, saying: Let My people go, that they may serve Me in the wilderness; and, behold, hitherto thou hast not hearkened;",
           "ref": "exodus 7:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "thus saith the LORD: In this thou shalt know that I am the LORD—behold, I will smite with the rod that is in my hand upon the waters which are in the river, and they shall be turned to blood."
-          },
+          "en": "thus saith the LORD: In this thou shalt know that I am the LORD—behold, I will smite with the rod that is in my hand upon the waters which are in the river, and they shall be turned to blood.",
           "ref": "exodus 7:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And the fish that are in the river shall die, and the river shall become foul; and the Egyptians shall loathe to drink water from the river.’"
-          },
+          "en": "And the fish that are in the river shall die, and the river shall become foul; and the Egyptians shall loathe to drink water from the river.’",
           "ref": "exodus 7:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Say unto Aaron: Take thy rod, and stretch out thy hand over the waters of Egypt, over their rivers, over their streams, and over their pools, and over all their ponds of water, that they may become blood; and there shall be blood throughout all the land of Egypt, both in vessels of wood and in vessels of stone.’"
-          },
+          "en": "And the LORD said unto Moses: ‘Say unto Aaron: Take thy rod, and stretch out thy hand over the waters of Egypt, over their rivers, over their streams, and over their pools, and over all their ponds of water, that they may become blood; and there shall be blood throughout all the land of Egypt, both in vessels of wood and in vessels of stone.’",
           "ref": "exodus 7:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses and Aaron did so, as the LORD commanded; and he lifted up the rod, and smote the waters that were in the river, in the sight of Pharaoh, and in the sight of his servants; and all the waters that were in the river were turned to blood."
-          },
+          "en": "And Moses and Aaron did so, as the LORD commanded; and he lifted up the rod, and smote the waters that were in the river, in the sight of Pharaoh, and in the sight of his servants; and all the waters that were in the river were turned to blood.",
           "ref": "exodus 7:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And the fish that were in the river died; and the river became foul, and the Egyptians could not drink water from the river; and the blood was throughout all the land of Egypt."
-          },
+          "en": "And the fish that were in the river died; and the river became foul, and the Egyptians could not drink water from the river; and the blood was throughout all the land of Egypt.",
           "ref": "exodus 7:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And the magicians of Egypt did in like manner with their secret arts; and Pharaoh’s heart was hardened, and he hearkened not unto them; as the LORD had spoken."
-          },
+          "en": "And the magicians of Egypt did in like manner with their secret arts; and Pharaoh’s heart was hardened, and he hearkened not unto them; as the LORD had spoken.",
           "ref": "exodus 7:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh turned and went into his house, neither did he lay even this to heart."
-          },
+          "en": "And Pharaoh turned and went into his house, neither did he lay even this to heart.",
           "ref": "exodus 7:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And all the Egyptians digged round about the river for water to drink; for they could not drink of the water of the river."
-          },
+          "en": "And all the Egyptians digged round about the river for water to drink; for they could not drink of the water of the river.",
           "ref": "exodus 7:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And seven days were fulfilled, after that the LORD had smitten the river."
-          },
+          "en": "And seven days were fulfilled, after that the LORD had smitten the river.",
           "ref": "exodus 7:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses: ‘Go in unto Pharaoh, and say unto him: Thus saith the LORD: Let My people go, that they may serve Me."
-          },
+          "en": "And the LORD spoke unto Moses: ‘Go in unto Pharaoh, and say unto him: Thus saith the LORD: Let My people go, that they may serve Me.",
           "ref": "exodus 7:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And if thou refuse to let them go, behold, I will smite all thy borders with frogs."
-          },
+          "en": "And if thou refuse to let them go, behold, I will smite all thy borders with frogs.",
           "ref": "exodus 7:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And the river shall swarm with frogs, which shall go up and come into thy house, and into thy bed-chamber, and upon thy bed, and into the house of thy servants, and upon thy people, and into thine ovens, and into thy kneading-troughs."
-          },
+          "en": "And the river shall swarm with frogs, which shall go up and come into thy house, and into thy bed-chamber, and upon thy bed, and into the house of thy servants, and upon thy people, and into thine ovens, and into thy kneading-troughs.",
           "ref": "exodus 7:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And the frogs shall come up both upon thee, and upon thy people, and upon all thy servants.’"
-          },
+          "en": "And the frogs shall come up both upon thee, and upon thy people, and upon all thy servants.’",
           "ref": "exodus 7:29"
         }
       ]
@@ -1498,226 +952,142 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Say unto Aaron: Stretch forth thy hand with thy rod over the rivers, over the canals, and over the pools, and cause frogs to come up upon the land of Egypt.’"
-          },
+          "en": "And the LORD said unto Moses: ‘Say unto Aaron: Stretch forth thy hand with thy rod over the rivers, over the canals, and over the pools, and cause frogs to come up upon the land of Egypt.’",
           "ref": "exodus 8:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": "vit",
-            "jps1917": "And Aaron stretched out his hand over the waters of Egypt; and the frogs came up, and covered the land of Egypt."
-          },
+          "en": "And Aaron stretched out his hand over the waters of Egypt; and the frogs came up, and covered the land of Egypt.",
           "ref": "exodus 8:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And the magicians did in like manner with their secret arts, and brought up frogs upon the land of Egypt."
-          },
+          "en": "And the magicians did in like manner with their secret arts, and brought up frogs upon the land of Egypt.",
           "ref": "exodus 8:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Pharaoh called for Moses and Aaron, and said: ‘Entreat the LORD, that He take away the frogs from me, and from my people; and I will let the people go, that they may sacrifice unto the LORD.’"
-          },
+          "en": "Then Pharaoh called for Moses and Aaron, and said: ‘Entreat the LORD, that He take away the frogs from me, and from my people; and I will let the people go, that they may sacrifice unto the LORD.’",
           "ref": "exodus 8:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto Pharaoh: ‘Have thou this glory over me; against what time shall I entreat for thee, and for thy servants, and for thy people, that the frogs be destroyed from thee and thy houses, and remain in the river only?’"
-          },
+          "en": "And Moses said unto Pharaoh: ‘Have thou this glory over me; against what time shall I entreat for thee, and for thy servants, and for thy people, that the frogs be destroyed from thee and thy houses, and remain in the river only?’",
           "ref": "exodus 8:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Against to-morrow.’ And he said: ‘Be it according to thy word; that thou mayest know that there is none like unto the LORD our God."
-          },
+          "en": "And he said: ‘Against to-morrow.’ And he said: ‘Be it according to thy word; that thou mayest know that there is none like unto the LORD our God.",
           "ref": "exodus 8:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And the frogs shall depart from thee, and from thy houses, and from thy servants, and from thy people; they shall remain in the river only.’"
-          },
+          "en": "And the frogs shall depart from thee, and from thy houses, and from thy servants, and from thy people; they shall remain in the river only.’",
           "ref": "exodus 8:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses and Aaron went out from Pharaoh; and Moses cried unto the LORD concerning the frogs, which He had brought upon Pharaoh."
-          },
+          "en": "And Moses and Aaron went out from Pharaoh; and Moses cried unto the LORD concerning the frogs, which He had brought upon Pharaoh.",
           "ref": "exodus 8:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD did according to the word of Moses; and the frogs died out of the houses, out of the courts, and out of the fields."
-          },
+          "en": "And the LORD did according to the word of Moses; and the frogs died out of the houses, out of the courts, and out of the fields.",
           "ref": "exodus 8:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And they gathered them together in heaps; and the land stank."
-          },
+          "en": "And they gathered them together in heaps; and the land stank.",
           "ref": "exodus 8:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "But when Pharaoh saw that there was respite, he hardened his heart, and hearkened not unto them; as the LORD had spoken."
-          },
+          "en": "But when Pharaoh saw that there was respite, he hardened his heart, and hearkened not unto them; as the LORD had spoken.",
           "ref": "exodus 8:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Say unto Aaron: Stretch out thy rod, and smite the dust of the earth, that it may become gnats throughout all the land of Egypt.’"
-          },
+          "en": "And the LORD said unto Moses: ‘Say unto Aaron: Stretch out thy rod, and smite the dust of the earth, that it may become gnats throughout all the land of Egypt.’",
           "ref": "exodus 8:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And they did so; and Aaron stretched out his hand with his rod, and smote the dust of the earth, and there were gnats upon man, and upon beast; all the dust of the earth became gnats throughout all the land of Egypt."
-          },
+          "en": "And they did so; and Aaron stretched out his hand with his rod, and smote the dust of the earth, and there were gnats upon man, and upon beast; all the dust of the earth became gnats throughout all the land of Egypt.",
           "ref": "exodus 8:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And the magicians did so with their secret arts to bring forth gnats, but they could not; and there were gnats upon man, and upon beast."
-          },
+          "en": "And the magicians did so with their secret arts to bring forth gnats, but they could not; and there were gnats upon man, and upon beast.",
           "ref": "exodus 8:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "Then the magicians said unto Pharaoh: ‘This is the finger of God’; and Pharaoh’s heart was hardened, and he hearkened not unto them; as the LORD had spoken."
-          },
+          "en": "Then the magicians said unto Pharaoh: ‘This is the finger of God’; and Pharaoh’s heart was hardened, and he hearkened not unto them; as the LORD had spoken.",
           "ref": "exodus 8:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Rise up early in the morning, and stand before Pharaoh; lo, he cometh forth to the water; and say unto him: Thus saith the LORD: Let My people go, that they may serve Me."
-          },
+          "en": "And the LORD said unto Moses: ‘Rise up early in the morning, and stand before Pharaoh; lo, he cometh forth to the water; and say unto him: Thus saith the LORD: Let My people go, that they may serve Me.",
           "ref": "exodus 8:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "Else, if thou wilt not let My people go, behold, I will send swarms of flies upon thee, and upon thy servants, and upon thy people, and into thy houses; and the houses of the Egyptians shall be full of swarms of flies, and also the ground whereon they are."
-          },
+          "en": "Else, if thou wilt not let My people go, behold, I will send swarms of flies upon thee, and upon thy servants, and upon thy people, and into thy houses; and the houses of the Egyptians shall be full of swarms of flies, and also the ground whereon they are.",
           "ref": "exodus 8:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will set apart in that day the land of Goshen, in which My people dwell, that no swarms of flies shall be there; to the end that thou mayest know that I am the LORD in the midst of the earth."
-          },
+          "en": "And I will set apart in that day the land of Goshen, in which My people dwell, that no swarms of flies shall be there; to the end that thou mayest know that I am the LORD in the midst of the earth.",
           "ref": "exodus 8:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will put a division between My people and thy people—by to-morrow shall this sign be.’"
-          },
+          "en": "And I will put a division between My people and thy people—by to-morrow shall this sign be.’",
           "ref": "exodus 8:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD did so; and there came grievous swarms of flies into the house of Pharaoh, and into his servants’houses; and in all the land of Egypt the land was ruined by reason of the swarms of flies."
-          },
+          "en": "And the LORD did so; and there came grievous swarms of flies into the house of Pharaoh, and into his servants’houses; and in all the land of Egypt the land was ruined by reason of the swarms of flies.",
           "ref": "exodus 8:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh called for Moses and for Aaron, and said: ‘Go ye, sacrifice to your God in the land.’"
-          },
+          "en": "And Pharaoh called for Moses and for Aaron, and said: ‘Go ye, sacrifice to your God in the land.’",
           "ref": "exodus 8:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said: ‘It is not meet so to do; for we shall sacrifice the abomination of the Egyptians to the LORD our God; lo, if we sacrifice the abomination of the Egyptians before their eyes, will they not stone us?"
-          },
+          "en": "And Moses said: ‘It is not meet so to do; for we shall sacrifice the abomination of the Egyptians to the LORD our God; lo, if we sacrifice the abomination of the Egyptians before their eyes, will they not stone us?",
           "ref": "exodus 8:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "We will go three days’journey into the wilderness, and sacrifice to the LORD our God, as He shall command us.’"
-          },
+          "en": "We will go three days’journey into the wilderness, and sacrifice to the LORD our God, as He shall command us.’",
           "ref": "exodus 8:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh said: ‘I will let you go, that ye may sacrifice to the LORD your God in the wilderness; only ye shall not go very far away; entreat for me.’"
-          },
+          "en": "And Pharaoh said: ‘I will let you go, that ye may sacrifice to the LORD your God in the wilderness; only ye shall not go very far away; entreat for me.’",
           "ref": "exodus 8:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said: ‘Behold, I go out from thee, and I will entreat the LORD that the swarms of flies may depart from Pharaoh, from his servants, and from his people, tomorrow; only let not Pharaoh deal deceitfully any more in not letting the people go to sacrifice to the LORD.’"
-          },
+          "en": "And Moses said: ‘Behold, I go out from thee, and I will entreat the LORD that the swarms of flies may depart from Pharaoh, from his servants, and from his people, tomorrow; only let not Pharaoh deal deceitfully any more in not letting the people go to sacrifice to the LORD.’",
           "ref": "exodus 8:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses went out from Pharaoh, and entreated the LORD."
-          },
+          "en": "And Moses went out from Pharaoh, and entreated the LORD.",
           "ref": "exodus 8:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD did according to the word of Moses; and He removed the swarms of flies from Pharaoh, from his servants, and from his people; there remained not one."
-          },
+          "en": "And the LORD did according to the word of Moses; and He removed the swarms of flies from Pharaoh, from his servants, and from his people; there remained not one.",
           "ref": "exodus 8:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh hardened his heart this time also, and he did not let the people go."
-          },
+          "en": "And Pharaoh hardened his heart this time also, and he did not let the people go.",
           "ref": "exodus 8:28"
         }
       ]
@@ -1727,282 +1097,177 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "Then the LORD said unto Moses: ‘Go in unto Pharaoh, and tell him: Thus saith the LORD, the God of the Hebrews: Let My people go, that they may serve Me."
-          },
+          "en": "Then the LORD said unto Moses: ‘Go in unto Pharaoh, and tell him: Thus saith the LORD, the God of the Hebrews: Let My people go, that they may serve Me.",
           "ref": "exodus 9:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "For if thou refuse to let them go, and wilt hold them still,"
-          },
+          "en": "For if thou refuse to let them go, and wilt hold them still,",
           "ref": "exodus 9:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "behold, the hand of the LORD is upon thy cattle which are in the field, upon the horses, upon the asses, upon the camels, upon the herds, and upon the flocks; there shall be a very grievous murrain."
-          },
+          "en": "behold, the hand of the LORD is upon thy cattle which are in the field, upon the horses, upon the asses, upon the camels, upon the herds, and upon the flocks; there shall be a very grievous murrain.",
           "ref": "exodus 9:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD shall make a division between the cattle of Israel and the cattle of Egypt; and there shall nothing die of all that belongeth to the children of Israel.’"
-          },
+          "en": "And the LORD shall make a division between the cattle of Israel and the cattle of Egypt; and there shall nothing die of all that belongeth to the children of Israel.’",
           "ref": "exodus 9:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD appointed a set time, saying: ‘Tomorrow the LORD shall do this thing in the land.’"
-          },
+          "en": "And the LORD appointed a set time, saying: ‘Tomorrow the LORD shall do this thing in the land.’",
           "ref": "exodus 9:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD did that thing on the morrow, and all the cattle of Egypt died; but of the cattle of the children of Israel died not one."
-          },
+          "en": "And the LORD did that thing on the morrow, and all the cattle of Egypt died; but of the cattle of the children of Israel died not one.",
           "ref": "exodus 9:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh sent, and, behold, there was not so much as one of the cattle of the Israelites dead. But the heart of Pharaoh was stubborn, and he did not let the people go."
-          },
+          "en": "And Pharaoh sent, and, behold, there was not so much as one of the cattle of the Israelites dead. But the heart of Pharaoh was stubborn, and he did not let the people go.",
           "ref": "exodus 9:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses and unto Aaron: ‘Take to you handfuls of soot of the furnace, and let Moses throw it heavenward in the sight of Pharaoh."
-          },
+          "en": "And the LORD said unto Moses and unto Aaron: ‘Take to you handfuls of soot of the furnace, and let Moses throw it heavenward in the sight of Pharaoh.",
           "ref": "exodus 9:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall become small dust over all the land of Egypt, and shall be a boil breaking forth with blains upon man and upon beast, throughout all the land of Egypt.’"
-          },
+          "en": "And it shall become small dust over all the land of Egypt, and shall be a boil breaking forth with blains upon man and upon beast, throughout all the land of Egypt.’",
           "ref": "exodus 9:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And they took soot of the furnace, and stood before Pharaoh; and Moses threw it up heavenward; and it became a boil breaking forth with blains upon man and upon beast."
-          },
+          "en": "And they took soot of the furnace, and stood before Pharaoh; and Moses threw it up heavenward; and it became a boil breaking forth with blains upon man and upon beast.",
           "ref": "exodus 9:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And the magicians could not stand before Moses because of the boils; for the boils were upon the magicians, and upon all the Egyptians."
-          },
+          "en": "And the magicians could not stand before Moses because of the boils; for the boils were upon the magicians, and upon all the Egyptians.",
           "ref": "exodus 9:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD hardened the heart of Pharaoh, and he hearkened not unto them; as the LORD had spoken unto Moses."
-          },
+          "en": "And the LORD hardened the heart of Pharaoh, and he hearkened not unto them; as the LORD had spoken unto Moses.",
           "ref": "exodus 9:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Rise up early in the morning, and stand before Pharaoh, and say unto him: Thus saith the LORD, the God of the Hebrews: Let My people go, that they may serve Me."
-          },
+          "en": "And the LORD said unto Moses: ‘Rise up early in the morning, and stand before Pharaoh, and say unto him: Thus saith the LORD, the God of the Hebrews: Let My people go, that they may serve Me.",
           "ref": "exodus 9:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "For I will this time send all My plagues upon thy person, and upon thy servants, and upon thy people; that thou mayest know that there is none like Me in all the earth."
-          },
+          "en": "For I will this time send all My plagues upon thy person, and upon thy servants, and upon thy people; that thou mayest know that there is none like Me in all the earth.",
           "ref": "exodus 9:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "Surely now I had put forth My hand, and smitten thee and thy people with pestilence, and thou hadst been cut off from the earth."
-          },
+          "en": "Surely now I had put forth My hand, and smitten thee and thy people with pestilence, and thou hadst been cut off from the earth.",
           "ref": "exodus 9:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "But in very deed for this cause have I made thee to stand, to show thee My power, and that My name may be declared throughout all the earth."
-          },
+          "en": "But in very deed for this cause have I made thee to stand, to show thee My power, and that My name may be declared throughout all the earth.",
           "ref": "exodus 9:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "As yet exaltest thou thyself against My people, that thou wilt not let them go?"
-          },
+          "en": "As yet exaltest thou thyself against My people, that thou wilt not let them go?",
           "ref": "exodus 9:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "Behold, tomorrow about this time I will cause it to rain a very grievous hail, such as hath not been in Egypt since the day it was founded even until now."
-          },
+          "en": "Behold, tomorrow about this time I will cause it to rain a very grievous hail, such as hath not been in Egypt since the day it was founded even until now.",
           "ref": "exodus 9:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "Now therefore send, hasten in thy cattle and all that thou hast in the field; for every man and beast that shall be found in the field, and shall not be brought home, the hail shall come down upon them, and they shall die.’"
-          },
+          "en": "Now therefore send, hasten in thy cattle and all that thou hast in the field; for every man and beast that shall be found in the field, and shall not be brought home, the hail shall come down upon them, and they shall die.’",
           "ref": "exodus 9:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "He that feared the word of the LORD among the servants of Pharaoh made his servants and his cattle flee into the houses;"
-          },
+          "en": "He that feared the word of the LORD among the servants of Pharaoh made his servants and his cattle flee into the houses;",
           "ref": "exodus 9:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "and he that regarded not the word of the LORD left his servants and his cattle in the field."
-          },
+          "en": "and he that regarded not the word of the LORD left his servants and his cattle in the field.",
           "ref": "exodus 9:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Stretch forth thy hand toward heaven, that there may be hail in all the land of Egypt, upon man, and upon beast, and upon every herb of the field, throughout the land of Egypt.’"
-          },
+          "en": "And the LORD said unto Moses: ‘Stretch forth thy hand toward heaven, that there may be hail in all the land of Egypt, upon man, and upon beast, and upon every herb of the field, throughout the land of Egypt.’",
           "ref": "exodus 9:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses stretched forth his rod toward heaven; and the LORD sent thunder and hail, and fire ran down unto the earth; and the LORD caused to hail upon the land of Egypt."
-          },
+          "en": "And Moses stretched forth his rod toward heaven; and the LORD sent thunder and hail, and fire ran down unto the earth; and the LORD caused to hail upon the land of Egypt.",
           "ref": "exodus 9:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "So there was hail, and fire flashing up amidst the hail, very grievous, such as had not been in all the land of Egypt since it became a nation."
-          },
+          "en": "So there was hail, and fire flashing up amidst the hail, very grievous, such as had not been in all the land of Egypt since it became a nation.",
           "ref": "exodus 9:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And the hail smote throughout all the land of Egypt all that was in the field, both man and beast; and the hail smote every herb of the field, and broke every tree of the field."
-          },
+          "en": "And the hail smote throughout all the land of Egypt all that was in the field, both man and beast; and the hail smote every herb of the field, and broke every tree of the field.",
           "ref": "exodus 9:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "Only in the land of Goshen, where the children of Israel were, was there no hail."
-          },
+          "en": "Only in the land of Goshen, where the children of Israel were, was there no hail.",
           "ref": "exodus 9:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh sent, and called for Moses and Aaron, and said unto them: ‘I have sinned this time; the LORD is righteous, and I and my people are wicked."
-          },
+          "en": "And Pharaoh sent, and called for Moses and Aaron, and said unto them: ‘I have sinned this time; the LORD is righteous, and I and my people are wicked.",
           "ref": "exodus 9:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "Entreat the LORD, and let there be enough of these mighty thunderings and hail; and I will let you go, and ye shall stay no longer.’"
-          },
+          "en": "Entreat the LORD, and let there be enough of these mighty thunderings and hail; and I will let you go, and ye shall stay no longer.’",
           "ref": "exodus 9:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto him: ‘As soon as I am gone out of the city, I will spread forth my hands unto the LORD; the thunders shall cease, neither shall there be any more hail; that thou mayest know that the earth is the LORD’s."
-          },
+          "en": "And Moses said unto him: ‘As soon as I am gone out of the city, I will spread forth my hands unto the LORD; the thunders shall cease, neither shall there be any more hail; that thou mayest know that the earth is the LORD’s.",
           "ref": "exodus 9:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "But as for thee and thy servants, I know that ye will not yet fear the LORD God.’—"
-          },
+          "en": "But as for thee and thy servants, I know that ye will not yet fear the LORD God.’—",
           "ref": "exodus 9:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And the flax and the barley were smitten; for the barley was in the ear, and the flax was in bloom."
-          },
+          "en": "And the flax and the barley were smitten; for the barley was in the ear, and the flax was in bloom.",
           "ref": "exodus 9:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "But the wheat and the spelt were not smitten; for they ripen late.—"
-          },
+          "en": "But the wheat and the spelt were not smitten; for they ripen late.—",
           "ref": "exodus 9:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses went out of the city from Pharaoh, and spread forth his hands unto the LORD; and the thunders and hail ceased, and the rain was not poured upon the earth."
-          },
+          "en": "And Moses went out of the city from Pharaoh, and spread forth his hands unto the LORD; and the thunders and hail ceased, and the rain was not poured upon the earth.",
           "ref": "exodus 9:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Pharaoh saw that the rain and the hail and the thunders were ceased, he sinned yet more, and hardened his heart, he and his servants."
-          },
+          "en": "And when Pharaoh saw that the rain and the hail and the thunders were ceased, he sinned yet more, and hardened his heart, he and his servants.",
           "ref": "exodus 9:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And the heart of Pharaoh was hardened, and he did not let the children of Israel go; as the LORD had spoken by Moses."
-          },
+          "en": "And the heart of Pharaoh was hardened, and he did not let the children of Israel go; as the LORD had spoken by Moses.",
           "ref": "exodus 9:35"
         }
       ]
@@ -2012,234 +1277,147 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Go in unto Pharaoh; for I have hardened his heart, and the heart of his servants, that I might show these My signs in the midst of them;"
-          },
+          "en": "And the LORD said unto Moses: ‘Go in unto Pharaoh; for I have hardened his heart, and the heart of his servants, that I might show these My signs in the midst of them;",
           "ref": "exodus 10:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "and that thou mayest tell in the ears of thy son, and of thy son’s son, what I have wrought upon Egypt, and My signs which I have done among them; that ye may know that I am the LORD.’"
-          },
+          "en": "and that thou mayest tell in the ears of thy son, and of thy son’s son, what I have wrought upon Egypt, and My signs which I have done among them; that ye may know that I am the LORD.’",
           "ref": "exodus 10:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses and Aaron went in unto Pharaoh, and said unto him: ‘Thus saith the LORD, the God of the Hebrews: How long wilt thou refuse to humble thyself before Me? let My people go, that they may serve Me."
-          },
+          "en": "And Moses and Aaron went in unto Pharaoh, and said unto him: ‘Thus saith the LORD, the God of the Hebrews: How long wilt thou refuse to humble thyself before Me? let My people go, that they may serve Me.",
           "ref": "exodus 10:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "Else, if thou refuse to let My people go, behold, to-morrow will I bring locusts into thy border;"
-          },
+          "en": "Else, if thou refuse to let My people go, behold, to-morrow will I bring locusts into thy border;",
           "ref": "exodus 10:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "and they shall cover the face of the earth, that one shall not be able to see the earth; and they shall eat the residue of that which is escaped, which remaineth unto you from the hail, and shall eat every tree which groweth for you out of the field;"
-          },
+          "en": "and they shall cover the face of the earth, that one shall not be able to see the earth; and they shall eat the residue of that which is escaped, which remaineth unto you from the hail, and shall eat every tree which groweth for you out of the field;",
           "ref": "exodus 10:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "and thy houses shall be filled, and the houses of all thy servants, and the houses of all the Egyptians; as neither thy fathers nor thy fathers’fathers have seen, since the day that they were upon the earth unto this day.’ And he turned, and went out from Pharaoh."
-          },
+          "en": "and thy houses shall be filled, and the houses of all thy servants, and the houses of all the Egyptians; as neither thy fathers nor thy fathers’fathers have seen, since the day that they were upon the earth unto this day.’ And he turned, and went out from Pharaoh.",
           "ref": "exodus 10:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh’s servants said unto him: ‘How long shall this man be a snare unto us? let the men go, that they may serve the LORD their God, knowest thou not yet that Egypt is destroyed?’"
-          },
+          "en": "And Pharaoh’s servants said unto him: ‘How long shall this man be a snare unto us? let the men go, that they may serve the LORD their God, knowest thou not yet that Egypt is destroyed?’",
           "ref": "exodus 10:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses and Aaron were brought again unto Pharaoh; and he said unto them: ‘Go, serve the LORD your God; but who are they that shall go?’"
-          },
+          "en": "And Moses and Aaron were brought again unto Pharaoh; and he said unto them: ‘Go, serve the LORD your God; but who are they that shall go?’",
           "ref": "exodus 10:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said: ‘We will go with our young and with our old, with our sons and with our daughters, with our flocks and with our herds we will go; for we must hold a feast unto the LORD.’"
-          },
+          "en": "And Moses said: ‘We will go with our young and with our old, with our sons and with our daughters, with our flocks and with our herds we will go; for we must hold a feast unto the LORD.’",
           "ref": "exodus 10:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto them: ‘So be the LORD with you, as I will let you go, and your little ones; see ye that evil is before your face."
-          },
+          "en": "And he said unto them: ‘So be the LORD with you, as I will let you go, and your little ones; see ye that evil is before your face.",
           "ref": "exodus 10:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "Not so; go now ye that are men, and serve the LORD; for that is what ye desire.’ And they were driven out from Pharaoh’s presence."
-          },
+          "en": "Not so; go now ye that are men, and serve the LORD; for that is what ye desire.’ And they were driven out from Pharaoh’s presence.",
           "ref": "exodus 10:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Stretch out thy hand over the land of Egypt for the locusts, that they may come up upon the land of Egypt, and eat every herb of the land, even all that the hail hath left.’"
-          },
+          "en": "And the LORD said unto Moses: ‘Stretch out thy hand over the land of Egypt for the locusts, that they may come up upon the land of Egypt, and eat every herb of the land, even all that the hail hath left.’",
           "ref": "exodus 10:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses stretched forth his rod over the land of Egypt, and the LORD brought an east wind upon the land all that day, and all the night; and when it was morning, the east wind brought the locusts."
-          },
+          "en": "And Moses stretched forth his rod over the land of Egypt, and the LORD brought an east wind upon the land all that day, and all the night; and when it was morning, the east wind brought the locusts.",
           "ref": "exodus 10:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And the locusts went up over all the land of Egypt, and rested in all the borders of Egypt; very grievous were they; before them there were no such locusts as they, neither after them shall be such."
-          },
+          "en": "And the locusts went up over all the land of Egypt, and rested in all the borders of Egypt; very grievous were they; before them there were no such locusts as they, neither after them shall be such.",
           "ref": "exodus 10:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "For they covered the face of the whole earth, so that the land was darkened; and they did eat every herb of the land, and all the fruit of the trees which the hail had left; and there remained not any green thing, either tree or herb of the field, through all the land of Egypt."
-          },
+          "en": "For they covered the face of the whole earth, so that the land was darkened; and they did eat every herb of the land, and all the fruit of the trees which the hail had left; and there remained not any green thing, either tree or herb of the field, through all the land of Egypt.",
           "ref": "exodus 10:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Pharaoh called for Moses and Aaron in haste; and he said: ‘I have sinned against the LORD your God, and against you."
-          },
+          "en": "Then Pharaoh called for Moses and Aaron in haste; and he said: ‘I have sinned against the LORD your God, and against you.",
           "ref": "exodus 10:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "Now therefore forgive, I pray thee, my sin only this once, and entreat the LORD your God, that He may take away from me this death only.’"
-          },
+          "en": "Now therefore forgive, I pray thee, my sin only this once, and entreat the LORD your God, that He may take away from me this death only.’",
           "ref": "exodus 10:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And he went out from Pharaoh, and entreated the LORD."
-          },
+          "en": "And he went out from Pharaoh, and entreated the LORD.",
           "ref": "exodus 10:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD turned an exceeding strong west wind, which took up the locusts, and drove them into the Red Sea; there remained not one locust in all the border of Egypt."
-          },
+          "en": "And the LORD turned an exceeding strong west wind, which took up the locusts, and drove them into the Red Sea; there remained not one locust in all the border of Egypt.",
           "ref": "exodus 10:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "But the LORD hardened Pharaoh’s heart, and he did not let the children of Israel go."
-          },
+          "en": "But the LORD hardened Pharaoh’s heart, and he did not let the children of Israel go.",
           "ref": "exodus 10:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Stretch out thy hand toward heaven, that there may be darkness over the land of Egypt, even darkness which may be felt.’"
-          },
+          "en": "And the LORD said unto Moses: ‘Stretch out thy hand toward heaven, that there may be darkness over the land of Egypt, even darkness which may be felt.’",
           "ref": "exodus 10:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses stretched forth his hand toward heaven; and there was a thick darkness in all the land of Egypt three days;"
-          },
+          "en": "And Moses stretched forth his hand toward heaven; and there was a thick darkness in all the land of Egypt three days;",
           "ref": "exodus 10:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "they saw not one another, neither rose any from his place for three days; but all the children of Israel had light in their dwellings."
-          },
+          "en": "they saw not one another, neither rose any from his place for three days; but all the children of Israel had light in their dwellings.",
           "ref": "exodus 10:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh called unto Moses, and said: ‘Go ye, serve the LORD; only let your flocks and your herds be stayed; let your little ones also go with you.’"
-          },
+          "en": "And Pharaoh called unto Moses, and said: ‘Go ye, serve the LORD; only let your flocks and your herds be stayed; let your little ones also go with you.’",
           "ref": "exodus 10:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said: ‘Thou must also give into our hand sacrifices and burnt-offerings, that we may sacrifice unto the LORD our God."
-          },
+          "en": "And Moses said: ‘Thou must also give into our hand sacrifices and burnt-offerings, that we may sacrifice unto the LORD our God.",
           "ref": "exodus 10:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "Our cattle also shall go with us; there shall not a hoof be left behind; for thereof must we take to serve the LORD our God; and we know not with what we must serve the LORD, until we come thither.’"
-          },
+          "en": "Our cattle also shall go with us; there shall not a hoof be left behind; for thereof must we take to serve the LORD our God; and we know not with what we must serve the LORD, until we come thither.’",
           "ref": "exodus 10:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "But the LORD hardened Pharaoh’s heart, and he would not let them go."
-          },
+          "en": "But the LORD hardened Pharaoh’s heart, and he would not let them go.",
           "ref": "exodus 10:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh said unto him: ‘Get thee from me, take heed to thyself, see my face no more; for in the day thou seest my face thou shalt die.’"
-          },
+          "en": "And Pharaoh said unto him: ‘Get thee from me, take heed to thyself, see my face no more; for in the day thou seest my face thou shalt die.’",
           "ref": "exodus 10:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said: ‘Thou hast spoken well; I will see thy face again no more.’"
-          },
+          "en": "And Moses said: ‘Thou hast spoken well; I will see thy face again no more.’",
           "ref": "exodus 10:29"
         }
       ]
@@ -2249,82 +1427,52 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Yet one plague more will I bring upon Pharaoh, and upon Egypt; afterwards he will let you go hence; when he shall let you go, he shall surely thrust you out hence altogether."
-          },
+          "en": "And the LORD said unto Moses: ‘Yet one plague more will I bring upon Pharaoh, and upon Egypt; afterwards he will let you go hence; when he shall let you go, he shall surely thrust you out hence altogether.",
           "ref": "exodus 11:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "Speak now in the ears of the people, and let them ask every man of his neighbour, and every woman of her neighbour, jewels of silver, and jewels of gold.’"
-          },
+          "en": "Speak now in the ears of the people, and let them ask every man of his neighbour, and every woman of her neighbour, jewels of silver, and jewels of gold.’",
           "ref": "exodus 11:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD gave the people favour in the sight of the Egyptians. Moreover the man Moses was very great in the land of Egypt, in the sight of Pharaoh’s servants, and in the sight of the people."
-          },
+          "en": "And the LORD gave the people favour in the sight of the Egyptians. Moreover the man Moses was very great in the land of Egypt, in the sight of Pharaoh’s servants, and in the sight of the people.",
           "ref": "exodus 11:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said: ‘Thus saith the LORD: About midnight will I go out into the midst of Egypt;"
-          },
+          "en": "And Moses said: ‘Thus saith the LORD: About midnight will I go out into the midst of Egypt;",
           "ref": "exodus 11:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "and all the first-born in the land of Egypt shall die, from the first-born of Pharaoh that sitteth upon his throne, even unto the first-born of the maid-servant that is behind the mill; and all the first-born of cattle."
-          },
+          "en": "and all the first-born in the land of Egypt shall die, from the first-born of Pharaoh that sitteth upon his throne, even unto the first-born of the maid-servant that is behind the mill; and all the first-born of cattle.",
           "ref": "exodus 11:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And there shall be a great cry throughout all the land of Egypt, such as there hath been none like it, nor shall be like it any more."
-          },
+          "en": "And there shall be a great cry throughout all the land of Egypt, such as there hath been none like it, nor shall be like it any more.",
           "ref": "exodus 11:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "But against any of the children of Israel shall not a dog whet his tongue, against man or beast; that ye may know how that the LORD doth put a difference between the Egyptians and Israel."
-          },
+          "en": "But against any of the children of Israel shall not a dog whet his tongue, against man or beast; that ye may know how that the LORD doth put a difference between the Egyptians and Israel.",
           "ref": "exodus 11:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And all these thy servants shall come down unto me, and bow down unto me, saying: Get thee out, and all the people that follow thee; and after that I will go out.’ And he went out from Pharaoh in hot anger."
-          },
+          "en": "And all these thy servants shall come down unto me, and bow down unto me, saying: Get thee out, and all the people that follow thee; and after that I will go out.’ And he went out from Pharaoh in hot anger.",
           "ref": "exodus 11:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Pharaoh will not hearken unto you; that My wonders may be multiplied in the land of Egypt.’"
-          },
+          "en": "And the LORD said unto Moses: ‘Pharaoh will not hearken unto you; that My wonders may be multiplied in the land of Egypt.’",
           "ref": "exodus 11:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses and Aaron did all these wonders before Pharaoh; and the LORD hardened Pharaoh’s heart, and he did not let the children of Israel go out of his land."
-          },
+          "en": "And Moses and Aaron did all these wonders before Pharaoh; and the LORD hardened Pharaoh’s heart, and he did not let the children of Israel go out of his land.",
           "ref": "exodus 11:10"
         }
       ]
@@ -2334,410 +1482,257 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses and Aaron in the land of Egypt, saying:"
-          },
+          "en": "And the LORD spoke unto Moses and Aaron in the land of Egypt, saying:",
           "ref": "exodus 12:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "’This month shall be unto you the beginning of months; it shall be the first month of the year to you."
-          },
+          "en": "’This month shall be unto you the beginning of months; it shall be the first month of the year to you.",
           "ref": "exodus 12:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "Speak ye unto all the congregation of Israel, saying: In the tenth day of this month they shall take to them every man a lamb, according to their fathers’houses, a lamb for a household;"
-          },
+          "en": "Speak ye unto all the congregation of Israel, saying: In the tenth day of this month they shall take to them every man a lamb, according to their fathers’houses, a lamb for a household;",
           "ref": "exodus 12:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "and if the household be too little for a lamb, then shall he and his neighbour next unto his house take one according to the number of the souls; according to every man’s eating ye shall make your count for the lamb."
-          },
+          "en": "and if the household be too little for a lamb, then shall he and his neighbour next unto his house take one according to the number of the souls; according to every man’s eating ye shall make your count for the lamb.",
           "ref": "exodus 12:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "Your lamb shall be without blemish, a male of the first year; ye shall take it from the sheep, or from the goats;"
-          },
+          "en": "Your lamb shall be without blemish, a male of the first year; ye shall take it from the sheep, or from the goats;",
           "ref": "exodus 12:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "and ye shall keep it unto the fourteenth day of the same month; and the whole assembly of the congregation of Israel shall kill it at dusk."
-          },
+          "en": "and ye shall keep it unto the fourteenth day of the same month; and the whole assembly of the congregation of Israel shall kill it at dusk.",
           "ref": "exodus 12:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And they shall take of the blood, and put it on the two side-posts and on the lintel, upon the houses wherein they shall eat it."
-          },
+          "en": "And they shall take of the blood, and put it on the two side-posts and on the lintel, upon the houses wherein they shall eat it.",
           "ref": "exodus 12:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And they shall eat the flesh in that night, roast with fire, and unleavened bread; with bitter herbs they shall eat it."
-          },
+          "en": "And they shall eat the flesh in that night, roast with fire, and unleavened bread; with bitter herbs they shall eat it.",
           "ref": "exodus 12:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "Eat not of it raw, nor sodden at all with water, but roast with fire; its head with its legs and with the inwards thereof."
-          },
+          "en": "Eat not of it raw, nor sodden at all with water, but roast with fire; its head with its legs and with the inwards thereof.",
           "ref": "exodus 12:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And ye shall let nothing of it remain until the morning; but that which remaineth of it until the morning ye shall burn with fire."
-          },
+          "en": "And ye shall let nothing of it remain until the morning; but that which remaineth of it until the morning ye shall burn with fire.",
           "ref": "exodus 12:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And thus shall ye eat it: with your loins girded, your shoes on your feet, and your staff in your hand; and ye shall eat it in haste—it is the LORD’s passover."
-          },
+          "en": "And thus shall ye eat it: with your loins girded, your shoes on your feet, and your staff in your hand; and ye shall eat it in haste—it is the LORD’s passover.",
           "ref": "exodus 12:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "For I will go through the land of Egypt in that night, and will smite all the first-born in the land of Egypt, both man and beast; and against all the gods of Egypt I will execute judgments: I am the LORD."
-          },
+          "en": "For I will go through the land of Egypt in that night, and will smite all the first-born in the land of Egypt, both man and beast; and against all the gods of Egypt I will execute judgments: I am the LORD.",
           "ref": "exodus 12:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And the blood shall be to you for a token upon the houses where ye are; and when I see the blood, I will pass over you, and there shall no plague be upon you to destroy you, when I smite the land of Egypt."
-          },
+          "en": "And the blood shall be to you for a token upon the houses where ye are; and when I see the blood, I will pass over you, and there shall no plague be upon you to destroy you, when I smite the land of Egypt.",
           "ref": "exodus 12:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And this day shall be unto you for a memorial, and ye shall keep it a feast to the LORD; throughout your generations ye shall keep it a feast by an ordinance for ever."
-          },
+          "en": "And this day shall be unto you for a memorial, and ye shall keep it a feast to the LORD; throughout your generations ye shall keep it a feast by an ordinance for ever.",
           "ref": "exodus 12:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "Seven days shall ye eat unleavened bread; howbeit the first day ye shall put away leaven out of your houses; for whosoever eateth leavened bread from the first day until the seventh day, that soul shall be cut off from Israel."
-          },
+          "en": "Seven days shall ye eat unleavened bread; howbeit the first day ye shall put away leaven out of your houses; for whosoever eateth leavened bread from the first day until the seventh day, that soul shall be cut off from Israel.",
           "ref": "exodus 12:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And in the first day there shall be to you a holy convocation, and in the seventh day a holy convocation; no manner of work shall be done in them, save that which every man must eat, that only may be done by you."
-          },
+          "en": "And in the first day there shall be to you a holy convocation, and in the seventh day a holy convocation; no manner of work shall be done in them, save that which every man must eat, that only may be done by you.",
           "ref": "exodus 12:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And ye shall observe the feast of unleavened bread; for in this selfsame day have I brought your hosts out of the land of Egypt; therefore shall ye observe this day throughout your generations by an ordinance for ever."
-          },
+          "en": "And ye shall observe the feast of unleavened bread; for in this selfsame day have I brought your hosts out of the land of Egypt; therefore shall ye observe this day throughout your generations by an ordinance for ever.",
           "ref": "exodus 12:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "In the first month, on the fourteenth day of the month at even, ye shall eat unleavened bread, until the one and twentieth day of the month at even."
-          },
+          "en": "In the first month, on the fourteenth day of the month at even, ye shall eat unleavened bread, until the one and twentieth day of the month at even.",
           "ref": "exodus 12:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "Seven days shall there be no leaven found in your houses; for whosoever eateth that which is leavened, that soul shall be cut off from the congregation of Israel, whether he be a sojourner, or one that is born in the land."
-          },
+          "en": "Seven days shall there be no leaven found in your houses; for whosoever eateth that which is leavened, that soul shall be cut off from the congregation of Israel, whether he be a sojourner, or one that is born in the land.",
           "ref": "exodus 12:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "Ye shall eat nothing leavened; in all your habitations shall ye eat unleavened bread.’"
-          },
+          "en": "Ye shall eat nothing leavened; in all your habitations shall ye eat unleavened bread.’",
           "ref": "exodus 12:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Moses called for all the elders of Israel, and said unto them: ‘Draw out, and take you lambs according to your families, and kill the passover lamb."
-          },
+          "en": "Then Moses called for all the elders of Israel, and said unto them: ‘Draw out, and take you lambs according to your families, and kill the passover lamb.",
           "ref": "exodus 12:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And ye shall take a bunch of hyssop, and dip it in the blood that is in the basin, and strike the lintel and the two side-posts with the blood that is in the basin; and none of you shall go out of the door of his house until the morning."
-          },
+          "en": "And ye shall take a bunch of hyssop, and dip it in the blood that is in the basin, and strike the lintel and the two side-posts with the blood that is in the basin; and none of you shall go out of the door of his house until the morning.",
           "ref": "exodus 12:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "For the LORD will pass through to smite the Egyptians; and when He seeth the blood upon the lintel, and on the two side-posts, the LORD will pass over the door, and will not suffer the destroyer to come in unto your houses to smite you."
-          },
+          "en": "For the LORD will pass through to smite the Egyptians; and when He seeth the blood upon the lintel, and on the two side-posts, the LORD will pass over the door, and will not suffer the destroyer to come in unto your houses to smite you.",
           "ref": "exodus 12:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And ye shall observe this thing for an ordinance to thee and to thy sons for ever."
-          },
+          "en": "And ye shall observe this thing for an ordinance to thee and to thy sons for ever.",
           "ref": "exodus 12:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall come to pass, when ye be come to the land which the LORD will give you, according as He hath promised, that ye shall keep this service."
-          },
+          "en": "And it shall come to pass, when ye be come to the land which the LORD will give you, according as He hath promised, that ye shall keep this service.",
           "ref": "exodus 12:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall come to pass, when your children shall say unto you: What mean ye by this service?"
-          },
+          "en": "And it shall come to pass, when your children shall say unto you: What mean ye by this service?",
           "ref": "exodus 12:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "that ye shall say: It is the sacrifice of the LORD’s passover, for that He passed over the houses of the children of Israel in Egypt, when He smote the Egyptians, and delivered our houses.’ And the people bowed the head and worshipped."
-          },
+          "en": "that ye shall say: It is the sacrifice of the LORD’s passover, for that He passed over the houses of the children of Israel in Egypt, when He smote the Egyptians, and delivered our houses.’ And the people bowed the head and worshipped.",
           "ref": "exodus 12:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And the children of Israel went and did so; as the LORD had commanded Moses and Aaron, so did they."
-          },
+          "en": "And the children of Israel went and did so; as the LORD had commanded Moses and Aaron, so did they.",
           "ref": "exodus 12:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass at midnight, that the LORD smote all the firstborn in the land of Egypt, from the first-born of Pharaoh that sat on his throne unto the first-born of the captive that was in the dungeon; and all the first-born of cattle."
-          },
+          "en": "And it came to pass at midnight, that the LORD smote all the firstborn in the land of Egypt, from the first-born of Pharaoh that sat on his throne unto the first-born of the captive that was in the dungeon; and all the first-born of cattle.",
           "ref": "exodus 12:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh rose up in the night, he, and all his servants, and all the Egyptians; and there was a great cry in Egypt; for there was not a house where there was not one dead."
-          },
+          "en": "And Pharaoh rose up in the night, he, and all his servants, and all the Egyptians; and there was a great cry in Egypt; for there was not a house where there was not one dead.",
           "ref": "exodus 12:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And he called for Moses and Aaron by night and said: ‘Rise up, get you forth from among my people, both ye and the children of Israel; and go, serve the LORD, as ye have said."
-          },
+          "en": "And he called for Moses and Aaron by night and said: ‘Rise up, get you forth from among my people, both ye and the children of Israel; and go, serve the LORD, as ye have said.",
           "ref": "exodus 12:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "Take both your flocks and your herds, as ye have said, and be gone; and bless me also.’"
-          },
+          "en": "Take both your flocks and your herds, as ye have said, and be gone; and bless me also.’",
           "ref": "exodus 12:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And the Egyptians were urgent upon the people, to send them out of the land in haste; for they said: ‘We are all dead men.’"
-          },
+          "en": "And the Egyptians were urgent upon the people, to send them out of the land in haste; for they said: ‘We are all dead men.’",
           "ref": "exodus 12:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And the people took their dough before it was leavened, their kneading-troughs being bound up in their clothes upon their shoulders."
-          },
+          "en": "And the people took their dough before it was leavened, their kneading-troughs being bound up in their clothes upon their shoulders.",
           "ref": "exodus 12:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And the children of Israel did according to the word of Moses; and they asked of the Egyptians jewels of silver, and jewels of gold, and raiment."
-          },
+          "en": "And the children of Israel did according to the word of Moses; and they asked of the Egyptians jewels of silver, and jewels of gold, and raiment.",
           "ref": "exodus 12:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD gave the people favour in the sight of the Egyptians, so that they let them have what they asked. And they despoiled the Egyptians."
-          },
+          "en": "And the LORD gave the people favour in the sight of the Egyptians, so that they let them have what they asked. And they despoiled the Egyptians.",
           "ref": "exodus 12:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": null,
-            "jps1917": "And the children of Israel journeyed from Rameses to Succoth, about six hundred thousand men on foot, beside children."
-          },
+          "en": "And the children of Israel journeyed from Rameses to Succoth, about six hundred thousand men on foot, beside children.",
           "ref": "exodus 12:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": null,
-            "jps1917": "And a mixed multitude went up also with them; and flocks, and herds, even very much cattle."
-          },
+          "en": "And a mixed multitude went up also with them; and flocks, and herds, even very much cattle.",
           "ref": "exodus 12:38"
         },
         {
           "n": 39,
-          "en": {
-            "sct": null,
-            "jps1917": "And they baked unleavened cakes of the dough which they brought forth out of Egypt, for it was not leavened; because they were thrust out of Egypt, and could not tarry, neither had they prepared for themselves any victual."
-          },
+          "en": "And they baked unleavened cakes of the dough which they brought forth out of Egypt, for it was not leavened; because they were thrust out of Egypt, and could not tarry, neither had they prepared for themselves any victual.",
           "ref": "exodus 12:39"
         },
         {
           "n": 40,
-          "en": {
-            "sct": null,
-            "jps1917": "Now the time that the children of Israel dwelt in Egypt was four hundred and thirty years."
-          },
+          "en": "Now the time that the children of Israel dwelt in Egypt was four hundred and thirty years.",
           "ref": "exodus 12:40"
         },
         {
           "n": 41,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass at the end of four hundred and thirty years, even the selfsame day it came to pass, that all the host of the LORD went out from the land of Egypt."
-          },
+          "en": "And it came to pass at the end of four hundred and thirty years, even the selfsame day it came to pass, that all the host of the LORD went out from the land of Egypt.",
           "ref": "exodus 12:41"
         },
         {
           "n": 42,
-          "en": {
-            "sct": null,
-            "jps1917": "It was a night of watching unto the LORD for bringing them out from the land of Egypt; this same night is a night of watching unto the LORD for all the children of Israel throughout their generations."
-          },
+          "en": "It was a night of watching unto the LORD for bringing them out from the land of Egypt; this same night is a night of watching unto the LORD for all the children of Israel throughout their generations.",
           "ref": "exodus 12:42"
         },
         {
           "n": 43,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses and Aaron: ‘This is the ordinance of the passover: there shall no alien eat thereof;"
-          },
+          "en": "And the LORD said unto Moses and Aaron: ‘This is the ordinance of the passover: there shall no alien eat thereof;",
           "ref": "exodus 12:43"
         },
         {
           "n": 44,
-          "en": {
-            "sct": null,
-            "jps1917": "but every man’s servant that is bought for money, when thou hast circumcised him, then shall he eat thereof."
-          },
+          "en": "but every man’s servant that is bought for money, when thou hast circumcised him, then shall he eat thereof.",
           "ref": "exodus 12:44"
         },
         {
           "n": 45,
-          "en": {
-            "sct": null,
-            "jps1917": "A sojourner and a hired servant shall not eat thereof."
-          },
+          "en": "A sojourner and a hired servant shall not eat thereof.",
           "ref": "exodus 12:45"
         },
         {
           "n": 46,
-          "en": {
-            "sct": null,
-            "jps1917": "In one house shall it be eaten; thou shalt not carry forth aught of the flesh abroad out of the house; neither shall ye break a bone thereof."
-          },
+          "en": "In one house shall it be eaten; thou shalt not carry forth aught of the flesh abroad out of the house; neither shall ye break a bone thereof.",
           "ref": "exodus 12:46"
         },
         {
           "n": 47,
-          "en": {
-            "sct": null,
-            "jps1917": "All the congregation of Israel shall keep it."
-          },
+          "en": "All the congregation of Israel shall keep it.",
           "ref": "exodus 12:47"
         },
         {
           "n": 48,
-          "en": {
-            "sct": null,
-            "jps1917": "And when a stranger shall sojourn with thee, and will keep the passover to the LORD, let all his males be circumcised, and then let him come near and keep it; and he shall be as one that is born in the land; but no uncircumcised person shall eat thereof."
-          },
+          "en": "And when a stranger shall sojourn with thee, and will keep the passover to the LORD, let all his males be circumcised, and then let him come near and keep it; and he shall be as one that is born in the land; but no uncircumcised person shall eat thereof.",
           "ref": "exodus 12:48"
         },
         {
           "n": 49,
-          "en": {
-            "sct": null,
-            "jps1917": "One law shall be to him that is homeborn, and unto the stranger that sojourneth among you.’"
-          },
+          "en": "One law shall be to him that is homeborn, and unto the stranger that sojourneth among you.’",
           "ref": "exodus 12:49"
         },
         {
           "n": 50,
-          "en": {
-            "sct": null,
-            "jps1917": "Thus did all the children of Israel; as the LORD commanded Moses and Aaron, so did they."
-          },
+          "en": "Thus did all the children of Israel; as the LORD commanded Moses and Aaron, so did they.",
           "ref": "exodus 12:50"
         },
         {
           "n": 51,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass the selfsame day that the LORD did bring the children of Israel out of the land of Egypt by their hosts."
-          },
+          "en": "And it came to pass the selfsame day that the LORD did bring the children of Israel out of the land of Egypt by their hosts.",
           "ref": "exodus 12:51"
         }
       ]
@@ -2747,178 +1742,112 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses, saying:"
-          },
+          "en": "And the LORD spoke unto Moses, saying:",
           "ref": "exodus 13:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "’Sanctify unto Me all the first-born, whatsoever opens the womb among the children of Israel, both of man and of beast, it is Mine.’"
-          },
+          "en": "’Sanctify unto Me all the first-born, whatsoever opens the womb among the children of Israel, both of man and of beast, it is Mine.’",
           "ref": "exodus 13:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto the people: ‘Remember this day, in which ye came out from Egypt, out of the house of bondage; for by strength of hand the LORD brought you out from this place; there shall no leavened bread be eaten."
-          },
+          "en": "And Moses said unto the people: ‘Remember this day, in which ye came out from Egypt, out of the house of bondage; for by strength of hand the LORD brought you out from this place; there shall no leavened bread be eaten.",
           "ref": "exodus 13:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "This day ye go forth in the month Abib."
-          },
+          "en": "This day ye go forth in the month Abib.",
           "ref": "exodus 13:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall be when the LORD shall bring thee into the land of the Canaanite, and the Hittite, and the Amorite, and the Hivite, and the Jebusite, which He swore unto thy fathers to give thee, a land flowing with milk and honey, that thou shalt keep this service in this month."
-          },
+          "en": "And it shall be when the LORD shall bring thee into the land of the Canaanite, and the Hittite, and the Amorite, and the Hivite, and the Jebusite, which He swore unto thy fathers to give thee, a land flowing with milk and honey, that thou shalt keep this service in this month.",
           "ref": "exodus 13:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "Seven days thou shalt eat unleavened bread, and in the seventh day shall be a feast to the LORD."
-          },
+          "en": "Seven days thou shalt eat unleavened bread, and in the seventh day shall be a feast to the LORD.",
           "ref": "exodus 13:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "Unleavened bread shall be eaten throughout the seven days; and there shall no leavened bread be seen with thee, neither shall there be leaven seen with thee, in all thy borders."
-          },
+          "en": "Unleavened bread shall be eaten throughout the seven days; and there shall no leavened bread be seen with thee, neither shall there be leaven seen with thee, in all thy borders.",
           "ref": "exodus 13:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt tell thy son in that day, saying: It is because of that which the LORD did for me when I came forth out of Egypt."
-          },
+          "en": "And thou shalt tell thy son in that day, saying: It is because of that which the LORD did for me when I came forth out of Egypt.",
           "ref": "exodus 13:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall be for a sign unto thee upon thy hand, and for a memorial between thine eyes, that the law of the LORD may be in thy mouth; for with a strong hand hath the LORD brought thee out of Egypt."
-          },
+          "en": "And it shall be for a sign unto thee upon thy hand, and for a memorial between thine eyes, that the law of the LORD may be in thy mouth; for with a strong hand hath the LORD brought thee out of Egypt.",
           "ref": "exodus 13:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt therefore keep this ordinance in its season from year to year."
-          },
+          "en": "Thou shalt therefore keep this ordinance in its season from year to year.",
           "ref": "exodus 13:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall be when the LORD shall bring thee into the land of the Canaanite, as He swore unto thee and to thy fathers, and shall give it thee,"
-          },
+          "en": "And it shall be when the LORD shall bring thee into the land of the Canaanite, as He swore unto thee and to thy fathers, and shall give it thee,",
           "ref": "exodus 13:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "that thou shalt set apart unto the LORD all that openeth the womb; every firstling that is a male, which thou hast coming of a beast, shall be the LORD’s."
-          },
+          "en": "that thou shalt set apart unto the LORD all that openeth the womb; every firstling that is a male, which thou hast coming of a beast, shall be the LORD’s.",
           "ref": "exodus 13:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And every firstling of an ass thou shalt redeem with a lamb; and if thou wilt not redeem it, then thou shalt break its neck; and all the first-born of man among thy sons shalt thou redeem."
-          },
+          "en": "And every firstling of an ass thou shalt redeem with a lamb; and if thou wilt not redeem it, then thou shalt break its neck; and all the first-born of man among thy sons shalt thou redeem.",
           "ref": "exodus 13:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall be when thy son asketh thee in time to come, saying: What is this? that thou shalt say unto him: By strength of hand the LORD brought us out from Egypt, from the house of bondage;"
-          },
+          "en": "And it shall be when thy son asketh thee in time to come, saying: What is this? that thou shalt say unto him: By strength of hand the LORD brought us out from Egypt, from the house of bondage;",
           "ref": "exodus 13:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "and it came to pass, when Pharaoh would hardly let us go that the LORD slew all the firstborn in the land of Egypt, both the first-born of man, and the first-born of beast; therefore I sacrifice to the LORD all that openeth the womb, being males; but all the first-born of my sons I redeem."
-          },
+          "en": "and it came to pass, when Pharaoh would hardly let us go that the LORD slew all the firstborn in the land of Egypt, both the first-born of man, and the first-born of beast; therefore I sacrifice to the LORD all that openeth the womb, being males; but all the first-born of my sons I redeem.",
           "ref": "exodus 13:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall be for a sign upon thy hand, and for frontlets between your eyes; for by strength of hand the LORD brought us forth out of Egypt.’"
-          },
+          "en": "And it shall be for a sign upon thy hand, and for frontlets between your eyes; for by strength of hand the LORD brought us forth out of Egypt.’",
           "ref": "exodus 13:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when Pharaoh had let the people go, that God led them not by the way of the land of the Philistines, although that was near; for God said: 'Lest the people regret when they see war, and they return to Egypt.’"
-          },
+          "en": "And it came to pass, when Pharaoh had let the people go, that God led them not by the way of the land of the Philistines, although that was near; for God said: 'Lest the people regret when they see war, and they return to Egypt.’",
           "ref": "exodus 13:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "But God led the people about, by the way of the wilderness by the Red Sea; and the children of Israel went up armed out of the land of Egypt."
-          },
+          "en": "But God led the people about, by the way of the wilderness by the Red Sea; and the children of Israel went up armed out of the land of Egypt.",
           "ref": "exodus 13:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses took the bones of Joseph with him; for he had surely sworn the children of Israel, saying: ‘God will surely remember you; and ye shall carry up my bones away hence with you.’"
-          },
+          "en": "And Moses took the bones of Joseph with him; for he had surely sworn the children of Israel, saying: ‘God will surely remember you; and ye shall carry up my bones away hence with you.’",
           "ref": "exodus 13:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And they took their journey from Succoth, and encamped in Etham, in the edge of the wilderness."
-          },
+          "en": "And they took their journey from Succoth, and encamped in Etham, in the edge of the wilderness.",
           "ref": "exodus 13:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD went before them by day in a pillar of cloud, to lead them the way; and by night in a pillar of fire, to give them light; that they might go by day and by night:"
-          },
+          "en": "And the LORD went before them by day in a pillar of cloud, to lead them the way; and by night in a pillar of fire, to give them light; that they might go by day and by night:",
           "ref": "exodus 13:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "the pillar of cloud by day, and the pillar of fire by night, departed not from before the people."
-          },
+          "en": "the pillar of cloud by day, and the pillar of fire by night, departed not from before the people.",
           "ref": "exodus 13:22"
         }
       ]
@@ -2928,250 +1857,157 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses, saying:"
-          },
+          "en": "And the LORD spoke unto Moses, saying:",
           "ref": "exodus 14:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "’Speak unto the children of Israel, that they turn back and encamp before Pi-hahiroth, between Migdol and the sea, before Baal-zephon, over against it shall ye encamp by the sea."
-          },
+          "en": "’Speak unto the children of Israel, that they turn back and encamp before Pi-hahiroth, between Migdol and the sea, before Baal-zephon, over against it shall ye encamp by the sea.",
           "ref": "exodus 14:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh will say of the children of Israel: They are entangled in the land, the wilderness hath shut them in."
-          },
+          "en": "And Pharaoh will say of the children of Israel: They are entangled in the land, the wilderness hath shut them in.",
           "ref": "exodus 14:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will harden Pharaoh’s heart, and he shall follow after them; and I will get Me honour upon Pharaoh, and upon all his host; and the Egyptians shall know that I am the LORD.’ And they did so."
-          },
+          "en": "And I will harden Pharaoh’s heart, and he shall follow after them; and I will get Me honour upon Pharaoh, and upon all his host; and the Egyptians shall know that I am the LORD.’ And they did so.",
           "ref": "exodus 14:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And it was told the king of Egypt that the people were fled; and the heart of Pharaoh and of his servants was turned towards the people, and they said: ‘What is this we have done, that we have let Israel go from serving us?"
-          },
+          "en": "And it was told the king of Egypt that the people were fled; and the heart of Pharaoh and of his servants was turned towards the people, and they said: ‘What is this we have done, that we have let Israel go from serving us?",
           "ref": "exodus 14:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made ready his chariots, and took his people with him."
-          },
+          "en": "And he made ready his chariots, and took his people with him.",
           "ref": "exodus 14:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And he took six hundred chosen chariots, and all the chariots of Egypt, and captains over all of them."
-          },
+          "en": "And he took six hundred chosen chariots, and all the chariots of Egypt, and captains over all of them.",
           "ref": "exodus 14:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD hardened the heart of Pharaoh king of Egypt, and he pursued after the children of Israel; for the children of Israel went out with a high hand."
-          },
+          "en": "And the LORD hardened the heart of Pharaoh king of Egypt, and he pursued after the children of Israel; for the children of Israel went out with a high hand.",
           "ref": "exodus 14:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And the Egyptians pursued after them, all the horses and chariots of Pharaoh, and his horsemen, and his army, and overtook them encamping by the sea, beside Pi-hahiroth, in front of Baal-zephon."
-          },
+          "en": "And the Egyptians pursued after them, all the horses and chariots of Pharaoh, and his horsemen, and his army, and overtook them encamping by the sea, beside Pi-hahiroth, in front of Baal-zephon.",
           "ref": "exodus 14:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Pharaoh drew nigh, the children of Israel lifted up their eyes, and, behold, the Egyptians were marching after them; and they were sore afraid; and the children of Israel cried out unto the LORD."
-          },
+          "en": "And when Pharaoh drew nigh, the children of Israel lifted up their eyes, and, behold, the Egyptians were marching after them; and they were sore afraid; and the children of Israel cried out unto the LORD.",
           "ref": "exodus 14:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said unto Moses: ‘Because there were no graves in Egypt, hast thou taken us away to die in the wilderness? wherefore hast thou dealt thus with us, to bring us forth out of Egypt?"
-          },
+          "en": "And they said unto Moses: ‘Because there were no graves in Egypt, hast thou taken us away to die in the wilderness? wherefore hast thou dealt thus with us, to bring us forth out of Egypt?",
           "ref": "exodus 14:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "Is not this the word that we spoke unto thee in Egypt, saying: Let us alone, that we may serve the Egyptians? For it were better for us to serve the Egyptians, than that we should die in the wilderness.’"
-          },
+          "en": "Is not this the word that we spoke unto thee in Egypt, saying: Let us alone, that we may serve the Egyptians? For it were better for us to serve the Egyptians, than that we should die in the wilderness.’",
           "ref": "exodus 14:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto the people: ‘Fear ye not, stand still, and see the salvation of the LORD, which He will work for you to-day; for whereas ye have seen the Egyptians to-day, ye shall see them again no more for ever."
-          },
+          "en": "And Moses said unto the people: ‘Fear ye not, stand still, and see the salvation of the LORD, which He will work for you to-day; for whereas ye have seen the Egyptians to-day, ye shall see them again no more for ever.",
           "ref": "exodus 14:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "The LORD will fight for you, and ye shall hold your peace.’"
-          },
+          "en": "The LORD will fight for you, and ye shall hold your peace.’",
           "ref": "exodus 14:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Wherefore criest thou unto Me? speak unto the children of Israel, that they go forward."
-          },
+          "en": "And the LORD said unto Moses: ‘Wherefore criest thou unto Me? speak unto the children of Israel, that they go forward.",
           "ref": "exodus 14:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And lift thou up thy rod, and stretch out thy hand over the sea, and divide it; and the children of Israel shall go into the midst of the sea on dry ground."
-          },
+          "en": "And lift thou up thy rod, and stretch out thy hand over the sea, and divide it; and the children of Israel shall go into the midst of the sea on dry ground.",
           "ref": "exodus 14:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And I, behold, I will harden the hearts of the Egyptians, and they shall go in after them; and I will get Me honour upon Pharaoh, and upon all his host, upon his chariots, and upon his horsemen."
-          },
+          "en": "And I, behold, I will harden the hearts of the Egyptians, and they shall go in after them; and I will get Me honour upon Pharaoh, and upon all his host, upon his chariots, and upon his horsemen.",
           "ref": "exodus 14:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And the Egyptians shall know that I am the LORD, when I have gotten Me honour upon Pharaoh, upon his chariots, and upon his horsemen.’"
-          },
+          "en": "And the Egyptians shall know that I am the LORD, when I have gotten Me honour upon Pharaoh, upon his chariots, and upon his horsemen.’",
           "ref": "exodus 14:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And the angel of God, who went before the camp of Israel, removed and went behind them; and the pillar of cloud removed from before them, and stood behind them;"
-          },
+          "en": "And the angel of God, who went before the camp of Israel, removed and went behind them; and the pillar of cloud removed from before them, and stood behind them;",
           "ref": "exodus 14:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "and it came between the camp of Egypt and the camp of Israel; and there was the cloud and the darkness here, yet gave it light by night there; and the one came not near the other all the night."
-          },
+          "en": "and it came between the camp of Egypt and the camp of Israel; and there was the cloud and the darkness here, yet gave it light by night there; and the one came not near the other all the night.",
           "ref": "exodus 14:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses stretched out his hand over the sea; and the LORD caused the sea to go back by a strong east wind all the night, and made the sea dry land, and the waters were divided."
-          },
+          "en": "And Moses stretched out his hand over the sea; and the LORD caused the sea to go back by a strong east wind all the night, and made the sea dry land, and the waters were divided.",
           "ref": "exodus 14:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And the children of Israel went into the midst of the sea upon the dry ground; and the waters were a wall unto them on their right hand, and on their left."
-          },
+          "en": "And the children of Israel went into the midst of the sea upon the dry ground; and the waters were a wall unto them on their right hand, and on their left.",
           "ref": "exodus 14:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And the Egyptians pursued, and went in after them into the midst of the sea, all Pharaoh’s horses, his chariots, and his horsemen."
-          },
+          "en": "And the Egyptians pursued, and went in after them into the midst of the sea, all Pharaoh’s horses, his chariots, and his horsemen.",
           "ref": "exodus 14:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass in the morning watch, that the LORD looked forth upon the host of the Egyptians through the pillar of fire and of cloud, and discomfited the host of the Egyptians."
-          },
+          "en": "And it came to pass in the morning watch, that the LORD looked forth upon the host of the Egyptians through the pillar of fire and of cloud, and discomfited the host of the Egyptians.",
           "ref": "exodus 14:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And He took off their chariot wheels, and made them to drive heavily; so that the Egyptians said: ‘Let us flee from the face of Israel; for the LORD fighteth for them against the Egyptians.’"
-          },
+          "en": "And He took off their chariot wheels, and made them to drive heavily; so that the Egyptians said: ‘Let us flee from the face of Israel; for the LORD fighteth for them against the Egyptians.’",
           "ref": "exodus 14:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Stretch out thy hand over the sea, that the waters may come back upon the Egyptians, upon their chariots, and upon their horsemen.’"
-          },
+          "en": "And the LORD said unto Moses: ‘Stretch out thy hand over the sea, that the waters may come back upon the Egyptians, upon their chariots, and upon their horsemen.’",
           "ref": "exodus 14:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses stretched forth his hand over the sea, and the sea returned to its strength when the morning appeared; and the Egyptians fled against it; and the LORD overthrew the Egyptians in the midst of the sea."
-          },
+          "en": "And Moses stretched forth his hand over the sea, and the sea returned to its strength when the morning appeared; and the Egyptians fled against it; and the LORD overthrew the Egyptians in the midst of the sea.",
           "ref": "exodus 14:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And the waters returned, and covered the chariots, and the horsemen, even all the host of Pharaoh that went in after them into the sea; there remained not so much as one of them."
-          },
+          "en": "And the waters returned, and covered the chariots, and the horsemen, even all the host of Pharaoh that went in after them into the sea; there remained not so much as one of them.",
           "ref": "exodus 14:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "But the children of Israel walked upon dry land in the midst of the sea; and the waters were a wall unto them on their right hand, and on their left."
-          },
+          "en": "But the children of Israel walked upon dry land in the midst of the sea; and the waters were a wall unto them on their right hand, and on their left.",
           "ref": "exodus 14:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "Thus the LORD saved Israel that day out of the hand of the Egyptians; and Israel saw the Egyptians dead upon the sea-shore."
-          },
+          "en": "Thus the LORD saved Israel that day out of the hand of the Egyptians; and Israel saw the Egyptians dead upon the sea-shore.",
           "ref": "exodus 14:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And Israel saw the great work which the LORD did upon the Egyptians, and the people feared the LORD; and they believed in the LORD, and in His servant Moses."
-          },
+          "en": "And Israel saw the great work which the LORD did upon the Egyptians, and the people feared the LORD; and they believed in the LORD, and in His servant Moses.",
           "ref": "exodus 14:31"
         }
       ]
@@ -3181,218 +2017,137 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "Then sang Moses and the children of Israel this song unto the LORD, and spoke, saying: I will sing unto the LORD, for He is highly exalted; The horse and his rider hath He thrown into the sea."
-          },
+          "en": "Then sang Moses and the children of Israel this song unto the LORD, and spoke, saying: I will sing unto the LORD, for He is highly exalted; The horse and his rider hath He thrown into the sea.",
           "ref": "exodus 15:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "The LORD is my strength and song, And He is become my salvation; This is my God, and I will glorify Him; My father’s God, and I will exalt Him."
-          },
+          "en": "The LORD is my strength and song, And He is become my salvation; This is my God, and I will glorify Him; My father’s God, and I will exalt Him.",
           "ref": "exodus 15:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "The LORD is a man of war, The LORD is His name."
-          },
+          "en": "The LORD is a man of war, The LORD is His name.",
           "ref": "exodus 15:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "Pharaoh’s chariots and his host hath He cast into the sea, And his chosen captains are sunk in the Red Sea."
-          },
+          "en": "Pharaoh’s chariots and his host hath He cast into the sea, And his chosen captains are sunk in the Red Sea.",
           "ref": "exodus 15:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "The deeps cover them— They went down into the depths like a stone."
-          },
+          "en": "The deeps cover them— They went down into the depths like a stone.",
           "ref": "exodus 15:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "Thy right hand, O LORD, glorious in power, Thy right hand, O LORD, dasheth in pieces the enemy."
-          },
+          "en": "Thy right hand, O LORD, glorious in power, Thy right hand, O LORD, dasheth in pieces the enemy.",
           "ref": "exodus 15:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And in the greatness of Thine excellency Thou overthrowest them that rise up against Thee; Thou sendest forth Thy wrath, it consumeth them as stubble."
-          },
+          "en": "And in the greatness of Thine excellency Thou overthrowest them that rise up against Thee; Thou sendest forth Thy wrath, it consumeth them as stubble.",
           "ref": "exodus 15:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And with the blast of Thy nostrils the waters were piled up— The floods stood upright as a heap; The deeps were congealed in the heart of the sea."
-          },
+          "en": "And with the blast of Thy nostrils the waters were piled up— The floods stood upright as a heap; The deeps were congealed in the heart of the sea.",
           "ref": "exodus 15:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "The enemy said: ‘I will pursue, I will overtake, I will divide the spoil; My lust shall be satisfied upon them; I will draw my sword, my hand shall destroy them.’"
-          },
+          "en": "The enemy said: ‘I will pursue, I will overtake, I will divide the spoil; My lust shall be satisfied upon them; I will draw my sword, my hand shall destroy them.’",
           "ref": "exodus 15:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou didst blow with Thy wind, the sea covered them; They sank as lead in the mighty waters."
-          },
+          "en": "Thou didst blow with Thy wind, the sea covered them; They sank as lead in the mighty waters.",
           "ref": "exodus 15:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "Who is like unto Thee, O LORD, among the mighty? Who is like unto Thee, glorious in holiness, Fearful in praises, doing wonders?"
-          },
+          "en": "Who is like unto Thee, O LORD, among the mighty? Who is like unto Thee, glorious in holiness, Fearful in praises, doing wonders?",
           "ref": "exodus 15:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou stretchedst out Thy right hand— The earth swallowed them."
-          },
+          "en": "Thou stretchedst out Thy right hand— The earth swallowed them.",
           "ref": "exodus 15:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou in Thy love hast led the people that Thou hast redeemed; Thou hast guided them in Thy strength to Thy holy habitation."
-          },
+          "en": "Thou in Thy love hast led the people that Thou hast redeemed; Thou hast guided them in Thy strength to Thy holy habitation.",
           "ref": "exodus 15:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "The peoples have heard, they tremble; Pangs have taken hold on the inhabitants of Philistia."
-          },
+          "en": "The peoples have heard, they tremble; Pangs have taken hold on the inhabitants of Philistia.",
           "ref": "exodus 15:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "Then were the chiefs of Edom affrighted; The mighty men of Moab, trembling taketh hold upon them; All the inhabitants of Canaan are melted away."
-          },
+          "en": "Then were the chiefs of Edom affrighted; The mighty men of Moab, trembling taketh hold upon them; All the inhabitants of Canaan are melted away.",
           "ref": "exodus 15:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "Terror and dread falleth upon them; By the greatness of Thine arm they are as still as a stone; Till Thy people pass over, O LORD, Till the people pass over that Thou hast gotten."
-          },
+          "en": "Terror and dread falleth upon them; By the greatness of Thine arm they are as still as a stone; Till Thy people pass over, O LORD, Till the people pass over that Thou hast gotten.",
           "ref": "exodus 15:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou bringest them in, and plantest them in the mountain of Thine inheritance, The place, O LORD, which Thou hast made for Thee to dwell in, The sanctuary, O Lord, which Thy hands have established."
-          },
+          "en": "Thou bringest them in, and plantest them in the mountain of Thine inheritance, The place, O LORD, which Thou hast made for Thee to dwell in, The sanctuary, O Lord, which Thy hands have established.",
           "ref": "exodus 15:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "The LORD shall reign for ever and ever."
-          },
+          "en": "The LORD shall reign for ever and ever.",
           "ref": "exodus 15:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "For the horses of Pharaoh went in with his chariots and with his horsemen into the sea, and the LORD brought back the waters of the sea upon them; but the children of Israel walked on dry land in the midst of the sea."
-          },
+          "en": "For the horses of Pharaoh went in with his chariots and with his horsemen into the sea, and the LORD brought back the waters of the sea upon them; but the children of Israel walked on dry land in the midst of the sea.",
           "ref": "exodus 15:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Miriam the prophetess, the sister of Aaron, took a timbrel in her hand; and all the women went out after her with timbrels and with dances."
-          },
+          "en": "And Miriam the prophetess, the sister of Aaron, took a timbrel in her hand; and all the women went out after her with timbrels and with dances.",
           "ref": "exodus 15:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And Miriam sang unto them: Sing ye to the LORD, for He is highly exalted: The horse and his rider hath He thrown into the sea."
-          },
+          "en": "And Miriam sang unto them: Sing ye to the LORD, for He is highly exalted: The horse and his rider hath He thrown into the sea.",
           "ref": "exodus 15:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses led Israel onward from the Red Sea, and they went out into the wilderness of Shur; and they went three days in the wilderness, and found no water."
-          },
+          "en": "And Moses led Israel onward from the Red Sea, and they went out into the wilderness of Shur; and they went three days in the wilderness, and found no water.",
           "ref": "exodus 15:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And when they came to Marah, they could not drink of the waters of Marah, for they were bitter. Therefore the name of it was called Marah."
-          },
+          "en": "And when they came to Marah, they could not drink of the waters of Marah, for they were bitter. Therefore the name of it was called Marah.",
           "ref": "exodus 15:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And the people murmured against Moses, saying: ‘What shall we drink?’"
-          },
+          "en": "And the people murmured against Moses, saying: ‘What shall we drink?’",
           "ref": "exodus 15:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And he cried unto the LORD; and the LORD showed him a tree, and he cast it into the waters, and the waters were made sweet. There He made for them a statute and an ordinance, and there He proved them;"
-          },
+          "en": "And he cried unto the LORD; and the LORD showed him a tree, and he cast it into the waters, and the waters were made sweet. There He made for them a statute and an ordinance, and there He proved them;",
           "ref": "exodus 15:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "and He said: ‘If thou wilt diligently hearken to the voice of the LORD thy God, and wilt do that which is right in His eyes, and wilt give ear to His commandments, and keep all His statutes, I will put none of the diseases upon thee, which I have put upon the Egyptians; for I am the LORD that healeth thee.’"
-          },
+          "en": "and He said: ‘If thou wilt diligently hearken to the voice of the LORD thy God, and wilt do that which is right in His eyes, and wilt give ear to His commandments, and keep all His statutes, I will put none of the diseases upon thee, which I have put upon the Egyptians; for I am the LORD that healeth thee.’",
           "ref": "exodus 15:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And they came to Elim, where were twelve springs of water, and three score and ten palm-trees; and they encamped there by the waters."
-          },
+          "en": "And they came to Elim, where were twelve springs of water, and three score and ten palm-trees; and they encamped there by the waters.",
           "ref": "exodus 15:27"
         }
       ]
@@ -3402,290 +2157,182 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And they took their journey from Elim, and all the congregation of the children of Israel came unto the wilderness of Sin, which is between Elim and Sinai, on the fifteenth day of the second month after their departing out of the land of Egypt."
-          },
+          "en": "And they took their journey from Elim, and all the congregation of the children of Israel came unto the wilderness of Sin, which is between Elim and Sinai, on the fifteenth day of the second month after their departing out of the land of Egypt.",
           "ref": "exodus 16:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And the whole congregation of the children of Israel murmured against Moses and against Aaron in the wilderness;"
-          },
+          "en": "And the whole congregation of the children of Israel murmured against Moses and against Aaron in the wilderness;",
           "ref": "exodus 16:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "and the children of Israel said unto them: ‘Would that we had died by the hand of the LORD in the land of Egypt, when we sat by the flesh-pots, when we did eat bread to the full; for ye have brought us forth into this wilderness, to kill this whole assembly with hunger.’"
-          },
+          "en": "and the children of Israel said unto them: ‘Would that we had died by the hand of the LORD in the land of Egypt, when we sat by the flesh-pots, when we did eat bread to the full; for ye have brought us forth into this wilderness, to kill this whole assembly with hunger.’",
           "ref": "exodus 16:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "Then said the LORD unto Moses: ‘Behold, I will cause to rain bread from heaven for you; and the people shall go out and gather a day’s portion every day, that I may prove them, whether they will walk in My law, or not."
-          },
+          "en": "Then said the LORD unto Moses: ‘Behold, I will cause to rain bread from heaven for you; and the people shall go out and gather a day’s portion every day, that I may prove them, whether they will walk in My law, or not.",
           "ref": "exodus 16:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall come to pass on the sixth day that they shall prepare that which they bring in, and it shall be twice as much as they gather daily.’"
-          },
+          "en": "And it shall come to pass on the sixth day that they shall prepare that which they bring in, and it shall be twice as much as they gather daily.’",
           "ref": "exodus 16:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses and Aaron said unto all the children of Israel: ‘At even, then ye shall know that the LORD hath brought you out from the land of Egypt;"
-          },
+          "en": "And Moses and Aaron said unto all the children of Israel: ‘At even, then ye shall know that the LORD hath brought you out from the land of Egypt;",
           "ref": "exodus 16:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "and in the morning, then ye shall see the glory of the LORD; for that He hath heard your murmurings against the LORD; and what are we, that ye murmur against us?’"
-          },
+          "en": "and in the morning, then ye shall see the glory of the LORD; for that He hath heard your murmurings against the LORD; and what are we, that ye murmur against us?’",
           "ref": "exodus 16:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said: ‘This shall be, when the LORD shall give you in the evening flesh to eat, and in the morning bread to the full; for that the LORD heareth your murmurings which ye murmur against Him; and what are we? your murmurings are not against us, but against the LORD.’"
-          },
+          "en": "And Moses said: ‘This shall be, when the LORD shall give you in the evening flesh to eat, and in the morning bread to the full; for that the LORD heareth your murmurings which ye murmur against Him; and what are we? your murmurings are not against us, but against the LORD.’",
           "ref": "exodus 16:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto Aaron: ‘Say unto all the congregation of the children of Israel: Come near before the LORD; for He hath heard your murmurings.’"
-          },
+          "en": "And Moses said unto Aaron: ‘Say unto all the congregation of the children of Israel: Come near before the LORD; for He hath heard your murmurings.’",
           "ref": "exodus 16:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, as Aaron spoke unto the whole congregation of the children of Israel, that they looked toward the wilderness, and, behold, the glory of the LORD appeared in the cloud."
-          },
+          "en": "And it came to pass, as Aaron spoke unto the whole congregation of the children of Israel, that they looked toward the wilderness, and, behold, the glory of the LORD appeared in the cloud.",
           "ref": "exodus 16:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses, saying:"
-          },
+          "en": "And the LORD spoke unto Moses, saying:",
           "ref": "exodus 16:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "’I have heard the murmurings of the children of Israel. Speak unto them, saying: At dusk ye shall eat flesh, and in the morning ye shall be filled with bread; and ye shall know that I am the LORD your God.’"
-          },
+          "en": "’I have heard the murmurings of the children of Israel. Speak unto them, saying: At dusk ye shall eat flesh, and in the morning ye shall be filled with bread; and ye shall know that I am the LORD your God.’",
           "ref": "exodus 16:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass at even, that the quails came up, and covered the camp; and in the morning there was a layer of dew round about the camp."
-          },
+          "en": "And it came to pass at even, that the quails came up, and covered the camp; and in the morning there was a layer of dew round about the camp.",
           "ref": "exodus 16:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And when the layer of dew was gone up, behold upon the face of the wilderness a fine, scale-like thing, fine as the hoar-frost on the ground."
-          },
+          "en": "And when the layer of dew was gone up, behold upon the face of the wilderness a fine, scale-like thing, fine as the hoar-frost on the ground.",
           "ref": "exodus 16:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And when the children of Israel saw it, they said one to another: ‘What is it?’—for they knew not what it was. And Moses said unto them: ‘It is the bread which the LORD hath given you to eat."
-          },
+          "en": "And when the children of Israel saw it, they said one to another: ‘What is it?’—for they knew not what it was. And Moses said unto them: ‘It is the bread which the LORD hath given you to eat.",
           "ref": "exodus 16:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "This is the thing which the LORD hath commanded: Gather ye of it every man according to his eating; an omer a head, according to the number of your persons, shall ye take it, every man for them that are in his tent.’"
-          },
+          "en": "This is the thing which the LORD hath commanded: Gather ye of it every man according to his eating; an omer a head, according to the number of your persons, shall ye take it, every man for them that are in his tent.’",
           "ref": "exodus 16:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And the children of Israel did so, and gathered some more, some less."
-          },
+          "en": "And the children of Israel did so, and gathered some more, some less.",
           "ref": "exodus 16:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And when they did mete it with an omer, he that gathered much had nothing over, and he that gathered little had no lack; they gathered every man according to his eating."
-          },
+          "en": "And when they did mete it with an omer, he that gathered much had nothing over, and he that gathered little had no lack; they gathered every man according to his eating.",
           "ref": "exodus 16:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto them: ‘Let no man leave of it till the morning.’"
-          },
+          "en": "And Moses said unto them: ‘Let no man leave of it till the morning.’",
           "ref": "exodus 16:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "Notwithstanding they hearkened not unto Moses; but some of them left of it until the morning, and it bred worms, and rotted; and Moses was wroth with them."
-          },
+          "en": "Notwithstanding they hearkened not unto Moses; but some of them left of it until the morning, and it bred worms, and rotted; and Moses was wroth with them.",
           "ref": "exodus 16:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And they gathered it morning by morning, every man according to his eating; and as the sun waxed hot, it melted."
-          },
+          "en": "And they gathered it morning by morning, every man according to his eating; and as the sun waxed hot, it melted.",
           "ref": "exodus 16:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass that on the sixth day they gathered twice as much bread, two omers for each one; and all the rulers of the congregation came and told Moses."
-          },
+          "en": "And it came to pass that on the sixth day they gathered twice as much bread, two omers for each one; and all the rulers of the congregation came and told Moses.",
           "ref": "exodus 16:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto them: ‘This is that which the LORD hath spoken: To-morrow is a solemn rest, a holy sabbath unto the LORD. Bake that which ye will bake, and seethe that which ye will seethe; and all that remaineth over lay up for you to be kept until the morning.’"
-          },
+          "en": "And he said unto them: ‘This is that which the LORD hath spoken: To-morrow is a solemn rest, a holy sabbath unto the LORD. Bake that which ye will bake, and seethe that which ye will seethe; and all that remaineth over lay up for you to be kept until the morning.’",
           "ref": "exodus 16:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And they laid it up till the morning, as Moses bade; and it did not rot, neither was there any worm therein."
-          },
+          "en": "And they laid it up till the morning, as Moses bade; and it did not rot, neither was there any worm therein.",
           "ref": "exodus 16:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said: ‘Eat that to-day; for to-day is a sabbath unto the LORD; to-day ye shall not find it in the field."
-          },
+          "en": "And Moses said: ‘Eat that to-day; for to-day is a sabbath unto the LORD; to-day ye shall not find it in the field.",
           "ref": "exodus 16:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "Six days ye shall gather it; but on the seventh day is the sabbath, in it there shall be none.’"
-          },
+          "en": "Six days ye shall gather it; but on the seventh day is the sabbath, in it there shall be none.’",
           "ref": "exodus 16:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass on the seventh day, that there went out some of the people to gather, and they found none."
-          },
+          "en": "And it came to pass on the seventh day, that there went out some of the people to gather, and they found none.",
           "ref": "exodus 16:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘How long refuse ye to keep My commandments and My laws?"
-          },
+          "en": "And the LORD said unto Moses: ‘How long refuse ye to keep My commandments and My laws?",
           "ref": "exodus 16:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "See that the LORD hath given you the sabbath; therefore He giveth you on the sixth day the bread of two days; abide ye every man in his place, let no man go out of his place on the seventh day.’"
-          },
+          "en": "See that the LORD hath given you the sabbath; therefore He giveth you on the sixth day the bread of two days; abide ye every man in his place, let no man go out of his place on the seventh day.’",
           "ref": "exodus 16:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "So the people rested on the seventh day."
-          },
+          "en": "So the people rested on the seventh day.",
           "ref": "exodus 16:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And the house of Israel called the name thereof Manna; and it was like coriander seed, white; and the taste of it was like wafers made with honey."
-          },
+          "en": "And the house of Israel called the name thereof Manna; and it was like coriander seed, white; and the taste of it was like wafers made with honey.",
           "ref": "exodus 16:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said: ‘This is the thing which the LORD hath commanded: Let an omerful of it be kept throughout your generations; that they may see the bread wherewith I fed you in the wilderness, when I brought you forth from the land of Egypt.’"
-          },
+          "en": "And Moses said: ‘This is the thing which the LORD hath commanded: Let an omerful of it be kept throughout your generations; that they may see the bread wherewith I fed you in the wilderness, when I brought you forth from the land of Egypt.’",
           "ref": "exodus 16:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto Aaron: ‘Take a jar, and put an omerful of manna therein, and lay it up before the LORD, to be kept throughout your generations.’"
-          },
+          "en": "And Moses said unto Aaron: ‘Take a jar, and put an omerful of manna therein, and lay it up before the LORD, to be kept throughout your generations.’",
           "ref": "exodus 16:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "As the LORD commanded Moses, so Aaron laid it up before the Testimony, to be kept."
-          },
+          "en": "As the LORD commanded Moses, so Aaron laid it up before the Testimony, to be kept.",
           "ref": "exodus 16:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And the children of Israel did eat the manna forty years, until they came to a land inhabited; they did eat the manna, until they came unto the borders of the land of Canaan."
-          },
+          "en": "And the children of Israel did eat the manna forty years, until they came to a land inhabited; they did eat the manna, until they came unto the borders of the land of Canaan.",
           "ref": "exodus 16:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "Now an omer is the tenth part of an ephah."
-          },
+          "en": "Now an omer is the tenth part of an ephah.",
           "ref": "exodus 16:36"
         }
       ]
@@ -3695,130 +2342,82 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And all the congregation of the children of Israel journeyed from the wilderness of Sin, by their stages, according to the commandment of the LORD, and encamped in Rephidim; and there was no water for the people to drink."
-          },
+          "en": "And all the congregation of the children of Israel journeyed from the wilderness of Sin, by their stages, according to the commandment of the LORD, and encamped in Rephidim; and there was no water for the people to drink.",
           "ref": "exodus 17:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "Wherefore the people strove with Moses, and said: ‘Give us water that we may drink.’ And Moses said unto them: ‘Why strive ye with me? wherefore do ye try the LORD?’"
-          },
+          "en": "Wherefore the people strove with Moses, and said: ‘Give us water that we may drink.’ And Moses said unto them: ‘Why strive ye with me? wherefore do ye try the LORD?’",
           "ref": "exodus 17:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And the people thirsted there for water; and the people murmured against Moses, and said: ‘Wherefore hast thou brought us up out of Egypt, to kill us and our children and our cattle with thirst?’"
-          },
+          "en": "And the people thirsted there for water; and the people murmured against Moses, and said: ‘Wherefore hast thou brought us up out of Egypt, to kill us and our children and our cattle with thirst?’",
           "ref": "exodus 17:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses cried unto the LORD, saying: ‘What shall I do unto this people? they are almost ready to stone me.’"
-          },
+          "en": "And Moses cried unto the LORD, saying: ‘What shall I do unto this people? they are almost ready to stone me.’",
           "ref": "exodus 17:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Pass on before the people, and take with thee of the elders of Israel; and thy rod, wherewith thou smotest the river, take in thy hand, and go."
-          },
+          "en": "And the LORD said unto Moses: ‘Pass on before the people, and take with thee of the elders of Israel; and thy rod, wherewith thou smotest the river, take in thy hand, and go.",
           "ref": "exodus 17:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "Behold, I will stand before thee there upon the rock in Horeb; and thou shalt smite the rock, and there shall come water out of it, that the people may drink.’ And Moses did so in the sight of the elders of Israel."
-          },
+          "en": "Behold, I will stand before thee there upon the rock in Horeb; and thou shalt smite the rock, and there shall come water out of it, that the people may drink.’ And Moses did so in the sight of the elders of Israel.",
           "ref": "exodus 17:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And the name of the place was called Massah, and Meribah, because of the striving of the children of Israel, and because they tried the LORD, saying: ‘Is the LORD among us, or not?’"
-          },
+          "en": "And the name of the place was called Massah, and Meribah, because of the striving of the children of Israel, and because they tried the LORD, saying: ‘Is the LORD among us, or not?’",
           "ref": "exodus 17:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "Then came Amalek, and fought with Israel in Rephidim."
-          },
+          "en": "Then came Amalek, and fought with Israel in Rephidim.",
           "ref": "exodus 17:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto Joshua: ‘Choose us out men, and go out, fight with Amalek; tomorrow I will stand on the top of the hill with the rod of God in my hand.’"
-          },
+          "en": "And Moses said unto Joshua: ‘Choose us out men, and go out, fight with Amalek; tomorrow I will stand on the top of the hill with the rod of God in my hand.’",
           "ref": "exodus 17:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "So Joshua did as Moses had said to him, and fought with Amalek; and Moses, Aaron, and Hur went up to the top of the hill."
-          },
+          "en": "So Joshua did as Moses had said to him, and fought with Amalek; and Moses, Aaron, and Hur went up to the top of the hill.",
           "ref": "exodus 17:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when Moses held up his hand, that Israel prevailed; and when he let down his hand, Amalek prevailed."
-          },
+          "en": "And it came to pass, when Moses held up his hand, that Israel prevailed; and when he let down his hand, Amalek prevailed.",
           "ref": "exodus 17:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "But Moses’hands were heavy; and they took a stone, and put it under him, and he sat thereon; and Aaron and Hur stayed up his hands, the one on the one side, and the other on the other side; and his hands were steady until the going down of the sun."
-          },
+          "en": "But Moses’hands were heavy; and they took a stone, and put it under him, and he sat thereon; and Aaron and Hur stayed up his hands, the one on the one side, and the other on the other side; and his hands were steady until the going down of the sun.",
           "ref": "exodus 17:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joshua discomfited Amalek and his people with the edge of the sword."
-          },
+          "en": "And Joshua discomfited Amalek and his people with the edge of the sword.",
           "ref": "exodus 17:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Write this for a memorial in the book, and rehearse it in the ears of Joshua: for I will utterly blot out the remembrance of Amalek from under heaven.’"
-          },
+          "en": "And the LORD said unto Moses: ‘Write this for a memorial in the book, and rehearse it in the ears of Joshua: for I will utterly blot out the remembrance of Amalek from under heaven.’",
           "ref": "exodus 17:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses built an altar, and called the name of it Adonai-nissi."
-          },
+          "en": "And Moses built an altar, and called the name of it Adonai-nissi.",
           "ref": "exodus 17:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘The hand upon the throne of the LORD: the LORD will have war with Amalek from generation to generation.’"
-          },
+          "en": "And he said: ‘The hand upon the throne of the LORD: the LORD will have war with Amalek from generation to generation.’",
           "ref": "exodus 17:16"
         }
       ]
@@ -3828,218 +2427,137 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "Now Jethro, the priest of Midian, Moses’father-in-law, heard of all that God had done for Moses, and for Israel His people, how that the LORD had brought Israel out of Egypt."
-          },
+          "en": "Now Jethro, the priest of Midian, Moses’father-in-law, heard of all that God had done for Moses, and for Israel His people, how that the LORD had brought Israel out of Egypt.",
           "ref": "exodus 18:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jethro, Moses’father-in-law, took Zipporah, Moses’wife, after he had sent her away,"
-          },
+          "en": "And Jethro, Moses’father-in-law, took Zipporah, Moses’wife, after he had sent her away,",
           "ref": "exodus 18:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "and her two sons; of whom the name of the one was Gershom; for he said: ‘I have been a stranger in a strange land’;"
-          },
+          "en": "and her two sons; of whom the name of the one was Gershom; for he said: ‘I have been a stranger in a strange land’;",
           "ref": "exodus 18:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "and the name of the other was Eliezer: ‘for the God of my father was my help, and delivered me from the sword of Pharaoh.’"
-          },
+          "en": "and the name of the other was Eliezer: ‘for the God of my father was my help, and delivered me from the sword of Pharaoh.’",
           "ref": "exodus 18:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jethro, Moses’father-in-law, came with his sons and his wife unto Moses into the wilderness where he was encamped, at the mount of God;"
-          },
+          "en": "And Jethro, Moses’father-in-law, came with his sons and his wife unto Moses into the wilderness where he was encamped, at the mount of God;",
           "ref": "exodus 18:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "and he said unto Moses: ‘I thy father-in-law Jethro am coming unto thee, and thy wife, and her two sons with her.’"
-          },
+          "en": "and he said unto Moses: ‘I thy father-in-law Jethro am coming unto thee, and thy wife, and her two sons with her.’",
           "ref": "exodus 18:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses went out to meet his father-in-law, and bowed down and kissed him; and they asked each other of their welfare; and they came into the tent."
-          },
+          "en": "And Moses went out to meet his father-in-law, and bowed down and kissed him; and they asked each other of their welfare; and they came into the tent.",
           "ref": "exodus 18:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses told his father-in-law all that the LORD had done unto Pharaoh and to the Egyptians for Israel’s sake, all the travail that had come upon them by the way, and how the LORD delivered them."
-          },
+          "en": "And Moses told his father-in-law all that the LORD had done unto Pharaoh and to the Egyptians for Israel’s sake, all the travail that had come upon them by the way, and how the LORD delivered them.",
           "ref": "exodus 18:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jethro rejoiced for all the goodness which the LORD had done to Israel, in that He had delivered them out of the hand of the Egyptians."
-          },
+          "en": "And Jethro rejoiced for all the goodness which the LORD had done to Israel, in that He had delivered them out of the hand of the Egyptians.",
           "ref": "exodus 18:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jethro said: ‘Blessed be the LORD, who hath delivered you out of the hand of the Egyptians, and out of the hand of Pharaoh; who hath delivered the people from under the hand of the Egyptians."
-          },
+          "en": "And Jethro said: ‘Blessed be the LORD, who hath delivered you out of the hand of the Egyptians, and out of the hand of Pharaoh; who hath delivered the people from under the hand of the Egyptians.",
           "ref": "exodus 18:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "Now I know that the LORD is greater than all gods; yea, for that they dealt proudly against them.’"
-          },
+          "en": "Now I know that the LORD is greater than all gods; yea, for that they dealt proudly against them.’",
           "ref": "exodus 18:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jethro, Moses’father-in-law, took a burnt-offering and sacrifices for God; and Aaron came, and all the elders of Israel, to eat bread with Moses’father-in-law before God."
-          },
+          "en": "And Jethro, Moses’father-in-law, took a burnt-offering and sacrifices for God; and Aaron came, and all the elders of Israel, to eat bread with Moses’father-in-law before God.",
           "ref": "exodus 18:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass on the morrow, that Moses sat to judge the people; and the people stood about Moses from the morning unto the evening."
-          },
+          "en": "And it came to pass on the morrow, that Moses sat to judge the people; and the people stood about Moses from the morning unto the evening.",
           "ref": "exodus 18:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Moses’father-in-law saw all that he did to the people, he said: ‘What is this thing that thou doest to the people? why sittest thou thyself alone, and all the people stand about thee from morning unto even?’"
-          },
+          "en": "And when Moses’father-in-law saw all that he did to the people, he said: ‘What is this thing that thou doest to the people? why sittest thou thyself alone, and all the people stand about thee from morning unto even?’",
           "ref": "exodus 18:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto his father-in-law: ‘Because the people come unto me to inquire of God;"
-          },
+          "en": "And Moses said unto his father-in-law: ‘Because the people come unto me to inquire of God;",
           "ref": "exodus 18:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "when they have a matter, it cometh unto me; and I judge between a man and his neighbour, and I make them know the statutes of God, and His laws.’"
-          },
+          "en": "when they have a matter, it cometh unto me; and I judge between a man and his neighbour, and I make them know the statutes of God, and His laws.’",
           "ref": "exodus 18:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses’father-in-law said unto him: ‘The thing that thou doest is not good."
-          },
+          "en": "And Moses’father-in-law said unto him: ‘The thing that thou doest is not good.",
           "ref": "exodus 18:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou wilt surely wear away, both thou, and this people that is with thee; for the thing is too heavy for thee; thou art not able to perform it thyself alone."
-          },
+          "en": "Thou wilt surely wear away, both thou, and this people that is with thee; for the thing is too heavy for thee; thou art not able to perform it thyself alone.",
           "ref": "exodus 18:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "Hearken now unto my voice, I will give thee counsel, and God be with thee: be thou for the people before God, and bring thou the causes unto God."
-          },
+          "en": "Hearken now unto my voice, I will give thee counsel, and God be with thee: be thou for the people before God, and bring thou the causes unto God.",
           "ref": "exodus 18:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt teach them the statutes and the laws, and shalt show them the way wherein they must walk, and the work that they must do."
-          },
+          "en": "And thou shalt teach them the statutes and the laws, and shalt show them the way wherein they must walk, and the work that they must do.",
           "ref": "exodus 18:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "Moreover thou shalt provide out of all the people able men, such as fear God, men of truth, hating unjust gain; and place such over them, to be rulers of thousands, rulers of hundreds, rulers of fifties, and rulers of tens."
-          },
+          "en": "Moreover thou shalt provide out of all the people able men, such as fear God, men of truth, hating unjust gain; and place such over them, to be rulers of thousands, rulers of hundreds, rulers of fifties, and rulers of tens.",
           "ref": "exodus 18:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And let them judge the people at all seasons; and it shall be, that every great matter they shall bring unto thee, but every small matter they shall judge themselves; so shall they make it easier for thee and bear the burden with thee."
-          },
+          "en": "And let them judge the people at all seasons; and it shall be, that every great matter they shall bring unto thee, but every small matter they shall judge themselves; so shall they make it easier for thee and bear the burden with thee.",
           "ref": "exodus 18:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "If thou shalt do this thing, and God command thee so, then thou shalt be able to endure, and all this people also shall go to their place in peace.’"
-          },
+          "en": "If thou shalt do this thing, and God command thee so, then thou shalt be able to endure, and all this people also shall go to their place in peace.’",
           "ref": "exodus 18:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "So Moses hearkened to the voice of his father-in-law, and did all that he had said."
-          },
+          "en": "So Moses hearkened to the voice of his father-in-law, and did all that he had said.",
           "ref": "exodus 18:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses chose able men out of all Israel, and made them heads over the people, rulers of thousands, rulers of hundreds, rulers of fifties, and rulers of tens."
-          },
+          "en": "And Moses chose able men out of all Israel, and made them heads over the people, rulers of thousands, rulers of hundreds, rulers of fifties, and rulers of tens.",
           "ref": "exodus 18:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And they judged the people at all seasons: the hard causes they brought unto Moses, but every small matter they judged themselves."
-          },
+          "en": "And they judged the people at all seasons: the hard causes they brought unto Moses, but every small matter they judged themselves.",
           "ref": "exodus 18:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses let his father-in-law depart; and he went his way into his own land."
-          },
+          "en": "And Moses let his father-in-law depart; and he went his way into his own land.",
           "ref": "exodus 18:27"
         }
       ]
@@ -4049,202 +2567,127 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "In the third month after the children of Israel were gone forth out of the land of Egypt, the same day came they into the wilderness of Sinai."
-          },
+          "en": "In the third month after the children of Israel were gone forth out of the land of Egypt, the same day came they into the wilderness of Sinai.",
           "ref": "exodus 19:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And when they were departed from Rephidim, and were come to the wilderness of Sinai, they encamped in the wilderness; and there Israel encamped before the mount."
-          },
+          "en": "And when they were departed from Rephidim, and were come to the wilderness of Sinai, they encamped in the wilderness; and there Israel encamped before the mount.",
           "ref": "exodus 19:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses went up unto God, and the LORD called unto him out of the mountain, saying: ‘Thus shalt thou say to the house of Jacob, and tell the children of Israel:"
-          },
+          "en": "And Moses went up unto God, and the LORD called unto him out of the mountain, saying: ‘Thus shalt thou say to the house of Jacob, and tell the children of Israel:",
           "ref": "exodus 19:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "Ye have seen what I did unto the Egyptians, and how I bore you on eagles’wings, and brought you unto Myself."
-          },
+          "en": "Ye have seen what I did unto the Egyptians, and how I bore you on eagles’wings, and brought you unto Myself.",
           "ref": "exodus 19:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "Now therefore, if ye will hearken unto My voice indeed, and keep My covenant, then ye shall be Mine own treasure from among all peoples; for all the earth is Mine;"
-          },
+          "en": "Now therefore, if ye will hearken unto My voice indeed, and keep My covenant, then ye shall be Mine own treasure from among all peoples; for all the earth is Mine;",
           "ref": "exodus 19:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "and ye shall be unto Me a kingdom of priests, and a holy nation. These are the words which thou shalt speak unto the children of Israel.’"
-          },
+          "en": "and ye shall be unto Me a kingdom of priests, and a holy nation. These are the words which thou shalt speak unto the children of Israel.’",
           "ref": "exodus 19:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses came and called for the elders of the people, and set before them all these words which the LORD commanded him."
-          },
+          "en": "And Moses came and called for the elders of the people, and set before them all these words which the LORD commanded him.",
           "ref": "exodus 19:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": "All the people answered as one, \"Everything that the Lord has spoken we will do.\"",
-            "jps1917": "And all the people answered together, and said: ‘All that the LORD hath spoken we will do.’ And Moses reported the words of the people unto the LORD."
-          },
+          "en": "And all the people answered together, and said: ‘All that the LORD hath spoken we will do.’ And Moses reported the words of the people unto the LORD.",
           "ref": "exodus 19:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Lo, I come unto thee in a thick cloud, that the people may hear when I speak with thee, and may also believe thee for ever.’ And Moses told the words of the people unto the LORD."
-          },
+          "en": "And the LORD said unto Moses: ‘Lo, I come unto thee in a thick cloud, that the people may hear when I speak with thee, and may also believe thee for ever.’ And Moses told the words of the people unto the LORD.",
           "ref": "exodus 19:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Go unto the people, and sanctify them to-day and to-morrow, and let them wash their garments,"
-          },
+          "en": "And the LORD said unto Moses: ‘Go unto the people, and sanctify them to-day and to-morrow, and let them wash their garments,",
           "ref": "exodus 19:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "and be ready against the third day; for the third day the LORD will come down in the sight of all the people upon mount Sinai."
-          },
+          "en": "and be ready against the third day; for the third day the LORD will come down in the sight of all the people upon mount Sinai.",
           "ref": "exodus 19:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt set bounds unto the people round about, saying: Take heed to yourselves, that ye go not up into the mount, or touch the border of it; whosoever toucheth the mount shall be surely put to death;"
-          },
+          "en": "And thou shalt set bounds unto the people round about, saying: Take heed to yourselves, that ye go not up into the mount, or touch the border of it; whosoever toucheth the mount shall be surely put to death;",
           "ref": "exodus 19:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "no hand shall touch him, but he shall surely be stoned, or shot through; whether it be beast or man, it shall not live; when the ram’s horn soundeth long, they shall come up to the mount.’"
-          },
+          "en": "no hand shall touch him, but he shall surely be stoned, or shot through; whether it be beast or man, it shall not live; when the ram’s horn soundeth long, they shall come up to the mount.’",
           "ref": "exodus 19:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses went down from the mount unto the people, and sanctified the people; and they washed their garments."
-          },
+          "en": "And Moses went down from the mount unto the people, and sanctified the people; and they washed their garments.",
           "ref": "exodus 19:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto the people: ‘Be ready against the third day; come not near a woman.’"
-          },
+          "en": "And he said unto the people: ‘Be ready against the third day; come not near a woman.’",
           "ref": "exodus 19:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass on the third day, when it was morning, that there were thunders and lightnings and a thick cloud upon the mount, and the voice of a horn exceeding loud; and all the people that were in the camp trembled."
-          },
+          "en": "And it came to pass on the third day, when it was morning, that there were thunders and lightnings and a thick cloud upon the mount, and the voice of a horn exceeding loud; and all the people that were in the camp trembled.",
           "ref": "exodus 19:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses brought forth the people out of the camp to meet God; and they stood at the nether part of the mount."
-          },
+          "en": "And Moses brought forth the people out of the camp to meet God; and they stood at the nether part of the mount.",
           "ref": "exodus 19:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "Now mount Sinai was altogether on smoke, because the LORD descended upon it in fire; and the smoke thereof ascended as the smoke of a furnace, and the whole mount quaked greatly."
-          },
+          "en": "Now mount Sinai was altogether on smoke, because the LORD descended upon it in fire; and the smoke thereof ascended as the smoke of a furnace, and the whole mount quaked greatly.",
           "ref": "exodus 19:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And when the voice of the horn waxed louder and louder, Moses spoke, and God answered him by a voice."
-          },
+          "en": "And when the voice of the horn waxed louder and louder, Moses spoke, and God answered him by a voice.",
           "ref": "exodus 19:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD came down upon mount Sinai, to the top of the mount; and the LORD called Moses to the top of the mount; and Moses went up."
-          },
+          "en": "And the LORD came down upon mount Sinai, to the top of the mount; and the LORD called Moses to the top of the mount; and Moses went up.",
           "ref": "exodus 19:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Go down, charge the people, lest they break through unto the LORD to gaze, and many of them perish."
-          },
+          "en": "And the LORD said unto Moses: ‘Go down, charge the people, lest they break through unto the LORD to gaze, and many of them perish.",
           "ref": "exodus 19:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And let the priests also, that come near to the LORD, sanctify themselves, lest the LORD break forth upon them.’"
-          },
+          "en": "And let the priests also, that come near to the LORD, sanctify themselves, lest the LORD break forth upon them.’",
           "ref": "exodus 19:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto the LORD: ‘The people cannot come up to mount Sinai; for thou didst charge us, saying: Set bounds about the mount, and sanctify it.’"
-          },
+          "en": "And Moses said unto the LORD: ‘The people cannot come up to mount Sinai; for thou didst charge us, saying: Set bounds about the mount, and sanctify it.’",
           "ref": "exodus 19:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto him: ‘Go, get thee down, and thou shalt come up, thou, and Aaron with thee; but let not the priests and the people break through to come up unto the LORD, lest He break forth upon them.’"
-          },
+          "en": "And the LORD said unto him: ‘Go, get thee down, and thou shalt come up, thou, and Aaron with thee; but let not the priests and the people break through to come up unto the LORD, lest He break forth upon them.’",
           "ref": "exodus 19:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "So Moses went down unto the people, and told them."
-          },
+          "en": "So Moses went down unto the people, and told them.",
           "ref": "exodus 19:25"
         }
       ]
@@ -4254,186 +2697,117 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And God spoke all these words, saying:"
-          },
+          "en": "And God spoke all these words, saying:",
           "ref": "exodus 20:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "I am the LORD thy God, who brought thee out of the land of Egypt, out of the house of bondage."
-          },
+          "en": "I am the LORD thy God, who brought thee out of the land of Egypt, out of the house of bondage.",
           "ref": "exodus 20:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt have no other gods before Me."
-          },
+          "en": "Thou shalt have no other gods before Me.",
           "ref": "exodus 20:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt not make unto thee a graven image, nor any manner of likeness, of any thing that is in heaven above, or that is in the earth beneath, or that is in the water under the earth;"
-          },
+          "en": "Thou shalt not make unto thee a graven image, nor any manner of likeness, of any thing that is in heaven above, or that is in the earth beneath, or that is in the water under the earth;",
           "ref": "exodus 20:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "thou shalt not bow down unto them, nor serve them; for I the LORD thy God am a jealous God, visiting the iniquity of the fathers upon the children unto the third and fourth generation of them that hate Me;"
-          },
+          "en": "thou shalt not bow down unto them, nor serve them; for I the LORD thy God am a jealous God, visiting the iniquity of the fathers upon the children unto the third and fourth generation of them that hate Me;",
           "ref": "exodus 20:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "and showing mercy unto the thousandth generation of them that love Me and keep My commandments."
-          },
+          "en": "and showing mercy unto the thousandth generation of them that love Me and keep My commandments.",
           "ref": "exodus 20:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt not take the name of the LORD thy God in vain; for the LORD will not hold him guiltless that taketh His name in vain."
-          },
+          "en": "Thou shalt not take the name of the LORD thy God in vain; for the LORD will not hold him guiltless that taketh His name in vain.",
           "ref": "exodus 20:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": "Sei eingedenk des Schabbat, um ihm zu heiligen.",
-            "jps1917": "Remember the sabbath day, to keep it holy."
-          },
+          "en": "Remember the sabbath day, to keep it holy.",
           "ref": "exodus 20:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "Six days shalt thou labour, and do all thy work;"
-          },
+          "en": "Six days shalt thou labour, and do all thy work;",
           "ref": "exodus 20:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "but the seventh day is a sabbath unto the LORD thy God, in it thou shalt not do any manner of work, thou, nor thy son, nor thy daughter, nor thy man-servant, nor thy maid-servant, nor thy cattle, nor thy stranger that is within thy gates;"
-          },
+          "en": "but the seventh day is a sabbath unto the LORD thy God, in it thou shalt not do any manner of work, thou, nor thy son, nor thy daughter, nor thy man-servant, nor thy maid-servant, nor thy cattle, nor thy stranger that is within thy gates;",
           "ref": "exodus 20:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "for in six days the LORD made heaven and earth, the sea, and all that in them is, and rested on the seventh day; wherefore the LORD blessed the sabbath day, and hallowed it."
-          },
+          "en": "for in six days the LORD made heaven and earth, the sea, and all that in them is, and rested on the seventh day; wherefore the LORD blessed the sabbath day, and hallowed it.",
           "ref": "exodus 20:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "Honour thy father and thy mother, that thy days may be long upon the land which the LORD thy God giveth thee."
-          },
+          "en": "Honour thy father and thy mother, that thy days may be long upon the land which the LORD thy God giveth thee.",
           "ref": "exodus 20:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt not murder. Thou shalt not commit adultery. Thou shalt not steal. Thou shalt not bear false witness against thy neighbour."
-          },
+          "en": "Thou shalt not murder. Thou shalt not commit adultery. Thou shalt not steal. Thou shalt not bear false witness against thy neighbour.",
           "ref": "exodus 20:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt not covet thy neighbour’s house; thou shalt not covet thy neighbour’s wife, nor his man-servant, nor his maid-servant, nor his ox, nor his ass, nor any thing that is thy neighbour’s."
-          },
+          "en": "Thou shalt not covet thy neighbour’s house; thou shalt not covet thy neighbour’s wife, nor his man-servant, nor his maid-servant, nor his ox, nor his ass, nor any thing that is thy neighbour’s.",
           "ref": "exodus 20:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And all the people perceived the thunderings, and the lightnings, and the voice of the horn, and the mountain smoking; and when the people saw it, they trembled, and stood afar off."
-          },
+          "en": "And all the people perceived the thunderings, and the lightnings, and the voice of the horn, and the mountain smoking; and when the people saw it, they trembled, and stood afar off.",
           "ref": "exodus 20:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said unto Moses: ‘Speak thou with us, and we will hear; but let not God speak with us, lest we die.’"
-          },
+          "en": "And they said unto Moses: ‘Speak thou with us, and we will hear; but let not God speak with us, lest we die.’",
           "ref": "exodus 20:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto the people: ‘Fear not; for God is come to prove you, and that His fear may be before you, that ye sin not.’"
-          },
+          "en": "And Moses said unto the people: ‘Fear not; for God is come to prove you, and that His fear may be before you, that ye sin not.’",
           "ref": "exodus 20:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And the people stood afar off; but Moses drew near unto the thick darkness where God was."
-          },
+          "en": "And the people stood afar off; but Moses drew near unto the thick darkness where God was.",
           "ref": "exodus 20:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: Thus thou shalt say unto the children of Israel: Ye yourselves have seen that I have talked with you from heaven."
-          },
+          "en": "And the LORD said unto Moses: Thus thou shalt say unto the children of Israel: Ye yourselves have seen that I have talked with you from heaven.",
           "ref": "exodus 20:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "Ye shall not make with Me—gods of silver, or gods of gold, ye shall not make unto you."
-          },
+          "en": "Ye shall not make with Me—gods of silver, or gods of gold, ye shall not make unto you.",
           "ref": "exodus 20:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "An altar of earth thou shalt make unto Me, and shalt sacrifice thereon thy burnt-offerings, and thy peace-offerings, thy sheep, and thine oxen; in every place where I cause My name to be mentioned I will come unto thee and bless thee."
-          },
+          "en": "An altar of earth thou shalt make unto Me, and shalt sacrifice thereon thy burnt-offerings, and thy peace-offerings, thy sheep, and thine oxen; in every place where I cause My name to be mentioned I will come unto thee and bless thee.",
           "ref": "exodus 20:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And if thou make Me an altar of stone, thou shalt not build it of hewn stones; for if thou lift up thy tool upon it, thou hast profaned it."
-          },
+          "en": "And if thou make Me an altar of stone, thou shalt not build it of hewn stones; for if thou lift up thy tool upon it, thou hast profaned it.",
           "ref": "exodus 20:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "Neither shalt thou go up by steps unto Mine altar, that thy nakedness be not uncovered thereon."
-          },
+          "en": "Neither shalt thou go up by steps unto Mine altar, that thy nakedness be not uncovered thereon.",
           "ref": "exodus 20:23"
         }
       ]
@@ -4443,298 +2817,187 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "Now these are the ordinances which thou shalt set before them."
-          },
+          "en": "Now these are the ordinances which thou shalt set before them.",
           "ref": "exodus 21:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "If thou buy a Hebrew servant, six years he shall serve; and in the seventh he shall go out free for nothing."
-          },
+          "en": "If thou buy a Hebrew servant, six years he shall serve; and in the seventh he shall go out free for nothing.",
           "ref": "exodus 21:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "If he come in by himself, he shall go out by himself; if he be married, then his wife shall go out with him."
-          },
+          "en": "If he come in by himself, he shall go out by himself; if he be married, then his wife shall go out with him.",
           "ref": "exodus 21:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "If his master give him a wife, and she bear him sons or daughters; the wife and her children shall be her master’s, and he shall go out by himself."
-          },
+          "en": "If his master give him a wife, and she bear him sons or daughters; the wife and her children shall be her master’s, and he shall go out by himself.",
           "ref": "exodus 21:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "But if the servant shall plainly say: I love my master, my wife, and my children; I will not go out free;"
-          },
+          "en": "But if the servant shall plainly say: I love my master, my wife, and my children; I will not go out free;",
           "ref": "exodus 21:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "then his master shall bring him unto God, and shall bring him to the door, or unto the door-post; and his master shall bore his ear through with an awl; and he shall serve him for ever."
-          },
+          "en": "then his master shall bring him unto God, and shall bring him to the door, or unto the door-post; and his master shall bore his ear through with an awl; and he shall serve him for ever.",
           "ref": "exodus 21:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And if a man sell his daughter to be a maid-servant, she shall not go out as the men-servants do."
-          },
+          "en": "And if a man sell his daughter to be a maid-servant, she shall not go out as the men-servants do.",
           "ref": "exodus 21:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "If she please not her master, who hath espoused her to himself, then shall he let her be redeemed; to sell her unto a foreign people he shall have no power, seeing he hath dealt deceitfully with her."
-          },
+          "en": "If she please not her master, who hath espoused her to himself, then shall he let her be redeemed; to sell her unto a foreign people he shall have no power, seeing he hath dealt deceitfully with her.",
           "ref": "exodus 21:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And if he espouse her unto his son, he shall deal with her after the manner of daughters."
-          },
+          "en": "And if he espouse her unto his son, he shall deal with her after the manner of daughters.",
           "ref": "exodus 21:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "If he take him another wife, her food, her raiment, and her conjugal rights, shall he not diminish."
-          },
+          "en": "If he take him another wife, her food, her raiment, and her conjugal rights, shall he not diminish.",
           "ref": "exodus 21:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And if he do not these three unto her, then shall she go out for nothing, without money."
-          },
+          "en": "And if he do not these three unto her, then shall she go out for nothing, without money.",
           "ref": "exodus 21:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "He that smiteth a man, so that he dieth, shall surely be put to death."
-          },
+          "en": "He that smiteth a man, so that he dieth, shall surely be put to death.",
           "ref": "exodus 21:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And if a man lie not in wait, but God cause it to come to hand; then I will appoint thee a place whither he may flee."
-          },
+          "en": "And if a man lie not in wait, but God cause it to come to hand; then I will appoint thee a place whither he may flee.",
           "ref": "exodus 21:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And if a man come presumptuously upon his neighbour, to slay him with guile; thou shalt take him from Mine altar, that he may die."
-          },
+          "en": "And if a man come presumptuously upon his neighbour, to slay him with guile; thou shalt take him from Mine altar, that he may die.",
           "ref": "exodus 21:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And he that smiteth his father, or his mother, shall be surely put to death. ."
-          },
+          "en": "And he that smiteth his father, or his mother, shall be surely put to death. .",
           "ref": "exodus 21:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And he that stealeth a man, and selleth him, or if he be found in his hand, he shall surely be put to death."
-          },
+          "en": "And he that stealeth a man, and selleth him, or if he be found in his hand, he shall surely be put to death.",
           "ref": "exodus 21:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And he that curseth his father or his mother, shall surely be put to death."
-          },
+          "en": "And he that curseth his father or his mother, shall surely be put to death.",
           "ref": "exodus 21:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And if men contend, and one smite the other with a stone, or with his fist, and he die not, but keep his bed;"
-          },
+          "en": "And if men contend, and one smite the other with a stone, or with his fist, and he die not, but keep his bed;",
           "ref": "exodus 21:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "if he rise again, and walk abroad upon his staff, then shall he that smote him be quit; only he shall pay for the loss of his time, and shall cause him to be thoroughly healed."
-          },
+          "en": "if he rise again, and walk abroad upon his staff, then shall he that smote him be quit; only he shall pay for the loss of his time, and shall cause him to be thoroughly healed.",
           "ref": "exodus 21:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And if a man smite his bondman, or his bondwoman, with a rod, and he die under his hand, he shall surely be punished."
-          },
+          "en": "And if a man smite his bondman, or his bondwoman, with a rod, and he die under his hand, he shall surely be punished.",
           "ref": "exodus 21:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "Notwithstanding if he continue a day or two, he shall not be punished; for he is his money."
-          },
+          "en": "Notwithstanding if he continue a day or two, he shall not be punished; for he is his money.",
           "ref": "exodus 21:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And if men strive together, and hurt a woman with child, so that her fruit depart, and yet no harm follow, he shall be surely fined, according as the woman’s husband shall lay upon him; and he shall pay as the judges determine."
-          },
+          "en": "And if men strive together, and hurt a woman with child, so that her fruit depart, and yet no harm follow, he shall be surely fined, according as the woman’s husband shall lay upon him; and he shall pay as the judges determine.",
           "ref": "exodus 21:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "But if any harm follow, then thou shalt give life for life,"
-          },
+          "en": "But if any harm follow, then thou shalt give life for life,",
           "ref": "exodus 21:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "eye for eye, tooth for tooth, hand for hand, foot for foot,"
-          },
+          "en": "eye for eye, tooth for tooth, hand for hand, foot for foot,",
           "ref": "exodus 21:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "burning for burning, wound for wound, stripe for stripe."
-          },
+          "en": "burning for burning, wound for wound, stripe for stripe.",
           "ref": "exodus 21:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And if a man smite the eye of his bondman, or the eye of his bondwoman, and destroy it, he shall let him go free for his eye’s sake."
-          },
+          "en": "And if a man smite the eye of his bondman, or the eye of his bondwoman, and destroy it, he shall let him go free for his eye’s sake.",
           "ref": "exodus 21:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And if he smite out his bondman’s tooth, or his bondwoman’s tooth, he shall let him go free for his tooth’s sake."
-          },
+          "en": "And if he smite out his bondman’s tooth, or his bondwoman’s tooth, he shall let him go free for his tooth’s sake.",
           "ref": "exodus 21:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And if an ox gore a man or a woman, that they die, the ox shall be surely stoned, and its flesh shall not be eaten; but the owner of the ox shall be quit."
-          },
+          "en": "And if an ox gore a man or a woman, that they die, the ox shall be surely stoned, and its flesh shall not be eaten; but the owner of the ox shall be quit.",
           "ref": "exodus 21:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "But if the ox was wont to gore in time past, and warning hath been given to its owner, and he hath not kept it in, but it hath killed a man or a woman; the ox shall be stoned, and its owner also shall be put to death."
-          },
+          "en": "But if the ox was wont to gore in time past, and warning hath been given to its owner, and he hath not kept it in, but it hath killed a man or a woman; the ox shall be stoned, and its owner also shall be put to death.",
           "ref": "exodus 21:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "If there be laid on him a ransom, then he shall give for the redemption of his life whatsoever is laid upon him."
-          },
+          "en": "If there be laid on him a ransom, then he shall give for the redemption of his life whatsoever is laid upon him.",
           "ref": "exodus 21:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "Whether it have gored a son, or have gored a daughter, according to this judgment shall it be done unto him."
-          },
+          "en": "Whether it have gored a son, or have gored a daughter, according to this judgment shall it be done unto him.",
           "ref": "exodus 21:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "If the ox gore a bondman or a bondwoman, he shall give unto their master thirty shekels of silver, and the ox shall be stoned."
-          },
+          "en": "If the ox gore a bondman or a bondwoman, he shall give unto their master thirty shekels of silver, and the ox shall be stoned.",
           "ref": "exodus 21:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And if a man shall open a pit, or if a man shall dig a pit and not cover it, and an ox or an ass fall therein,"
-          },
+          "en": "And if a man shall open a pit, or if a man shall dig a pit and not cover it, and an ox or an ass fall therein,",
           "ref": "exodus 21:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "the owner of the pit shall make it good; he shall give money unto the owner of them, and the dead beast shall be his."
-          },
+          "en": "the owner of the pit shall make it good; he shall give money unto the owner of them, and the dead beast shall be his.",
           "ref": "exodus 21:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And if one man’s ox hurt another’s, so that it dieth; then they shall sell the live ox, and divide the price of it; and the dead also they shall divide."
-          },
+          "en": "And if one man’s ox hurt another’s, so that it dieth; then they shall sell the live ox, and divide the price of it; and the dead also they shall divide.",
           "ref": "exodus 21:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "Or if it be known that the ox was wont to gore in time past, and its owner hath not kept it in; he shall surely pay ox for ox, and the dead beast shall be his own."
-          },
+          "en": "Or if it be known that the ox was wont to gore in time past, and its owner hath not kept it in; he shall surely pay ox for ox, and the dead beast shall be his own.",
           "ref": "exodus 21:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": null,
-            "jps1917": "If a man steal an ox, or a sheep, and kill it, or sell it, he shall pay five oxen for an ox, and four sheep for a sheep."
-          },
+          "en": "If a man steal an ox, or a sheep, and kill it, or sell it, he shall pay five oxen for an ox, and four sheep for a sheep.",
           "ref": "exodus 21:37"
         }
       ]
@@ -4744,242 +3007,152 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "If a thief be found breaking in, and be smitten so that he dieth, there shall be no bloodguiltiness for him."
-          },
+          "en": "If a thief be found breaking in, and be smitten so that he dieth, there shall be no bloodguiltiness for him.",
           "ref": "exodus 22:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "If the sun be risen upon him, there shall be bloodguiltiness for him—he shall make restitution; if he have nothing, then he shall be sold for his theft."
-          },
+          "en": "If the sun be risen upon him, there shall be bloodguiltiness for him—he shall make restitution; if he have nothing, then he shall be sold for his theft.",
           "ref": "exodus 22:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "If the theft be found in his hand alive, whether it be ox, or ass, or sheep, he shall pay double."
-          },
+          "en": "If the theft be found in his hand alive, whether it be ox, or ass, or sheep, he shall pay double.",
           "ref": "exodus 22:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "If a man cause a field or vineyard to be eaten, and shall let his beast loose, and it feed in another man’s field; of the best of his own field, and of the best of his own vineyard, shall he make restitution."
-          },
+          "en": "If a man cause a field or vineyard to be eaten, and shall let his beast loose, and it feed in another man’s field; of the best of his own field, and of the best of his own vineyard, shall he make restitution.",
           "ref": "exodus 22:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "If fire break out, and catch in thorns, so that the shocks of corn, or the standing corn, or the field are consumed; he that kindled the fire shall surely make restitution."
-          },
+          "en": "If fire break out, and catch in thorns, so that the shocks of corn, or the standing corn, or the field are consumed; he that kindled the fire shall surely make restitution.",
           "ref": "exodus 22:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "If a man deliver unto his neighbour money or stuff to keep, and it be stolen out of the man’s house; if the thief be found, he shall pay double."
-          },
+          "en": "If a man deliver unto his neighbour money or stuff to keep, and it be stolen out of the man’s house; if the thief be found, he shall pay double.",
           "ref": "exodus 22:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "If the thief be not found, then the master of the house shall come near unto God, to see whether he have not put his hand unto his neighbour’s goods."
-          },
+          "en": "If the thief be not found, then the master of the house shall come near unto God, to see whether he have not put his hand unto his neighbour’s goods.",
           "ref": "exodus 22:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "For every matter of trespass, whether it be for ox, for ass, for sheep, for raiment, or for any manner of lost thing, whereof one saith: 'This is it,' the cause of both parties shall come before God; he whom God shall condemn shall pay double unto his neighbour."
-          },
+          "en": "For every matter of trespass, whether it be for ox, for ass, for sheep, for raiment, or for any manner of lost thing, whereof one saith: 'This is it,' the cause of both parties shall come before God; he whom God shall condemn shall pay double unto his neighbour.",
           "ref": "exodus 22:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "If a man deliver unto his neighbour an ass, or an ox, or a sheep, or any beast, to keep, and it die, or be hurt, or driven away, no man seeing it;"
-          },
+          "en": "If a man deliver unto his neighbour an ass, or an ox, or a sheep, or any beast, to keep, and it die, or be hurt, or driven away, no man seeing it;",
           "ref": "exodus 22:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "the oath of the LORD shall be between them both, to see whether he have not put his hand unto his neighbour’s goods; and the owner thereof shall accept it, and he shall not make restitution."
-          },
+          "en": "the oath of the LORD shall be between them both, to see whether he have not put his hand unto his neighbour’s goods; and the owner thereof shall accept it, and he shall not make restitution.",
           "ref": "exodus 22:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "But if it be stolen from him, he shall make restitution unto the owner thereof."
-          },
+          "en": "But if it be stolen from him, he shall make restitution unto the owner thereof.",
           "ref": "exodus 22:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "If it be torn in pieces, let him bring it for witness; he shall not make good that which was torn."
-          },
+          "en": "If it be torn in pieces, let him bring it for witness; he shall not make good that which was torn.",
           "ref": "exodus 22:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And if a man borrow aught of his neighbour, and it be hurt, or die, the owner thereof not being with it, he shall surely make restitution."
-          },
+          "en": "And if a man borrow aught of his neighbour, and it be hurt, or die, the owner thereof not being with it, he shall surely make restitution.",
           "ref": "exodus 22:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "If the owner thereof be with it, he shall not make it good; if it be a hireling, he loseth his hire."
-          },
+          "en": "If the owner thereof be with it, he shall not make it good; if it be a hireling, he loseth his hire.",
           "ref": "exodus 22:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And if a man entice a virgin that is not betrothed, and lie with her, he shall surely pay a dowry for her to be his wife."
-          },
+          "en": "And if a man entice a virgin that is not betrothed, and lie with her, he shall surely pay a dowry for her to be his wife.",
           "ref": "exodus 22:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "If her father utterly refuse to give her unto him, he shall pay money according to the dowry of virgins."
-          },
+          "en": "If her father utterly refuse to give her unto him, he shall pay money according to the dowry of virgins.",
           "ref": "exodus 22:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt not suffer a sorceress to live."
-          },
+          "en": "Thou shalt not suffer a sorceress to live.",
           "ref": "exodus 22:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "Whosoever lieth with a beast shall surely be put to death."
-          },
+          "en": "Whosoever lieth with a beast shall surely be put to death.",
           "ref": "exodus 22:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "He that sacrificeth unto the gods, save unto the LORD only, shall be utterly destroyed."
-          },
+          "en": "He that sacrificeth unto the gods, save unto the LORD only, shall be utterly destroyed.",
           "ref": "exodus 22:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And a stranger shalt thou not wrong, neither shalt thou oppress him; for ye were strangers in the land of Egypt."
-          },
+          "en": "And a stranger shalt thou not wrong, neither shalt thou oppress him; for ye were strangers in the land of Egypt.",
           "ref": "exodus 22:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "Ye shall not afflict any widow, or fatherless child."
-          },
+          "en": "Ye shall not afflict any widow, or fatherless child.",
           "ref": "exodus 22:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "If thou afflict them in any wise—for if they cry at all unto Me, I will surely hear their cry—"
-          },
+          "en": "If thou afflict them in any wise—for if they cry at all unto Me, I will surely hear their cry—",
           "ref": "exodus 22:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "My wrath shall wax hot, and I will kill you with the sword; and your wives shall be widows, and your children fatherless."
-          },
+          "en": "My wrath shall wax hot, and I will kill you with the sword; and your wives shall be widows, and your children fatherless.",
           "ref": "exodus 22:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "If thou lend money to any of My people, even to the poor with thee, thou shalt not be to him as a creditor; neither shall ye lay upon him interest."
-          },
+          "en": "If thou lend money to any of My people, even to the poor with thee, thou shalt not be to him as a creditor; neither shall ye lay upon him interest.",
           "ref": "exodus 22:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "If thou at all take thy neighbour’s garment to pledge, thou shalt restore it unto him by that the sun goeth down;"
-          },
+          "en": "If thou at all take thy neighbour’s garment to pledge, thou shalt restore it unto him by that the sun goeth down;",
           "ref": "exodus 22:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "for that is his only covering, it is his garment for his skin; wherein shall he sleep? and it shall come to pass, when he crieth unto Me, that I will hear; for I am gracious."
-          },
+          "en": "for that is his only covering, it is his garment for his skin; wherein shall he sleep? and it shall come to pass, when he crieth unto Me, that I will hear; for I am gracious.",
           "ref": "exodus 22:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt not revile God, nor curse a ruler of thy people."
-          },
+          "en": "Thou shalt not revile God, nor curse a ruler of thy people.",
           "ref": "exodus 22:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt not delay to offer of the fulness of thy harvest, and of the outflow of thy presses. The first-born of thy sons shalt thou give unto Me."
-          },
+          "en": "Thou shalt not delay to offer of the fulness of thy harvest, and of the outflow of thy presses. The first-born of thy sons shalt thou give unto Me.",
           "ref": "exodus 22:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "Likewise shalt thou do with thine oxen, and with thy sheep; seven days it shall be with its dam; on the eighth day thou shalt give it Me."
-          },
+          "en": "Likewise shalt thou do with thine oxen, and with thy sheep; seven days it shall be with its dam; on the eighth day thou shalt give it Me.",
           "ref": "exodus 22:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And ye shall be holy men unto Me; therefore ye shall not eat any flesh that is torn of beasts in the field; ye shall cast it to the dogs."
-          },
+          "en": "And ye shall be holy men unto Me; therefore ye shall not eat any flesh that is torn of beasts in the field; ye shall cast it to the dogs.",
           "ref": "exodus 22:30"
         }
       ]
@@ -4989,266 +3162,167 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt not utter a false report; put not thy hand with the wicked to be an unrighteous witness."
-          },
+          "en": "Thou shalt not utter a false report; put not thy hand with the wicked to be an unrighteous witness.",
           "ref": "exodus 23:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt not follow a multitude to do evil; neither shalt thou bear witness in a cause to turn aside after a multitude to pervert justice;"
-          },
+          "en": "Thou shalt not follow a multitude to do evil; neither shalt thou bear witness in a cause to turn aside after a multitude to pervert justice;",
           "ref": "exodus 23:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "neither shalt thou favour a poor man in his cause."
-          },
+          "en": "neither shalt thou favour a poor man in his cause.",
           "ref": "exodus 23:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "If thou meet thine enemy’s ox or his ass going astray, thou shalt surely bring it back to him again."
-          },
+          "en": "If thou meet thine enemy’s ox or his ass going astray, thou shalt surely bring it back to him again.",
           "ref": "exodus 23:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "If thou see the ass of him that hateth thee lying under its burden, thou shalt forbear to pass by him; thou shalt surely release it with him."
-          },
+          "en": "If thou see the ass of him that hateth thee lying under its burden, thou shalt forbear to pass by him; thou shalt surely release it with him.",
           "ref": "exodus 23:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt not wrest the judgment of thy poor in his cause."
-          },
+          "en": "Thou shalt not wrest the judgment of thy poor in his cause.",
           "ref": "exodus 23:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "Keep thee far from a false matter; and the innocent and righteous slay thou not; for I will not justify the wicked."
-          },
+          "en": "Keep thee far from a false matter; and the innocent and righteous slay thou not; for I will not justify the wicked.",
           "ref": "exodus 23:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt take no gift; for a gift blindeth them that have sight, and perverteth the words of the righteous."
-          },
+          "en": "And thou shalt take no gift; for a gift blindeth them that have sight, and perverteth the words of the righteous.",
           "ref": "exodus 23:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And a stranger shalt thou not oppress; for ye know the heart of a stranger, seeing ye were strangers in the land of Egypt."
-          },
+          "en": "And a stranger shalt thou not oppress; for ye know the heart of a stranger, seeing ye were strangers in the land of Egypt.",
           "ref": "exodus 23:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And six years thou shalt sow thy land, and gather in the increase thereof;"
-          },
+          "en": "And six years thou shalt sow thy land, and gather in the increase thereof;",
           "ref": "exodus 23:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "but the seventh year thou shalt let it rest and lie fallow, that the poor of thy people may eat; and what they leave the beast of the field shall eat. In like manner thou shalt deal with thy vineyard, and with thy oliveyard."
-          },
+          "en": "but the seventh year thou shalt let it rest and lie fallow, that the poor of thy people may eat; and what they leave the beast of the field shall eat. In like manner thou shalt deal with thy vineyard, and with thy oliveyard.",
           "ref": "exodus 23:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "Six days thou shalt do thy work, but on the seventh day thou shalt rest; that thine ox and thine ass may have rest, and the son of thy handmaid, and the stranger, may be refreshed."
-          },
+          "en": "Six days thou shalt do thy work, but on the seventh day thou shalt rest; that thine ox and thine ass may have rest, and the son of thy handmaid, and the stranger, may be refreshed.",
           "ref": "exodus 23:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And in all things that I have said unto you take ye heed; and make no mention of the name of other gods, neither let it be heard out of thy mouth. ."
-          },
+          "en": "And in all things that I have said unto you take ye heed; and make no mention of the name of other gods, neither let it be heard out of thy mouth. .",
           "ref": "exodus 23:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "Three times thou shalt keep a feast unto Me in the year."
-          },
+          "en": "Three times thou shalt keep a feast unto Me in the year.",
           "ref": "exodus 23:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "The feast of unleavened bread shalt thou keep; seven days thou shalt eat unleavened bread, as I commanded thee, at the time appointed in the month Abib—for in it thou camest out from Egypt; and none shall appear before Me empty;"
-          },
+          "en": "The feast of unleavened bread shalt thou keep; seven days thou shalt eat unleavened bread, as I commanded thee, at the time appointed in the month Abib—for in it thou camest out from Egypt; and none shall appear before Me empty;",
           "ref": "exodus 23:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "and the feast of harvest, the first-fruits of thy labours, which thou sowest in the field; and the feast of ingathering, at the end of the year, when thou gatherest in thy labours out of the field."
-          },
+          "en": "and the feast of harvest, the first-fruits of thy labours, which thou sowest in the field; and the feast of ingathering, at the end of the year, when thou gatherest in thy labours out of the field.",
           "ref": "exodus 23:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "Three times in the year all thy males shall appear before the Lord GOD."
-          },
+          "en": "Three times in the year all thy males shall appear before the Lord GOD.",
           "ref": "exodus 23:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt not offer the blood of My sacrifice with leavened bread; neither shall the fat of My feast remain all night until the morning."
-          },
+          "en": "Thou shalt not offer the blood of My sacrifice with leavened bread; neither shall the fat of My feast remain all night until the morning.",
           "ref": "exodus 23:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "The choicest first-fruits of thy land thou shalt bring into the house of the LORD thy God. Thou shalt not seethe a kid in its mother’s milk."
-          },
+          "en": "The choicest first-fruits of thy land thou shalt bring into the house of the LORD thy God. Thou shalt not seethe a kid in its mother’s milk.",
           "ref": "exodus 23:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "Behold, I send an angel before thee, to keep thee by the way, and to bring thee into the place which I have prepared."
-          },
+          "en": "Behold, I send an angel before thee, to keep thee by the way, and to bring thee into the place which I have prepared.",
           "ref": "exodus 23:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "Take heed of him, and hearken unto his voice; be not rebellious against him; for he will not pardon your transgression; for My name is in him."
-          },
+          "en": "Take heed of him, and hearken unto his voice; be not rebellious against him; for he will not pardon your transgression; for My name is in him.",
           "ref": "exodus 23:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "But if thou shalt indeed hearken unto his voice, and do all that I speak; then I will be an enemy unto thine enemies, and an adversary unto thine adversaries."
-          },
+          "en": "But if thou shalt indeed hearken unto his voice, and do all that I speak; then I will be an enemy unto thine enemies, and an adversary unto thine adversaries.",
           "ref": "exodus 23:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "For Mine angel shall go before thee, and bring thee in unto the Amorite, and the Hittite, and the Perizzite, and the Canaanite, the Hivite, and the Jebusite; and I will cut them off."
-          },
+          "en": "For Mine angel shall go before thee, and bring thee in unto the Amorite, and the Hittite, and the Perizzite, and the Canaanite, the Hivite, and the Jebusite; and I will cut them off.",
           "ref": "exodus 23:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt not bow down to their gods, nor serve them, nor do after their doings; but thou shalt utterly overthrow them, and break in pieces their pillars."
-          },
+          "en": "Thou shalt not bow down to their gods, nor serve them, nor do after their doings; but thou shalt utterly overthrow them, and break in pieces their pillars.",
           "ref": "exodus 23:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And ye shall serve the LORD your God, and He will bless thy bread, and thy water; and I will take sickness away from the midst of thee."
-          },
+          "en": "And ye shall serve the LORD your God, and He will bless thy bread, and thy water; and I will take sickness away from the midst of thee.",
           "ref": "exodus 23:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "None shall miscarry, nor be barren, in thy land; the number of thy days I will fulfil."
-          },
+          "en": "None shall miscarry, nor be barren, in thy land; the number of thy days I will fulfil.",
           "ref": "exodus 23:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "I will send My terror before thee, and will discomfit all the people to whom thou shalt come, and I will make all thine enemies turn their backs unto thee."
-          },
+          "en": "I will send My terror before thee, and will discomfit all the people to whom thou shalt come, and I will make all thine enemies turn their backs unto thee.",
           "ref": "exodus 23:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will send the hornet before thee, which shall drive out the Hivite, the Canaanite, and the Hittite, from before thee."
-          },
+          "en": "And I will send the hornet before thee, which shall drive out the Hivite, the Canaanite, and the Hittite, from before thee.",
           "ref": "exodus 23:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "I will not drive them out from before thee in one year, lest the land become desolate, and the beasts of the field multiply against thee."
-          },
+          "en": "I will not drive them out from before thee in one year, lest the land become desolate, and the beasts of the field multiply against thee.",
           "ref": "exodus 23:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "By little and little I will drive them out from before thee, until thou be increased, and inherit the land."
-          },
+          "en": "By little and little I will drive them out from before thee, until thou be increased, and inherit the land.",
           "ref": "exodus 23:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will set thy border from the Red Sea even unto the sea of the Philistines, and from the wilderness unto athe River; for I will deliver the inhabitants of the land into your hand; and thou shalt drive them out before thee."
-          },
+          "en": "And I will set thy border from the Red Sea even unto the sea of the Philistines, and from the wilderness unto athe River; for I will deliver the inhabitants of the land into your hand; and thou shalt drive them out before thee.",
           "ref": "exodus 23:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt make no covenant with them, nor with their gods."
-          },
+          "en": "Thou shalt make no covenant with them, nor with their gods.",
           "ref": "exodus 23:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "They shall not dwell in thy land—lest they make thee sin against Me, for thou wilt serve their gods—for they will be a snare unto thee."
-          },
+          "en": "They shall not dwell in thy land—lest they make thee sin against Me, for thou wilt serve their gods—for they will be a snare unto thee.",
           "ref": "exodus 23:33"
         }
       ]
@@ -5258,146 +3332,92 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And unto Moses He said: ‘Come up unto the LORD, thou, and Aaron, Nadab, and Abihu, and seventy of the elders of Israel; and worship ye afar off;"
-          },
+          "en": "And unto Moses He said: ‘Come up unto the LORD, thou, and Aaron, Nadab, and Abihu, and seventy of the elders of Israel; and worship ye afar off;",
           "ref": "exodus 24:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "and Moses alone shall come near unto the LORD; but they shall not come near; neither shall the people go up with him.’"
-          },
+          "en": "and Moses alone shall come near unto the LORD; but they shall not come near; neither shall the people go up with him.’",
           "ref": "exodus 24:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses came and told the people all the words of the LORD, and all the ordinances; and all the people answered with one voice, and said: ‘All the words which the Lord hath spoken will we do.’"
-          },
+          "en": "And Moses came and told the people all the words of the LORD, and all the ordinances; and all the people answered with one voice, and said: ‘All the words which the Lord hath spoken will we do.’",
           "ref": "exodus 24:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses wrote all the words of the LORD, and rose up early in the morning, and builded an altar under the mount, and twelve pillars, according to the twelve tribes of Israel."
-          },
+          "en": "And Moses wrote all the words of the LORD, and rose up early in the morning, and builded an altar under the mount, and twelve pillars, according to the twelve tribes of Israel.",
           "ref": "exodus 24:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And he sent the young men of the children of Israel, who offered burnt-offerings, and sacrificed peace-offerings of oxen unto the LORD."
-          },
+          "en": "And he sent the young men of the children of Israel, who offered burnt-offerings, and sacrificed peace-offerings of oxen unto the LORD.",
           "ref": "exodus 24:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses took half of the blood, and put it in basins; and half of the blood he dashed against the altar."
-          },
+          "en": "And Moses took half of the blood, and put it in basins; and half of the blood he dashed against the altar.",
           "ref": "exodus 24:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And he took the book of the covenant, and read in the hearing of the people; and they said: ‘All that the LORD hath spoken will we do, and obey.’"
-          },
+          "en": "And he took the book of the covenant, and read in the hearing of the people; and they said: ‘All that the LORD hath spoken will we do, and obey.’",
           "ref": "exodus 24:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses took the blood, and sprinkled it on the people, and said: ‘Behold the blood of the covenant, which the LORD hath made with you in agreement with all these words.’"
-          },
+          "en": "And Moses took the blood, and sprinkled it on the people, and said: ‘Behold the blood of the covenant, which the LORD hath made with you in agreement with all these words.’",
           "ref": "exodus 24:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "Then went up Moses, and Aaron, Nadab, and Abihu, and seventy of the elders of Israel;"
-          },
+          "en": "Then went up Moses, and Aaron, Nadab, and Abihu, and seventy of the elders of Israel;",
           "ref": "exodus 24:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "and they saw the God of Israel; and there was under His feet the like of a paved work of sapphire stone, and the like of the very heaven for clearness."
-          },
+          "en": "and they saw the God of Israel; and there was under His feet the like of a paved work of sapphire stone, and the like of the very heaven for clearness.",
           "ref": "exodus 24:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And upon the nobles of the children of Israel He laid not His hand; and they beheld God, and did eat and drink."
-          },
+          "en": "And upon the nobles of the children of Israel He laid not His hand; and they beheld God, and did eat and drink.",
           "ref": "exodus 24:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Come up to Me into the mount and be there; and I will give thee the tables of stone, and the law and the commandment, which I have written, that thou mayest teach them.’"
-          },
+          "en": "And the LORD said unto Moses: ‘Come up to Me into the mount and be there; and I will give thee the tables of stone, and the law and the commandment, which I have written, that thou mayest teach them.’",
           "ref": "exodus 24:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses rose up, and Joshua his minister; and Moses went up into the mount of God."
-          },
+          "en": "And Moses rose up, and Joshua his minister; and Moses went up into the mount of God.",
           "ref": "exodus 24:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And unto the elders he said: ‘Tarry ye here for us, until we come back unto you; and, behold, Aaron and Hur are with you; whosoever hath a cause, let him come near unto them.’"
-          },
+          "en": "And unto the elders he said: ‘Tarry ye here for us, until we come back unto you; and, behold, Aaron and Hur are with you; whosoever hath a cause, let him come near unto them.’",
           "ref": "exodus 24:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses went up into the mount, and the cloud covered the mount."
-          },
+          "en": "And Moses went up into the mount, and the cloud covered the mount.",
           "ref": "exodus 24:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And the glory of the LORD abode upon mount Sinai, and the cloud covered it six days; and the seventh day He called unto Moses out of the midst of the cloud."
-          },
+          "en": "And the glory of the LORD abode upon mount Sinai, and the cloud covered it six days; and the seventh day He called unto Moses out of the midst of the cloud.",
           "ref": "exodus 24:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And the appearance of the glory of the LORD was like devouring fire on the top of the mount in the eyes of the children of Israel."
-          },
+          "en": "And the appearance of the glory of the LORD was like devouring fire on the top of the mount in the eyes of the children of Israel.",
           "ref": "exodus 24:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses entered into the midst of the cloud, and went up into the mount; and Moses was in the mount forty days and forty nights."
-          },
+          "en": "And Moses entered into the midst of the cloud, and went up into the mount; and Moses was in the mount forty days and forty nights.",
           "ref": "exodus 24:18"
         }
       ]
@@ -5407,322 +3427,202 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses, saying:"
-          },
+          "en": "And the LORD spoke unto Moses, saying:",
           "ref": "exodus 25:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "’Speak unto the children of Israel, that they take for Me an offering; of every man whose heart maketh him willing ye shall take My offering."
-          },
+          "en": "’Speak unto the children of Israel, that they take for Me an offering; of every man whose heart maketh him willing ye shall take My offering.",
           "ref": "exodus 25:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And this is the offering which ye shall take of them: gold, and silver, and brass;"
-          },
+          "en": "And this is the offering which ye shall take of them: gold, and silver, and brass;",
           "ref": "exodus 25:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "and blue, and purple, and scarlet, and fine linen, and goats’hair;"
-          },
+          "en": "and blue, and purple, and scarlet, and fine linen, and goats’hair;",
           "ref": "exodus 25:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "and rams’skins dyed red, and sealskins, and acacia-wood;"
-          },
+          "en": "and rams’skins dyed red, and sealskins, and acacia-wood;",
           "ref": "exodus 25:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "oil for the light, spices for the anointing oil, and for the sweet incense;"
-          },
+          "en": "oil for the light, spices for the anointing oil, and for the sweet incense;",
           "ref": "exodus 25:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "onyx stones, and stones to be set, for the ephod, and for the breastplate."
-          },
+          "en": "onyx stones, and stones to be set, for the ephod, and for the breastplate.",
           "ref": "exodus 25:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And let them make Me a sanctuary, that I may dwell among them."
-          },
+          "en": "And let them make Me a sanctuary, that I may dwell among them.",
           "ref": "exodus 25:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "According to all that I show thee, the pattern of the tabernacle, and the pattern of all the furniture thereof, even so shall ye make it."
-          },
+          "en": "According to all that I show thee, the pattern of the tabernacle, and the pattern of all the furniture thereof, even so shall ye make it.",
           "ref": "exodus 25:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And they shall make an ark of acacia-wood: two cubits and a half shall be the length thereof, and a cubit and a half the breadth thereof, and a cubit and a half the height thereof."
-          },
+          "en": "And they shall make an ark of acacia-wood: two cubits and a half shall be the length thereof, and a cubit and a half the breadth thereof, and a cubit and a half the height thereof.",
           "ref": "exodus 25:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt overlay it with pure gold, within and without shalt thou overlay it, and shalt make upon it a crown of gold round about."
-          },
+          "en": "And thou shalt overlay it with pure gold, within and without shalt thou overlay it, and shalt make upon it a crown of gold round about.",
           "ref": "exodus 25:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt cast four rings of gold for it, and put them in the four feet thereof; and two rings shall be on the one side of it, and two rings on the other side of it."
-          },
+          "en": "And thou shalt cast four rings of gold for it, and put them in the four feet thereof; and two rings shall be on the one side of it, and two rings on the other side of it.",
           "ref": "exodus 25:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make staves of acacia-wood, and overlay them with gold."
-          },
+          "en": "And thou shalt make staves of acacia-wood, and overlay them with gold.",
           "ref": "exodus 25:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt put the staves into the rings on the sides of the ark, wherewith to bear the ark."
-          },
+          "en": "And thou shalt put the staves into the rings on the sides of the ark, wherewith to bear the ark.",
           "ref": "exodus 25:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "The staves shall be in the rings of the ark; they shall not be taken from it."
-          },
+          "en": "The staves shall be in the rings of the ark; they shall not be taken from it.",
           "ref": "exodus 25:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt put into the ark the testimony which I shall give thee."
-          },
+          "en": "And thou shalt put into the ark the testimony which I shall give thee.",
           "ref": "exodus 25:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make an ark-cover of pure gold: two cubits and a half shall be the length thereof, and a cubit and a half the breadth thereof."
-          },
+          "en": "And thou shalt make an ark-cover of pure gold: two cubits and a half shall be the length thereof, and a cubit and a half the breadth thereof.",
           "ref": "exodus 25:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make two cherubim of gold; of beaten work shalt thou make them, at the two ends of the ark-cover."
-          },
+          "en": "And thou shalt make two cherubim of gold; of beaten work shalt thou make them, at the two ends of the ark-cover.",
           "ref": "exodus 25:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And make one cherub at the one end, and one cherub at the other end; of one piece with the ark-cover shall ye make the cherubim of the two ends thereof."
-          },
+          "en": "And make one cherub at the one end, and one cherub at the other end; of one piece with the ark-cover shall ye make the cherubim of the two ends thereof.",
           "ref": "exodus 25:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And the cherubim shall spread out their wings on high, screening the ark-cover with their wings, with their faces one to another; toward the ark-cover shall the faces of the cherubim be."
-          },
+          "en": "And the cherubim shall spread out their wings on high, screening the ark-cover with their wings, with their faces one to another; toward the ark-cover shall the faces of the cherubim be.",
           "ref": "exodus 25:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt put the ark-cover above upon the ark; and in the ark thou shalt put the testimony that I shall give thee."
-          },
+          "en": "And thou shalt put the ark-cover above upon the ark; and in the ark thou shalt put the testimony that I shall give thee.",
           "ref": "exodus 25:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And there I will meet with thee, and I will speak with thee from above the ark-cover, from between the two cherubim which are upon the ark of the testimony, of all things which I will give thee in commandment unto the children of Israel."
-          },
+          "en": "And there I will meet with thee, and I will speak with thee from above the ark-cover, from between the two cherubim which are upon the ark of the testimony, of all things which I will give thee in commandment unto the children of Israel.",
           "ref": "exodus 25:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make a table of acacia-wood: two cubits shall be the length thereof, and a cubit the breadth thereof, and a cubit and a half the height thereof."
-          },
+          "en": "And thou shalt make a table of acacia-wood: two cubits shall be the length thereof, and a cubit the breadth thereof, and a cubit and a half the height thereof.",
           "ref": "exodus 25:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt overlay it with pure gold, and make thereto a crown of gold round about."
-          },
+          "en": "And thou shalt overlay it with pure gold, and make thereto a crown of gold round about.",
           "ref": "exodus 25:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make unto it a border of a handbreadth round about, and thou shalt make a golden crown to the border thereof round about."
-          },
+          "en": "And thou shalt make unto it a border of a handbreadth round about, and thou shalt make a golden crown to the border thereof round about.",
           "ref": "exodus 25:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make for it four rings of gold, and put the rings in the four corners that are on the four feet thereof."
-          },
+          "en": "And thou shalt make for it four rings of gold, and put the rings in the four corners that are on the four feet thereof.",
           "ref": "exodus 25:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "Close by the border shall the rings be, for places for the staves to bear the table."
-          },
+          "en": "Close by the border shall the rings be, for places for the staves to bear the table.",
           "ref": "exodus 25:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make the staves of acacia-wood, and overlay them with gold, that the table may be borne with them."
-          },
+          "en": "And thou shalt make the staves of acacia-wood, and overlay them with gold, that the table may be borne with them.",
           "ref": "exodus 25:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make the dishes thereof, and the pans thereof, and the jars thereof, and the bowls thereof, wherewith to pour out; of pure gold shalt thou make them."
-          },
+          "en": "And thou shalt make the dishes thereof, and the pans thereof, and the jars thereof, and the bowls thereof, wherewith to pour out; of pure gold shalt thou make them.",
           "ref": "exodus 25:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt set upon the table showbread before Me always."
-          },
+          "en": "And thou shalt set upon the table showbread before Me always.",
           "ref": "exodus 25:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make a candlestick of pure gold: of beaten work shall the candlestick be made, even its base, and its shaft; its cups, its knops, and its flowers, shall be of one piece with it."
-          },
+          "en": "And thou shalt make a candlestick of pure gold: of beaten work shall the candlestick be made, even its base, and its shaft; its cups, its knops, and its flowers, shall be of one piece with it.",
           "ref": "exodus 25:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And there shall be six branches going out of the sides thereof: three branches of the candlestick out of the one side thereof, and three branches of the candle-stick out of the other side thereof;"
-          },
+          "en": "And there shall be six branches going out of the sides thereof: three branches of the candlestick out of the one side thereof, and three branches of the candle-stick out of the other side thereof;",
           "ref": "exodus 25:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "three cups made like almond-blossoms in one branch, a knop and a flower; and three cups made like almond-blossoms in the other branch, a knop and a flower; so for the six branches going out of the candlestick."
-          },
+          "en": "three cups made like almond-blossoms in one branch, a knop and a flower; and three cups made like almond-blossoms in the other branch, a knop and a flower; so for the six branches going out of the candlestick.",
           "ref": "exodus 25:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And in the candlestick four cups made like almond-blossoms, the knops thereof, and the flowers thereof."
-          },
+          "en": "And in the candlestick four cups made like almond-blossoms, the knops thereof, and the flowers thereof.",
           "ref": "exodus 25:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And a knop under two branches of one piece with it, and a knop under two branches of one piece with it, and a knop under two branches of one piece with it, for the six branches going out of the candlestick."
-          },
+          "en": "And a knop under two branches of one piece with it, and a knop under two branches of one piece with it, and a knop under two branches of one piece with it, for the six branches going out of the candlestick.",
           "ref": "exodus 25:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "Their knops and their branches shall be of one piece with it; the whole of it one beaten work of pure gold."
-          },
+          "en": "Their knops and their branches shall be of one piece with it; the whole of it one beaten work of pure gold.",
           "ref": "exodus 25:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make the lamps thereof, seven; and they shall light the lamps thereof, to give light over against it."
-          },
+          "en": "And thou shalt make the lamps thereof, seven; and they shall light the lamps thereof, to give light over against it.",
           "ref": "exodus 25:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": null,
-            "jps1917": "And the tongs thereof, and the snuffdishes thereof, shall be of pure gold."
-          },
+          "en": "And the tongs thereof, and the snuffdishes thereof, shall be of pure gold.",
           "ref": "exodus 25:38"
         },
         {
           "n": 39,
-          "en": {
-            "sct": null,
-            "jps1917": "Of a talent of pure gold shall it be made, with all these vessels."
-          },
+          "en": "Of a talent of pure gold shall it be made, with all these vessels.",
           "ref": "exodus 25:39"
         },
         {
           "n": 40,
-          "en": {
-            "sct": null,
-            "jps1917": "And see that thou make them after their pattern, which is being shown thee in the mount."
-          },
+          "en": "And see that thou make them after their pattern, which is being shown thee in the mount.",
           "ref": "exodus 25:40"
         }
       ]
@@ -5732,298 +3632,187 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": "And the tabernacle (the mishkan) shall you make with ten curtains [to serve it as a roof and as partitions outside the boards, the curtains being hung behind them to cover them]: twisted linen (shesh) and blue (wool) and purple and scarlet, [four varieties in each thread, one of linen and three of wool and each thread twisted six (shesh) times, giving a twenty-four-fold thread], cherubs of artistic work [(figures interwoven on both sides)] shall you make them.",
-            "jps1917": "Moreover thou shalt make the tabernacle with ten curtains: of fine twined linen, and blue, and purple, and scarlet, with cherubim the work of the skilful workman shalt thou make them."
-          },
+          "en": "Moreover thou shalt make the tabernacle with ten curtains: of fine twined linen, and blue, and purple, and scarlet, with cherubim the work of the skilful workman shalt thou make them.",
           "ref": "exodus 26:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": "The length of one curtain, twenty-eight cubits; and the width, four cubits for one curtain — one measure for all the curtains.",
-            "jps1917": "The length of each curtain shall be eight and twenty cubits, and the breadth of each curtain four cubits; all the curtains shall have one measure."
-          },
+          "en": "The length of each curtain shall be eight and twenty cubits, and the breadth of each curtain four cubits; all the curtains shall have one measure.",
           "ref": "exodus 26:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": "Five curtains shall be attached [by sewing] one to the other, and five curtains, one to the other.",
-            "jps1917": "Five curtains shall be coupled together one to another; and the other five curtains shall be coupled one to another."
-          },
+          "en": "Five curtains shall be coupled together one to another; and the other five curtains shall be coupled one to another.",
           "ref": "exodus 26:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": "And you shall make loops of purple wool at the edge of the end curtain of one (five-curtain) joining, and, likewise, at the edge of the end curtain of the other joining.",
-            "jps1917": "And thou shalt make loops of blue upon the edge of the one curtain that is outmost in the first set; and likewise shalt thou make in the edge of the curtain that is outmost in the second set."
-          },
+          "en": "And thou shalt make loops of blue upon the edge of the one curtain that is outmost in the first set; and likewise shalt thou make in the edge of the curtain that is outmost in the second set.",
           "ref": "exodus 26:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": "Fifty loops shall you make in the one (end) curtain, and fifty loops shall you make at the edge of the (end) curtain in the second joining, the loops [on the respective joinings] directly aligned one with the other.",
-            "jps1917": "Fifty loops shalt thou make in the one curtain, and fifty loops shalt thou make in the edge of the curtain that is in the second set; the loops shall be opposite one to another."
-          },
+          "en": "Fifty loops shalt thou make in the one curtain, and fifty loops shalt thou make in the edge of the curtain that is in the second set; the loops shall be opposite one to another.",
           "ref": "exodus 26:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": "And you shall make fifty golden hooks, and you shall join the curtains one to the other by the hooks, [inserting one end of the hook into one loop, and the other end, into its corresponding loop], and the tabernacle shall be one.",
-            "jps1917": "And thou shalt make fifty clasps of gold, and couple the curtains one to another with the clasps, that the tabernacle may be one whole."
-          },
+          "en": "And thou shalt make fifty clasps of gold, and couple the curtains one to another with the clasps, that the tabernacle may be one whole.",
           "ref": "exodus 26:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": "And you shall make curtains of goats' hair to tent over the [lower curtains of the] tabernacle; eleven curtains shall you make them.",
-            "jps1917": "And thou shalt make curtains of goats’hair for a tent over the tabernacle; eleven curtains shalt thou make them."
-          },
+          "en": "And thou shalt make curtains of goats’hair for a tent over the tabernacle; eleven curtains shalt thou make them.",
           "ref": "exodus 26:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": "The length of one curtain, thirty cubits; and the width, four cubits for one curtain — one measure for the eleven curtains.",
-            "jps1917": "The length of each curtain shall be thirty cubits, and the breadth of each curtain four cubits; the eleven curtains shall have one measure."
-          },
+          "en": "The length of each curtain shall be thirty cubits, and the breadth of each curtain four cubits; the eleven curtains shall have one measure.",
           "ref": "exodus 26:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": "And you shall join five curtains separately and six curtains separately, and you shall double [two cubits of] the sixth curtain [the \"surplus\" vis-à-vis the lower curtains] over the face of the tent [the screen on the east (as a bride's face is veiled in modesty)].",
-            "jps1917": "And thou shalt couple five curtains by themselves, and six curtains by themselves, and shalt double over the sixth curtain in the forefront of the tent."
-          },
+          "en": "And thou shalt couple five curtains by themselves, and six curtains by themselves, and shalt double over the sixth curtain in the forefront of the tent.",
           "ref": "exodus 26:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": "And you shall make fifty loops at the edge of the end curtain in (one) joining, and fifty loops at the edge of the curtain in the second joining.",
-            "jps1917": "And thou shalt make fifty loops on the edge of the one curtain that is outmost in the first set, and fifty loops upon the edge of the curtain which is outmost in the second set."
-          },
+          "en": "And thou shalt make fifty loops on the edge of the one curtain that is outmost in the first set, and fifty loops upon the edge of the curtain which is outmost in the second set.",
           "ref": "exodus 26:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": "And you shall make fifty copper hooks, and you shall insert the hooks into the loops, and you shall join the tent [the goats' hair covering], and it shall be one.",
-            "jps1917": "And thou shalt make fifty clasps of brass, and put the clasps into the loops, and couple the tent together, that it may be one."
-          },
+          "en": "And thou shalt make fifty clasps of brass, and put the clasps into the loops, and couple the tent together, that it may be one.",
           "ref": "exodus 26:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": "And the additional draping in the curtains of the tent, half of the additional curtain [i.e., two cubits], you shall hang over the back [the west] of the tabernacle [to cover the two cubits of exposed beams.]",
-            "jps1917": "And as for the overhanging part that remaineth of the curtains of the tent, the half curtain that remaineth over shall hang over the back of the tabernacle."
-          },
+          "en": "And as for the overhanging part that remaineth of the curtains of the tent, the half curtain that remaineth over shall hang over the back of the tabernacle.",
           "ref": "exodus 26:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": "And the cubit on one side and the cubit on the other side in excess [of the length of the lower curtains] in the length of the curtains of the tent, shall be spread over both sides [north and south] of the tabernacle [curtains] to cover it [(for purposes of adornment)].",
-            "jps1917": "And the cubit on the one side, and the cubit on the other side, of that which remaineth over in the length of the curtains of the tent, shall hang over the sides of the tabernacle on this side and on that side, to cover it."
-          },
+          "en": "And the cubit on the one side, and the cubit on the other side, of that which remaineth over in the length of the curtains of the tent, shall hang over the sides of the tabernacle on this side and on that side, to cover it.",
           "ref": "exodus 26:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": "And you shall make a cover for the tent [(the goats' hair roof)] of rams' skins dyed red, and a cover of tachash skins above.",
-            "jps1917": "And thou shalt make a covering for the tent of rams’skins dyed red and a covering of sealskins above."
-          },
+          "en": "And thou shalt make a covering for the tent of rams’skins dyed red and a covering of sealskins above.",
           "ref": "exodus 26:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": "And you shall make the beams of the tabernacle [those that have been designated for the purpose (Jacob, prophetically, having planted acacia trees to this end)] of standing acacia wood. [The beams of the tabernacle walls are to be stood up vertically, and not placed horizontally one atop the other.]",
-            "jps1917": "And thou shalt make the boards for the tabernacle of acacia-wood, standing up."
-          },
+          "en": "And thou shalt make the boards for the tabernacle of acacia-wood, standing up.",
           "ref": "exodus 26:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": "Ten cubits the length of the beam [(so that the height of the tabernacle was ten cubits)], and a cubit and a half the breadth of each beam [(so that the length of the tabernacle was thirty cubits)].",
-            "jps1917": "Ten cubits shall be the length of a board, and a cubit and a half the breadth of each board."
-          },
+          "en": "Ten cubits shall be the length of a board, and a cubit and a half the breadth of each board.",
           "ref": "exodus 26:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": "Two prongs (wooden projections) for each beam [(the beam being hollowed out at the bottom to form these prongs)], rung-like, one near the other [like the rungs of a ladder]. So shall you do for all the beams of the tabernacle.",
-            "jps1917": "Two tenons shall there be in each board, joined one to another; thus shalt thou make for all the boards of the tabernacle."
-          },
+          "en": "Two tenons shall there be in each board, joined one to another; thus shalt thou make for all the boards of the tabernacle.",
           "ref": "exodus 26:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": "And you shall make the beams for the tabernacle, twenty beams for the southern side.",
-            "jps1917": "And thou shalt make the boards for the tabernacle, twenty boards for the south side southward:"
-          },
+          "en": "And thou shalt make the boards for the tabernacle, twenty boards for the south side southward:",
           "ref": "exodus 26:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": "And forty silver sockets shall you make under the twenty beams; two sockets under one beam for its two prongs, and two sockets under the next beam for its two prongs.",
-            "jps1917": "And thou shalt make forty sockets of silver under the twenty boards: two sockets under one board for its two tenons, and two sockets under another board for its two tenons;"
-          },
+          "en": "And thou shalt make forty sockets of silver under the twenty boards: two sockets under one board for its two tenons, and two sockets under another board for its two tenons;",
           "ref": "exodus 26:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": "And for the second side of the tabernacle, the northern side, twenty beams.",
-            "jps1917": "and for the second side of the tabernacle, on the north side, twenty boards."
-          },
+          "en": "and for the second side of the tabernacle, on the north side, twenty boards.",
           "ref": "exodus 26:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": "And their forty silver sockets, two sockets under one beam and two sockets under the next beam.",
-            "jps1917": "And their forty sockets of silver: two sockets under one board, and two sockets under another board."
-          },
+          "en": "And their forty sockets of silver: two sockets under one board, and two sockets under another board.",
           "ref": "exodus 26:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": "And for the ends [i.e., the back] of the tabernacle on the west, you shall make six beams, [accounting for nine cubits of width.]",
-            "jps1917": "And for the hinder part of the tabernacle westward thou shalt make six boards."
-          },
+          "en": "And for the hinder part of the tabernacle westward thou shalt make six boards.",
           "ref": "exodus 26:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": "And two beams shall you make for the corners of the tabernacle at the ends, [(so that the interior width is ten cubits)].",
-            "jps1917": "And two boards shalt thou make for the corners of the tabernacle in the hinder part."
-          },
+          "en": "And two boards shalt thou make for the corners of the tabernacle in the hinder part.",
           "ref": "exodus 26:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": "And they (the beams) shall be fitted against each other at the bottom, and together shall they be fitted at its top into one ring. [Two adjacent beams were fixed together by a ring placed in grooves along their breadth.] So shall it be for the two of them [for the two beams at the end, the beam at the northern end and the western beam, and so,] for the two corners shall they be.",
-            "jps1917": "And they shall be double beneath, and in like manner they shall be complete unto the top thereof unto the first ring; thus shall it be for them both; they shall be for the two corners."
-          },
+          "en": "And they shall be double beneath, and in like manner they shall be complete unto the top thereof unto the first ring; thus shall it be for them both; they shall be for the two corners.",
           "ref": "exodus 26:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": "And [on the western side] there shall be eight beams and their silver sockets, sixteen sockets; two sockets under one beam and two sockets under the next beam.",
-            "jps1917": "Thus there shall be eight boards, and their sockets of silver, sixteen sockets: two sockets under one board, and two sockets under another board."
-          },
+          "en": "Thus there shall be eight boards, and their sockets of silver, sixteen sockets: two sockets under one board, and two sockets under another board.",
           "ref": "exodus 26:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": "And you shall make bars of acacia wood, five for the beams of one side of the tabernacle [These \"five\" are three, the upper and lower bars, respectively, consisting of two equal (fifteen cubit segments) running along the side wall, and one bar running the entire length through a hole bored in each beam.]",
-            "jps1917": "And thou shalt make bars of acacia-wood: five for the boards of the one side of the tabernacle,"
-          },
+          "en": "And thou shalt make bars of acacia-wood: five for the boards of the one side of the tabernacle,",
           "ref": "exodus 26:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": "And five bars for the beams of the second side of the tabernacle, and five bars for the beams of the side of the tabernacle at the western ends.",
-            "jps1917": "and five bars for the boards of the other side of the tabernacle, and five bars for the boards of the side of the tabernacle, for the hinder part westward;"
-          },
+          "en": "and five bars for the boards of the other side of the tabernacle, and five bars for the boards of the side of the tabernacle, for the hinder part westward;",
           "ref": "exodus 26:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": "And the middle bar in the midst of the beams shall extend from end to end.",
-            "jps1917": "and the middle bar in the midst of the boards, which shall pass through from end to end."
-          },
+          "en": "and the middle bar in the midst of the boards, which shall pass through from end to end.",
           "ref": "exodus 26:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": "And the beams shall you cover with gold, and their rings shall you make of gold [to serve as] housings for the bars, and you shall cover the bars with gold [i.e., They will be \"covered\" with gold when they are inserted into the golden rings flanked by the golden half-reeds on either side.]",
-            "jps1917": "And thou shalt overlay the boards with gold, and make their rings of gold for holders for the bars; and thou shalt overlay the bars with gold."
-          },
+          "en": "And thou shalt overlay the boards with gold, and make their rings of gold for holders for the bars; and thou shalt overlay the bars with gold.",
           "ref": "exodus 26:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": "And you shall set up the tabernacle after the manner which will have been shown to you [by the L rd] in the mountain.",
-            "jps1917": "And thou shalt rear up the tabernacle according to the fashion thereof which hath been shown thee in the mount."
-          },
+          "en": "And thou shalt rear up the tabernacle according to the fashion thereof which hath been shown thee in the mount.",
           "ref": "exodus 26:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": "And you shall make a parocheth (partition) of blue wool and purple wool and scarlet wool and twisted linen. Artistic work shall he make it, cherubs. [See Rashi on verse 1].",
-            "jps1917": "And thou shalt make a veil of blue, and purple, and scarlet, and fine twined linen; with cherubim the work of the skilful workman shall it be made."
-          },
+          "en": "And thou shalt make a veil of blue, and purple, and scarlet, and fine twined linen; with cherubim the work of the skilful workman shall it be made.",
           "ref": "exodus 26:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": "And you shall place it on four pillars of acacia wood covered with gold, their hooks of gold [(Hooks bent upwards were set in the pillars on which to place the pole on which the top of the parocheth was wrapped)] (the pillars standing) upon four sockets of silver.",
-            "jps1917": "And thou shalt hang it upon four pillars of acacia overlaid with gold, their hooks being of gold, upon four sockets of silver."
-          },
+          "en": "And thou shalt hang it upon four pillars of acacia overlaid with gold, their hooks being of gold, upon four sockets of silver.",
           "ref": "exodus 26:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": "And you shall put the parocheth under the hooks, and you shall bring there, inside the parocheth, the ark of testimony; and the parocheth shall separate for you between the holy and the holy of holies.",
-            "jps1917": "And thou shalt hang up the veil under the clasps, and shalt bring in thither within the veil the ark of the testimony; and the veil shall divide unto you between the holy place and the most holy."
-          },
+          "en": "And thou shalt hang up the veil under the clasps, and shalt bring in thither within the veil the ark of the testimony; and the veil shall divide unto you between the holy place and the most holy.",
           "ref": "exodus 26:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": "And you shall put the kaporeth (the lid) upon the ark of testimony in the holy of holies.",
-            "jps1917": "And thou shalt put the ark-cover upon the ark of the testimony in the most holy place."
-          },
+          "en": "And thou shalt put the ark-cover upon the ark of the testimony in the most holy place.",
           "ref": "exodus 26:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": "And you shall place the table outside the parocheth, and the menorah opposite the table on the southern side of the tabernacle; and the table shall you place on the northern side.",
-            "jps1917": "And thou shalt set the table without the veil, and the candlestick over against the table on the side of the tabernacle toward the south; and thou shalt put the table on the north side."
-          },
+          "en": "And thou shalt set the table without the veil, and the candlestick over against the table on the side of the tabernacle toward the south; and thou shalt put the table on the north side.",
           "ref": "exodus 26:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": "And you shall make a screen [a curtain] for the entrance of the tent, of blue wool, purple wool, scarlet wool, and twisted linen, the work of an embroiderer [needlework, the figures on one side being the same as those on the other.]",
-            "jps1917": "And thou shalt make a screen for the door of the Tent, of blue, and purple, and scarlet, and fine twined linen, the work of the weaver in colours."
-          },
+          "en": "And thou shalt make a screen for the door of the Tent, of blue, and purple, and scarlet, and fine twined linen, the work of the weaver in colours.",
           "ref": "exodus 26:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": "And you shall make for the screen five pillars of acacia wood, and you shall cover them with gold, and their hooks (shall be) of gold; and you shall cast for them five copper sockets.",
-            "jps1917": "And thou shalt make for the screen five pillars of acacia, and overlay them with gold; their hooks shall be of gold; and thou shalt cast five sockets of brass for them."
-          },
+          "en": "And thou shalt make for the screen five pillars of acacia, and overlay them with gold; their hooks shall be of gold; and thou shalt cast five sockets of brass for them.",
           "ref": "exodus 26:37"
         }
       ]
@@ -6033,170 +3822,107 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make the altar of acacia-wood, five cubits long, and five cubits broad; the altar shall be four-square; and the height thereof shall be three cubits."
-          },
+          "en": "And thou shalt make the altar of acacia-wood, five cubits long, and five cubits broad; the altar shall be four-square; and the height thereof shall be three cubits.",
           "ref": "exodus 27:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make the horns of it upon the four corners thereof; the horns thereof shall be of one piece with it; and thou shalt overlay it with brass."
-          },
+          "en": "And thou shalt make the horns of it upon the four corners thereof; the horns thereof shall be of one piece with it; and thou shalt overlay it with brass.",
           "ref": "exodus 27:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make its pots to take away its ashes, and its shovels, and its basins, and its flesh-hooks, and its fire-pans; all the vessels thereof thou shalt make of brass."
-          },
+          "en": "And thou shalt make its pots to take away its ashes, and its shovels, and its basins, and its flesh-hooks, and its fire-pans; all the vessels thereof thou shalt make of brass.",
           "ref": "exodus 27:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make for it a grating of network of brass; and upon the net shalt thou make four brazen rings in the four corners thereof."
-          },
+          "en": "And thou shalt make for it a grating of network of brass; and upon the net shalt thou make four brazen rings in the four corners thereof.",
           "ref": "exodus 27:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt put it under the ledge round the altar beneath, that the net may reach halfway up the altar."
-          },
+          "en": "And thou shalt put it under the ledge round the altar beneath, that the net may reach halfway up the altar.",
           "ref": "exodus 27:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make staves for the altar, staves of acacia-wood, and overlay them with brass."
-          },
+          "en": "And thou shalt make staves for the altar, staves of acacia-wood, and overlay them with brass.",
           "ref": "exodus 27:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And the staves thereof shall be put into the rings, and the staves shall be upon the two sides of the altar, in bearing it."
-          },
+          "en": "And the staves thereof shall be put into the rings, and the staves shall be upon the two sides of the altar, in bearing it.",
           "ref": "exodus 27:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "Hollow with planks shalt thou make it; as it hath been shown thee in the mount, so shall they make it."
-          },
+          "en": "Hollow with planks shalt thou make it; as it hath been shown thee in the mount, so shall they make it.",
           "ref": "exodus 27:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make the court of the tabernacle: for the south side southward there shall be hangings for the court of fine twined linen a hundred cubits long for one side."
-          },
+          "en": "And thou shalt make the court of the tabernacle: for the south side southward there shall be hangings for the court of fine twined linen a hundred cubits long for one side.",
           "ref": "exodus 27:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And the pillars thereof shall be twenty, and their sockets twenty, of brass; the hooks of the pillars and their fillets shall be of silver."
-          },
+          "en": "And the pillars thereof shall be twenty, and their sockets twenty, of brass; the hooks of the pillars and their fillets shall be of silver.",
           "ref": "exodus 27:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And likewise for the north side in length there shall be hangings a hundred cubits long, and the pillars thereof twenty, and their sockets twenty, of brass; the hooks of the pillars and their fillets of silver."
-          },
+          "en": "And likewise for the north side in length there shall be hangings a hundred cubits long, and the pillars thereof twenty, and their sockets twenty, of brass; the hooks of the pillars and their fillets of silver.",
           "ref": "exodus 27:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And for the breadth of the court on the west side shall be hangings of fifty cubits: their pillars ten, and their sockets ten."
-          },
+          "en": "And for the breadth of the court on the west side shall be hangings of fifty cubits: their pillars ten, and their sockets ten.",
           "ref": "exodus 27:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And the breadth of the court on the east side eastward shall be fifty cubits."
-          },
+          "en": "And the breadth of the court on the east side eastward shall be fifty cubits.",
           "ref": "exodus 27:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "The hangings for the one side [of the gate] shall be fifteen cubits: their pillars three, and their sockets three."
-          },
+          "en": "The hangings for the one side [of the gate] shall be fifteen cubits: their pillars three, and their sockets three.",
           "ref": "exodus 27:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And for the other side shall be hangings of fifteen cubits: their pillars three, and their sockets three."
-          },
+          "en": "And for the other side shall be hangings of fifteen cubits: their pillars three, and their sockets three.",
           "ref": "exodus 27:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And for the gate of the court shall be a screen of twenty cubits, of blue, and purple, and scarlet, and fine twined linen, the work of the weaver in colours: their pillars four, and their sockets four."
-          },
+          "en": "And for the gate of the court shall be a screen of twenty cubits, of blue, and purple, and scarlet, and fine twined linen, the work of the weaver in colours: their pillars four, and their sockets four.",
           "ref": "exodus 27:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "All the pillars of the court round about shall be filleted with silver; their hooks of silver, and their sockets of brass."
-          },
+          "en": "All the pillars of the court round about shall be filleted with silver; their hooks of silver, and their sockets of brass.",
           "ref": "exodus 27:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "The length of the court shall be a hundred cubits, and the breadth fifty every where, and the height five cubits, of fine twined linen, and their sockets of brass."
-          },
+          "en": "The length of the court shall be a hundred cubits, and the breadth fifty every where, and the height five cubits, of fine twined linen, and their sockets of brass.",
           "ref": "exodus 27:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "All the instruments of the tabernacle in all the service thereof, and all the pins thereof, and all the pins of the court, shall be of brass."
-          },
+          "en": "All the instruments of the tabernacle in all the service thereof, and all the pins thereof, and all the pins of the court, shall be of brass.",
           "ref": "exodus 27:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt command the children of Israel, that they bring unto thee pure olive oil beaten for the light, to cause a lamp to burn continually."
-          },
+          "en": "And thou shalt command the children of Israel, that they bring unto thee pure olive oil beaten for the light, to cause a lamp to burn continually.",
           "ref": "exodus 27:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "In the tent of meeting, without the veil which is before the testimony, Aaron and his sons shall set it in order, to burn from evening to morning before the LORD; it shall be a statute for ever throughout their generations on the behalf of the children of Israel."
-          },
+          "en": "In the tent of meeting, without the veil which is before the testimony, Aaron and his sons shall set it in order, to burn from evening to morning before the LORD; it shall be a statute for ever throughout their generations on the behalf of the children of Israel.",
           "ref": "exodus 27:21"
         }
       ]
@@ -6206,346 +3932,217 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And bring thou near unto thee Aaron thy brother, and his sons with him, from among the children of Israel, that they may minister unto Me in the priest’s office, even Aaron, Nadab and Abihu, Eleazar and Ithamar, Aaron’s sons."
-          },
+          "en": "And bring thou near unto thee Aaron thy brother, and his sons with him, from among the children of Israel, that they may minister unto Me in the priest’s office, even Aaron, Nadab and Abihu, Eleazar and Ithamar, Aaron’s sons.",
           "ref": "exodus 28:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make holy garments for Aaron thy brother, for splendour and for beauty."
-          },
+          "en": "And thou shalt make holy garments for Aaron thy brother, for splendour and for beauty.",
           "ref": "exodus 28:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt speak unto all that are wise-hearted, whom I have filled with the spirit of wisdom, that they make Aaron’s garments to sanctify him, that he may minister unto Me in the priest’s office."
-          },
+          "en": "And thou shalt speak unto all that are wise-hearted, whom I have filled with the spirit of wisdom, that they make Aaron’s garments to sanctify him, that he may minister unto Me in the priest’s office.",
           "ref": "exodus 28:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the garments which they shall make: a breastplate, and an ephod, and a robe, and a tunic of chequer work, a mitre, and a girdle; and they shall make holy garments for Aaron thy brother, and his sons, that he may minister unto Me in the priest’s office."
-          },
+          "en": "And these are the garments which they shall make: a breastplate, and an ephod, and a robe, and a tunic of chequer work, a mitre, and a girdle; and they shall make holy garments for Aaron thy brother, and his sons, that he may minister unto Me in the priest’s office.",
           "ref": "exodus 28:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And they shall take the gold, and the blue, and the purple, and the scarlet, and the fine linen."
-          },
+          "en": "And they shall take the gold, and the blue, and the purple, and the scarlet, and the fine linen.",
           "ref": "exodus 28:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And they shall make the ephod of gold, of blue, and purple, scarlet, and fine twined linen, the work of the skilful workman."
-          },
+          "en": "And they shall make the ephod of gold, of blue, and purple, scarlet, and fine twined linen, the work of the skilful workman.",
           "ref": "exodus 28:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "It shall have two shoulder-pieces joined to the two ends thereof, that it may be joined together."
-          },
+          "en": "It shall have two shoulder-pieces joined to the two ends thereof, that it may be joined together.",
           "ref": "exodus 28:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And the skilfully woven band, which is upon it, wherewith to gird it on, shall be like the work thereof and of the same piece: of gold, of blue, and purple, and scarlet, and fine twined linen."
-          },
+          "en": "And the skilfully woven band, which is upon it, wherewith to gird it on, shall be like the work thereof and of the same piece: of gold, of blue, and purple, and scarlet, and fine twined linen.",
           "ref": "exodus 28:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt take two onyx stones, and grave on them the names of the children of Israel:"
-          },
+          "en": "And thou shalt take two onyx stones, and grave on them the names of the children of Israel:",
           "ref": "exodus 28:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "six of their names on the one stone, and the names of the six that remain on the other stone, according to their birth."
-          },
+          "en": "six of their names on the one stone, and the names of the six that remain on the other stone, according to their birth.",
           "ref": "exodus 28:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "With the work of an engraver in stone, like the engravings of a signet, shalt thou engrave the two stones, according to the names of the children of Israel; thou shalt make them to be inclosed in settings of gold."
-          },
+          "en": "With the work of an engraver in stone, like the engravings of a signet, shalt thou engrave the two stones, according to the names of the children of Israel; thou shalt make them to be inclosed in settings of gold.",
           "ref": "exodus 28:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt put the two stones upon the shoulder-pieces of the ephod, to be stones of memorial for the children of Israel; and Aaron shall bear their names before the LORD upon his two shoulders for a memorial."
-          },
+          "en": "And thou shalt put the two stones upon the shoulder-pieces of the ephod, to be stones of memorial for the children of Israel; and Aaron shall bear their names before the LORD upon his two shoulders for a memorial.",
           "ref": "exodus 28:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make settings of gold;"
-          },
+          "en": "And thou shalt make settings of gold;",
           "ref": "exodus 28:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "and two chains of pure gold; of plaited thread shalt thou make them, of wreathen work; and thou shalt put the wreathen chains on the settings."
-          },
+          "en": "and two chains of pure gold; of plaited thread shalt thou make them, of wreathen work; and thou shalt put the wreathen chains on the settings.",
           "ref": "exodus 28:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make a breastplate of judgment, the work of the skilful workman; like the work of the ephod thou shalt make it: of gold, of blue, and purple, and scarlet, and fine twined linen, shalt thou make it."
-          },
+          "en": "And thou shalt make a breastplate of judgment, the work of the skilful workman; like the work of the ephod thou shalt make it: of gold, of blue, and purple, and scarlet, and fine twined linen, shalt thou make it.",
           "ref": "exodus 28:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "Four-square it shall be and double: a span shall be the length thereof, and a span the breadth thereof."
-          },
+          "en": "Four-square it shall be and double: a span shall be the length thereof, and a span the breadth thereof.",
           "ref": "exodus 28:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt set in it settings of stones, four rows of stones: a row of carnelian, topaz, and smaragd shall be the first row;"
-          },
+          "en": "And thou shalt set in it settings of stones, four rows of stones: a row of carnelian, topaz, and smaragd shall be the first row;",
           "ref": "exodus 28:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "and the second row a carbuncle, a sapphire, and an emerald;"
-          },
+          "en": "and the second row a carbuncle, a sapphire, and an emerald;",
           "ref": "exodus 28:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "and the third row a jacinth, an agate, and an amethyst;"
-          },
+          "en": "and the third row a jacinth, an agate, and an amethyst;",
           "ref": "exodus 28:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "and the fourth row a beryl, and an onyx, and a jasper; they shall be inclosed in gold in their settings."
-          },
+          "en": "and the fourth row a beryl, and an onyx, and a jasper; they shall be inclosed in gold in their settings.",
           "ref": "exodus 28:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And the stones shall be according to the names of the children of Israel, twelve, according to their names; like the engravings of a signet, every one according to his name, they shall be for the twelve tribes."
-          },
+          "en": "And the stones shall be according to the names of the children of Israel, twelve, according to their names; like the engravings of a signet, every one according to his name, they shall be for the twelve tribes.",
           "ref": "exodus 28:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make upon the breastplate plaited chains of wreathen work of pure gold."
-          },
+          "en": "And thou shalt make upon the breastplate plaited chains of wreathen work of pure gold.",
           "ref": "exodus 28:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make upon the breastplate two rings of gold, and shalt put the two rings on the two ends of the breastplate."
-          },
+          "en": "And thou shalt make upon the breastplate two rings of gold, and shalt put the two rings on the two ends of the breastplate.",
           "ref": "exodus 28:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt put the two wreathen chains of gold on the two rings at the ends of the breastplate."
-          },
+          "en": "And thou shalt put the two wreathen chains of gold on the two rings at the ends of the breastplate.",
           "ref": "exodus 28:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And the other two ends of the two wreathen chains thou shalt put on the two settings, and put them on the shoulder-pieces of the ephod, in the forepart thereof."
-          },
+          "en": "And the other two ends of the two wreathen chains thou shalt put on the two settings, and put them on the shoulder-pieces of the ephod, in the forepart thereof.",
           "ref": "exodus 28:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make two rings of gold, and thou shalt put them upon the two ends of the breastplate, upon the edge thereof, which is toward the side of the ephod inward."
-          },
+          "en": "And thou shalt make two rings of gold, and thou shalt put them upon the two ends of the breastplate, upon the edge thereof, which is toward the side of the ephod inward.",
           "ref": "exodus 28:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make two rings of gold, and shalt put them on the two shoulder-pieces of the ephod underneath, in the forepart thereof, close by the coupling thereof, above the skilfully woven band of the ephod."
-          },
+          "en": "And thou shalt make two rings of gold, and shalt put them on the two shoulder-pieces of the ephod underneath, in the forepart thereof, close by the coupling thereof, above the skilfully woven band of the ephod.",
           "ref": "exodus 28:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And they shall bind the breastplate by the rings thereof unto the rings of the ephod with a thread of blue, that it may be upon the skilfully woven band of the ephod, and that the breastplate be not loosed from the ephod."
-          },
+          "en": "And they shall bind the breastplate by the rings thereof unto the rings of the ephod with a thread of blue, that it may be upon the skilfully woven band of the ephod, and that the breastplate be not loosed from the ephod.",
           "ref": "exodus 28:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And Aaron shall bear the names of the children of Israel in the breastplate of judgment upon his heart, when he goeth in unto the holy place, for a memorial before the LORD continually. ."
-          },
+          "en": "And Aaron shall bear the names of the children of Israel in the breastplate of judgment upon his heart, when he goeth in unto the holy place, for a memorial before the LORD continually. .",
           "ref": "exodus 28:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt put in the breastplate of judgment the Urim and the Thummim; and they shall be upon Aaron’s heart, when he goeth in before the LORD; and Aaron shall bear the judgment of the children of Israel upon his heart before the LORD continually."
-          },
+          "en": "And thou shalt put in the breastplate of judgment the Urim and the Thummim; and they shall be upon Aaron’s heart, when he goeth in before the LORD; and Aaron shall bear the judgment of the children of Israel upon his heart before the LORD continually.",
           "ref": "exodus 28:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make the robe of the ephod all of blue."
-          },
+          "en": "And thou shalt make the robe of the ephod all of blue.",
           "ref": "exodus 28:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall have a hole for the head in the midst thereof; it shall have a binding of woven work round about the hole of it, as it were the hole of a coat of mail that it be not rent."
-          },
+          "en": "And it shall have a hole for the head in the midst thereof; it shall have a binding of woven work round about the hole of it, as it were the hole of a coat of mail that it be not rent.",
           "ref": "exodus 28:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And upon the skirts of it thou shalt make pomegranates of blue, and of purple, and of scarlet, round about the skirts thereof; and bells of gold between them round about:"
-          },
+          "en": "And upon the skirts of it thou shalt make pomegranates of blue, and of purple, and of scarlet, round about the skirts thereof; and bells of gold between them round about:",
           "ref": "exodus 28:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "a golden bell and a pomegranate, a golden bell and a pomegranate, upon the skirts of the robe round about."
-          },
+          "en": "a golden bell and a pomegranate, a golden bell and a pomegranate, upon the skirts of the robe round about.",
           "ref": "exodus 28:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall be upon Aaron to minister; and the sound thereof shall be heard when he goeth in unto the holy place before the LORD, and when he cometh out, that he die not."
-          },
+          "en": "And it shall be upon Aaron to minister; and the sound thereof shall be heard when he goeth in unto the holy place before the LORD, and when he cometh out, that he die not.",
           "ref": "exodus 28:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make a plate of pure gold, and engrave upon it, like the engravings of a signet: HOLY TO THE LORD."
-          },
+          "en": "And thou shalt make a plate of pure gold, and engrave upon it, like the engravings of a signet: HOLY TO THE LORD.",
           "ref": "exodus 28:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt put it on a thread of blue, and it shall be upon the mitre; upon the forefront of the mitre it shall be."
-          },
+          "en": "And thou shalt put it on a thread of blue, and it shall be upon the mitre; upon the forefront of the mitre it shall be.",
           "ref": "exodus 28:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall be upon Aaron’s forehead, and Aaron shall bear the iniquity committed in the holy things, which the children of Israel shall hallow, even in all their holy gifts; and it shall be always upon his forehead, that they may be accepted before the LORD."
-          },
+          "en": "And it shall be upon Aaron’s forehead, and Aaron shall bear the iniquity committed in the holy things, which the children of Israel shall hallow, even in all their holy gifts; and it shall be always upon his forehead, that they may be accepted before the LORD.",
           "ref": "exodus 28:38"
         },
         {
           "n": 39,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt weave the tunic in chequer work of fine linen, and thou shalt make a mitre of fine linen, and thou shalt make a girdle, the work of the weaver in colours."
-          },
+          "en": "And thou shalt weave the tunic in chequer work of fine linen, and thou shalt make a mitre of fine linen, and thou shalt make a girdle, the work of the weaver in colours.",
           "ref": "exodus 28:39"
         },
         {
           "n": 40,
-          "en": {
-            "sct": null,
-            "jps1917": "And for Aaron’s sons thou shalt make tunics, and thou shalt make for them girdles, and head-tires shalt thou make for them, for splendour and for beauty."
-          },
+          "en": "And for Aaron’s sons thou shalt make tunics, and thou shalt make for them girdles, and head-tires shalt thou make for them, for splendour and for beauty.",
           "ref": "exodus 28:40"
         },
         {
           "n": 41,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt put them upon Aaron thy brother, and upon his sons with him; and shalt anoint them, and consecrate them, and sanctify them, that they may minister unto Me in the priest’s office."
-          },
+          "en": "And thou shalt put them upon Aaron thy brother, and upon his sons with him; and shalt anoint them, and consecrate them, and sanctify them, that they may minister unto Me in the priest’s office.",
           "ref": "exodus 28:41"
         },
         {
           "n": 42,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make them linen breeches to cover the flesh of their nakedness; from the loins even unto the thighs they shall reach."
-          },
+          "en": "And thou shalt make them linen breeches to cover the flesh of their nakedness; from the loins even unto the thighs they shall reach.",
           "ref": "exodus 28:42"
         },
         {
           "n": 43,
-          "en": {
-            "sct": null,
-            "jps1917": "And they shall be upon Aaron, and upon his sons, when they go in unto the tent of meeting, or when they come near unto the altar to minister in the holy place; that they bear not iniquity, and die; it shall be a statute for ever unto him and unto his seed after him."
-          },
+          "en": "And they shall be upon Aaron, and upon his sons, when they go in unto the tent of meeting, or when they come near unto the altar to minister in the holy place; that they bear not iniquity, and die; it shall be a statute for ever unto him and unto his seed after him.",
           "ref": "exodus 28:43"
         }
       ]
@@ -6555,370 +4152,232 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And this is the thing that thou shalt do unto them to hallow them, to minister unto Me in the priest’s office: take one young bullock and two rams without blemish,"
-          },
+          "en": "And this is the thing that thou shalt do unto them to hallow them, to minister unto Me in the priest’s office: take one young bullock and two rams without blemish,",
           "ref": "exodus 29:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "and unleavened bread, and cakes unleavened mingled with oil, and wafers unleavened spread with oil; of fine wheaten flour shalt thou make them."
-          },
+          "en": "and unleavened bread, and cakes unleavened mingled with oil, and wafers unleavened spread with oil; of fine wheaten flour shalt thou make them.",
           "ref": "exodus 29:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt put them into one basket, and bring them in the basket, with the bullock and the two rams."
-          },
+          "en": "And thou shalt put them into one basket, and bring them in the basket, with the bullock and the two rams.",
           "ref": "exodus 29:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And Aaron and his sons thou shalt bring unto the door of the tent of meeting, and shalt wash them with water."
-          },
+          "en": "And Aaron and his sons thou shalt bring unto the door of the tent of meeting, and shalt wash them with water.",
           "ref": "exodus 29:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt take the garments, and put upon Aaron the tunic, and the robe of the ephod, and the ephod, and the breastplate, and gird him with the skilfully woven band of the ephod."
-          },
+          "en": "And thou shalt take the garments, and put upon Aaron the tunic, and the robe of the ephod, and the ephod, and the breastplate, and gird him with the skilfully woven band of the ephod.",
           "ref": "exodus 29:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt set the mitre upon his head, and put the holy crown upon the mitre."
-          },
+          "en": "And thou shalt set the mitre upon his head, and put the holy crown upon the mitre.",
           "ref": "exodus 29:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "Then shalt thou take the anointing oil, and pour it upon his head, and anoint him."
-          },
+          "en": "Then shalt thou take the anointing oil, and pour it upon his head, and anoint him.",
           "ref": "exodus 29:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt bring his sons, and put tunics upon them."
-          },
+          "en": "And thou shalt bring his sons, and put tunics upon them.",
           "ref": "exodus 29:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt gird them with girdles, Aaron and his sons, and bind head-tires on them; and they shall have the priesthood by a perpetual statute; and thou shalt consecrate Aaron and his sons."
-          },
+          "en": "And thou shalt gird them with girdles, Aaron and his sons, and bind head-tires on them; and they shall have the priesthood by a perpetual statute; and thou shalt consecrate Aaron and his sons.",
           "ref": "exodus 29:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt bring the bullock before the tent of meeting; and Aaron and his sons shall lay their hands upon the head of the bullock."
-          },
+          "en": "And thou shalt bring the bullock before the tent of meeting; and Aaron and his sons shall lay their hands upon the head of the bullock.",
           "ref": "exodus 29:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt kill the bullock before the LORD, at the door of the tent of meeting."
-          },
+          "en": "And thou shalt kill the bullock before the LORD, at the door of the tent of meeting.",
           "ref": "exodus 29:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt take of the blood of the bullock, and put it upon the horns of the altar with thy finger; and thou shalt pour out all the remaining blood at the base of the altar."
-          },
+          "en": "And thou shalt take of the blood of the bullock, and put it upon the horns of the altar with thy finger; and thou shalt pour out all the remaining blood at the base of the altar.",
           "ref": "exodus 29:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt take all the fat that covereth the inwards, and the lobe above the liver, and the two kidneys, and the fat that is upon them, and make them smoke upon the altar."
-          },
+          "en": "And thou shalt take all the fat that covereth the inwards, and the lobe above the liver, and the two kidneys, and the fat that is upon them, and make them smoke upon the altar.",
           "ref": "exodus 29:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "But the flesh of the bullock, and its skin, and its dung, shalt thou burn with fire without the camp; it is a sin-offering."
-          },
+          "en": "But the flesh of the bullock, and its skin, and its dung, shalt thou burn with fire without the camp; it is a sin-offering.",
           "ref": "exodus 29:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt also take the one ram; and Aaron and his sons shall lay their hands upon the head of the ram."
-          },
+          "en": "Thou shalt also take the one ram; and Aaron and his sons shall lay their hands upon the head of the ram.",
           "ref": "exodus 29:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt slay the ram, and thou shalt take its blood, and dash it round about against the altar."
-          },
+          "en": "And thou shalt slay the ram, and thou shalt take its blood, and dash it round about against the altar.",
           "ref": "exodus 29:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt cut the ram into its pieces, and wash its inwards, and its legs, and put them with its pieces, and with its head."
-          },
+          "en": "And thou shalt cut the ram into its pieces, and wash its inwards, and its legs, and put them with its pieces, and with its head.",
           "ref": "exodus 29:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make the whole ram smoke upon the altar; it is a burnt-offering unto the LORD; it is a sweet savour, an offering made by fire unto the LORD."
-          },
+          "en": "And thou shalt make the whole ram smoke upon the altar; it is a burnt-offering unto the LORD; it is a sweet savour, an offering made by fire unto the LORD.",
           "ref": "exodus 29:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt take the other ram; and Aaron and his sons shall lay their hands upon the head of the ram."
-          },
+          "en": "And thou shalt take the other ram; and Aaron and his sons shall lay their hands upon the head of the ram.",
           "ref": "exodus 29:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "Then shalt thou kill the ram, and take of its blood, and put it upon the tip of the right ear of Aaron, and upon the tip of the right ear of his sons, and upon the thumb of their right hand, and upon the great toe of their right foot, and dash the blood against the altar round about."
-          },
+          "en": "Then shalt thou kill the ram, and take of its blood, and put it upon the tip of the right ear of Aaron, and upon the tip of the right ear of his sons, and upon the thumb of their right hand, and upon the great toe of their right foot, and dash the blood against the altar round about.",
           "ref": "exodus 29:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt take of the blood that is upon the altar, and of the anointing oil, and sprinkle it upon Aaron, and upon his garments, and upon his sons, and upon the garments of his sons with him; and he and his garments shall be hallowed, and his sons and his sons’garments with him."
-          },
+          "en": "And thou shalt take of the blood that is upon the altar, and of the anointing oil, and sprinkle it upon Aaron, and upon his garments, and upon his sons, and upon the garments of his sons with him; and he and his garments shall be hallowed, and his sons and his sons’garments with him.",
           "ref": "exodus 29:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "Also thou shalt take of the ram the fat, and the fat tail, and the fat that covereth the inwards, and the lobe of the liver, and the two kidneys, and the fat that is upon them, and the right thigh; for it is a ram of consecration;"
-          },
+          "en": "Also thou shalt take of the ram the fat, and the fat tail, and the fat that covereth the inwards, and the lobe of the liver, and the two kidneys, and the fat that is upon them, and the right thigh; for it is a ram of consecration;",
           "ref": "exodus 29:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "and one loaf of bread, and one cake of oiled bread, and one wafer, out of the basket of unleavened bread that is before the LORD."
-          },
+          "en": "and one loaf of bread, and one cake of oiled bread, and one wafer, out of the basket of unleavened bread that is before the LORD.",
           "ref": "exodus 29:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt put the whole upon the hands of Aaron, and upon the hands of his sons; and shalt wave them for a wave-offering before the LORD."
-          },
+          "en": "And thou shalt put the whole upon the hands of Aaron, and upon the hands of his sons; and shalt wave them for a wave-offering before the LORD.",
           "ref": "exodus 29:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt take them from their hands, and make them smoke on the altar upon the burnt-offering, for a sweet savour before the LORD; it is an offering made by fire unto the LORD."
-          },
+          "en": "And thou shalt take them from their hands, and make them smoke on the altar upon the burnt-offering, for a sweet savour before the LORD; it is an offering made by fire unto the LORD.",
           "ref": "exodus 29:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt take the breast of Aaron’s ram of consecration, and wave it for a wave-offering before the LORD; and it shall be thy portion."
-          },
+          "en": "And thou shalt take the breast of Aaron’s ram of consecration, and wave it for a wave-offering before the LORD; and it shall be thy portion.",
           "ref": "exodus 29:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt sanctify the breast of the wave-offering, and the thigh of the heave-offering, which is waved, and which is heaved up, of the ram of consecration, even of that which is Aaron’s, and of that which is his sons’."
-          },
+          "en": "And thou shalt sanctify the breast of the wave-offering, and the thigh of the heave-offering, which is waved, and which is heaved up, of the ram of consecration, even of that which is Aaron’s, and of that which is his sons’.",
           "ref": "exodus 29:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall be for Aaron and his sons as a due for ever from the children of Israel; for it is a heave-offering; and it shall be a heave-offering from the children of Israel of their sacrifices of peace-offerings, even their heave-offering unto the LORD."
-          },
+          "en": "And it shall be for Aaron and his sons as a due for ever from the children of Israel; for it is a heave-offering; and it shall be a heave-offering from the children of Israel of their sacrifices of peace-offerings, even their heave-offering unto the LORD.",
           "ref": "exodus 29:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And the holy garments of Aaron shall be for his sons after him, to be anointed in them, and to be consecrated in them."
-          },
+          "en": "And the holy garments of Aaron shall be for his sons after him, to be anointed in them, and to be consecrated in them.",
           "ref": "exodus 29:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "Seven days shall the son that is priest in his stead put them on, even he who cometh into the tent of meeting to minister in the holy place."
-          },
+          "en": "Seven days shall the son that is priest in his stead put them on, even he who cometh into the tent of meeting to minister in the holy place.",
           "ref": "exodus 29:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt take the ram of consecration, and seethe its flesh in a holy place."
-          },
+          "en": "And thou shalt take the ram of consecration, and seethe its flesh in a holy place.",
           "ref": "exodus 29:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And Aaron and his sons shall eat the flesh of the ram, and the bread that is in the basket, at the door of the tent of meeting."
-          },
+          "en": "And Aaron and his sons shall eat the flesh of the ram, and the bread that is in the basket, at the door of the tent of meeting.",
           "ref": "exodus 29:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And they shall eat those things wherewith atonement was made, to consecrate and to sanctify them; but a stranger shall not eat thereof, because they are holy."
-          },
+          "en": "And they shall eat those things wherewith atonement was made, to consecrate and to sanctify them; but a stranger shall not eat thereof, because they are holy.",
           "ref": "exodus 29:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And if aught of the flesh of the consecration, or of the bread, remain unto the morning, then thou shalt burn the remainder with fire; it shall not be eaten, because it is holy."
-          },
+          "en": "And if aught of the flesh of the consecration, or of the bread, remain unto the morning, then thou shalt burn the remainder with fire; it shall not be eaten, because it is holy.",
           "ref": "exodus 29:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And thus shalt thou do unto Aaron, and to his sons, according to all that I have commanded thee; seven days shalt thou consecrate them."
-          },
+          "en": "And thus shalt thou do unto Aaron, and to his sons, according to all that I have commanded thee; seven days shalt thou consecrate them.",
           "ref": "exodus 29:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "And every day shalt thou offer the bullock of sin-offering, beside the other offerings of atonement; and thou shalt do the purification upon the altar when thou makest atonement for it; and thou shalt anoint it, to sanctify it."
-          },
+          "en": "And every day shalt thou offer the bullock of sin-offering, beside the other offerings of atonement; and thou shalt do the purification upon the altar when thou makest atonement for it; and thou shalt anoint it, to sanctify it.",
           "ref": "exodus 29:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": null,
-            "jps1917": "Seven days thou shalt make atonement for the altar, and sanctify it; thus shall the altar be most holy; whatsoever toucheth the altar shall be holy."
-          },
+          "en": "Seven days thou shalt make atonement for the altar, and sanctify it; thus shall the altar be most holy; whatsoever toucheth the altar shall be holy.",
           "ref": "exodus 29:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": null,
-            "jps1917": "Now this is that which thou shalt offer upon the altar: two lambs of the first year day by day continually."
-          },
+          "en": "Now this is that which thou shalt offer upon the altar: two lambs of the first year day by day continually.",
           "ref": "exodus 29:38"
         },
         {
           "n": 39,
-          "en": {
-            "sct": null,
-            "jps1917": "The one lamb thou shalt offer in the morning; and the other lamb thou shalt offer at dusk."
-          },
+          "en": "The one lamb thou shalt offer in the morning; and the other lamb thou shalt offer at dusk.",
           "ref": "exodus 29:39"
         },
         {
           "n": 40,
-          "en": {
-            "sct": null,
-            "jps1917": "And with the one lamb a tenth part of an ephah of fine flour mingled with the fourth part of a hin of beaten oil; and the fourth part of a hin of wine for a drink-offering."
-          },
+          "en": "And with the one lamb a tenth part of an ephah of fine flour mingled with the fourth part of a hin of beaten oil; and the fourth part of a hin of wine for a drink-offering.",
           "ref": "exodus 29:40"
         },
         {
           "n": 41,
-          "en": {
-            "sct": null,
-            "jps1917": "And the other lamb thou shalt offer at dusk, and shalt do thereto according to the meal-offering of the morning, and according to the drink-offering thereof, for a sweet savour, an offering made by fire unto the LORD."
-          },
+          "en": "And the other lamb thou shalt offer at dusk, and shalt do thereto according to the meal-offering of the morning, and according to the drink-offering thereof, for a sweet savour, an offering made by fire unto the LORD.",
           "ref": "exodus 29:41"
         },
         {
           "n": 42,
-          "en": {
-            "sct": null,
-            "jps1917": "It shall be a continual burnt-offering throughout your generations at the door of the tent of meeting before the LORD, where I will meet with you, to speak there unto thee."
-          },
+          "en": "It shall be a continual burnt-offering throughout your generations at the door of the tent of meeting before the LORD, where I will meet with you, to speak there unto thee.",
           "ref": "exodus 29:42"
         },
         {
           "n": 43,
-          "en": {
-            "sct": null,
-            "jps1917": "And there I will meet with the children of Israel; and [the Tent] shall be sanctified by My glory."
-          },
+          "en": "And there I will meet with the children of Israel; and [the Tent] shall be sanctified by My glory.",
           "ref": "exodus 29:43"
         },
         {
           "n": 44,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will sanctify the tent of meeting, and the altar; Aaron also and his sons will I sanctify, to minister to Me in the priest’s office."
-          },
+          "en": "And I will sanctify the tent of meeting, and the altar; Aaron also and his sons will I sanctify, to minister to Me in the priest’s office.",
           "ref": "exodus 29:44"
         },
         {
           "n": 45,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will dwell among the children of Israel, and will be their God."
-          },
+          "en": "And I will dwell among the children of Israel, and will be their God.",
           "ref": "exodus 29:45"
         },
         {
           "n": 46,
-          "en": {
-            "sct": null,
-            "jps1917": "And they shall know that I am the LORD their God, that brought them forth out of the land of Egypt, that I may dwell among them. I am the LORD their God."
-          },
+          "en": "And they shall know that I am the LORD their God, that brought them forth out of the land of Egypt, that I may dwell among them. I am the LORD their God.",
           "ref": "exodus 29:46"
         }
       ]
@@ -6928,306 +4387,192 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make an altar to burn incense upon; of acacia-wood shalt thou make it."
-          },
+          "en": "And thou shalt make an altar to burn incense upon; of acacia-wood shalt thou make it.",
           "ref": "exodus 30:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "A cubit shall be the length thereof, and a cubit the breadth thereof; foursquare shall it be; and two cubits shall be the height thereof; the horns thereof shall be of one piece with it."
-          },
+          "en": "A cubit shall be the length thereof, and a cubit the breadth thereof; foursquare shall it be; and two cubits shall be the height thereof; the horns thereof shall be of one piece with it.",
           "ref": "exodus 30:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt overlay it with pure gold, the top thereof, and the sides thereof round about, and the horns thereof; and thou shalt make unto it a crown of gold round about."
-          },
+          "en": "And thou shalt overlay it with pure gold, the top thereof, and the sides thereof round about, and the horns thereof; and thou shalt make unto it a crown of gold round about.",
           "ref": "exodus 30:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And two golden rings shalt thou make for it under the crown thereof, upon the two ribs thereof, upon the two sides of it shalt thou make them; and they shall be for places for staves wherewith to bear it."
-          },
+          "en": "And two golden rings shalt thou make for it under the crown thereof, upon the two ribs thereof, upon the two sides of it shalt thou make them; and they shall be for places for staves wherewith to bear it.",
           "ref": "exodus 30:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make the staves of acacia-wood, and overlay them with gold."
-          },
+          "en": "And thou shalt make the staves of acacia-wood, and overlay them with gold.",
           "ref": "exodus 30:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt put it before the veil that is by the ark of the testimony, before the ark-cover that is over the testimony, where I will meet with thee."
-          },
+          "en": "And thou shalt put it before the veil that is by the ark of the testimony, before the ark-cover that is over the testimony, where I will meet with thee.",
           "ref": "exodus 30:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Aaron shall burn thereon incense of sweet spices; every morning, when he dresseth the lamps, he shall burn it."
-          },
+          "en": "And Aaron shall burn thereon incense of sweet spices; every morning, when he dresseth the lamps, he shall burn it.",
           "ref": "exodus 30:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Aaron lighteth the lamps at dusk, he shall burn it, a perpetual incense before the LORD throughout your generations."
-          },
+          "en": "And when Aaron lighteth the lamps at dusk, he shall burn it, a perpetual incense before the LORD throughout your generations.",
           "ref": "exodus 30:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "Ye shall offer no strange incense thereon, nor burnt-offering, nor meal-offering; and ye shall pour no drink-offering thereon."
-          },
+          "en": "Ye shall offer no strange incense thereon, nor burnt-offering, nor meal-offering; and ye shall pour no drink-offering thereon.",
           "ref": "exodus 30:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And Aaron shall make atonement upon the horns of it once in the year; with the blood of the sin-offering of atonement once in the year shall he make atonement for it throughout your generations; it is most holy unto the LORD.’"
-          },
+          "en": "And Aaron shall make atonement upon the horns of it once in the year; with the blood of the sin-offering of atonement once in the year shall he make atonement for it throughout your generations; it is most holy unto the LORD.’",
           "ref": "exodus 30:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses, saying:"
-          },
+          "en": "And the LORD spoke unto Moses, saying:",
           "ref": "exodus 30:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "’When thou takest the sum of the children of Israel, according to their number, then shall they give every man a ransom for his soul unto the LORD, when thou numberest them; that there be no plague among them, when thou numberest them."
-          },
+          "en": "’When thou takest the sum of the children of Israel, according to their number, then shall they give every man a ransom for his soul unto the LORD, when thou numberest them; that there be no plague among them, when thou numberest them.",
           "ref": "exodus 30:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "This they shall give, every one that passeth among them that are numbered, half a shekel after the shekel of the sanctuary—the shekel is twenty gerahs—half a shekel for an offering to the LORD."
-          },
+          "en": "This they shall give, every one that passeth among them that are numbered, half a shekel after the shekel of the sanctuary—the shekel is twenty gerahs—half a shekel for an offering to the LORD.",
           "ref": "exodus 30:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "Every one that passeth among them that are numbered, from twenty years old and upward, shall give the offering of the LORD."
-          },
+          "en": "Every one that passeth among them that are numbered, from twenty years old and upward, shall give the offering of the LORD.",
           "ref": "exodus 30:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "The rich shall not give more, and the poor shall not give less, than the half shekel, when they give the offering of the LORD, to make atonement for your souls."
-          },
+          "en": "The rich shall not give more, and the poor shall not give less, than the half shekel, when they give the offering of the LORD, to make atonement for your souls.",
           "ref": "exodus 30:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt take the atonement money from the children of Israel, and shalt appoint it for the service of the tent of meeting, that it may be a memorial for the children of Israel before the LORD, to make atonement for your souls.’"
-          },
+          "en": "And thou shalt take the atonement money from the children of Israel, and shalt appoint it for the service of the tent of meeting, that it may be a memorial for the children of Israel before the LORD, to make atonement for your souls.’",
           "ref": "exodus 30:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses, saying:"
-          },
+          "en": "And the LORD spoke unto Moses, saying:",
           "ref": "exodus 30:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "’Thou shalt also make a laver of brass, and the base thereof of brass, whereat to wash; and thou shalt put it between the tent of meeting and the altar, and thou shalt put water therein."
-          },
+          "en": "’Thou shalt also make a laver of brass, and the base thereof of brass, whereat to wash; and thou shalt put it between the tent of meeting and the altar, and thou shalt put water therein.",
           "ref": "exodus 30:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And Aaron and his sons shall wash their hands and their feet thereat;"
-          },
+          "en": "And Aaron and his sons shall wash their hands and their feet thereat;",
           "ref": "exodus 30:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "when they go into the tent of meeting, they shall wash with water, that they die not; or when they come near to the altar to minister, to cause an offering made by fire to smoke unto the LORD;"
-          },
+          "en": "when they go into the tent of meeting, they shall wash with water, that they die not; or when they come near to the altar to minister, to cause an offering made by fire to smoke unto the LORD;",
           "ref": "exodus 30:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "so they shall wash their hands and their feet, that they die not; and it shall be a statute for ever to them, even to him and to his seed throughout their generations.’"
-          },
+          "en": "so they shall wash their hands and their feet, that they die not; and it shall be a statute for ever to them, even to him and to his seed throughout their generations.’",
           "ref": "exodus 30:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "Moreover the LORD spoke unto Moses, saying:"
-          },
+          "en": "Moreover the LORD spoke unto Moses, saying:",
           "ref": "exodus 30:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "’Take thou also unto thee the chief spices, of flowing myrrh five hundred shekels, and of sweet cinnamon half so much, even two hundred and fifty, and of sweet calamus two hundred and fifty,"
-          },
+          "en": "’Take thou also unto thee the chief spices, of flowing myrrh five hundred shekels, and of sweet cinnamon half so much, even two hundred and fifty, and of sweet calamus two hundred and fifty,",
           "ref": "exodus 30:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "and of cassia five hundred, after the shekel of the sanctuary, and of olive oil a hin."
-          },
+          "en": "and of cassia five hundred, after the shekel of the sanctuary, and of olive oil a hin.",
           "ref": "exodus 30:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make it a holy anointing oil, a perfume compounded after the art of the perfumer; it shall be a holy anointing oil."
-          },
+          "en": "And thou shalt make it a holy anointing oil, a perfume compounded after the art of the perfumer; it shall be a holy anointing oil.",
           "ref": "exodus 30:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt anoint therewith the tent of meeting, and the ark of the testimony,"
-          },
+          "en": "And thou shalt anoint therewith the tent of meeting, and the ark of the testimony,",
           "ref": "exodus 30:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "and the table and all the vessels thereof, and the candlestick and the vessels thereof, and the altar of incense,"
-          },
+          "en": "and the table and all the vessels thereof, and the candlestick and the vessels thereof, and the altar of incense,",
           "ref": "exodus 30:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "and the altar of burnt-offering with all the vessels thereof, and the laver and the base thereof."
-          },
+          "en": "and the altar of burnt-offering with all the vessels thereof, and the laver and the base thereof.",
           "ref": "exodus 30:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt sanctify them, that they may be most holy; whatsoever toucheth them shall be holy."
-          },
+          "en": "And thou shalt sanctify them, that they may be most holy; whatsoever toucheth them shall be holy.",
           "ref": "exodus 30:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt anoint Aaron and his sons, and sanctify them, that they may minister unto Me in the priest’s office."
-          },
+          "en": "And thou shalt anoint Aaron and his sons, and sanctify them, that they may minister unto Me in the priest’s office.",
           "ref": "exodus 30:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt speak unto the children of Israel, saying: This shall be a holy anointing oil unto Me throughout your generations."
-          },
+          "en": "And thou shalt speak unto the children of Israel, saying: This shall be a holy anointing oil unto Me throughout your generations.",
           "ref": "exodus 30:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "Upon the flesh of man shall it not be poured, neither shall ye make any like it, according to the composition thereof; it is holy, and it shall be holy unto you."
-          },
+          "en": "Upon the flesh of man shall it not be poured, neither shall ye make any like it, according to the composition thereof; it is holy, and it shall be holy unto you.",
           "ref": "exodus 30:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "Whosoever compoundeth any like it, or whosoever putteth any of it upon a stranger, he shall be cut off from his people.’"
-          },
+          "en": "Whosoever compoundeth any like it, or whosoever putteth any of it upon a stranger, he shall be cut off from his people.’",
           "ref": "exodus 30:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Take unto thee sweet spices, stacte, and onycha, and galbanum; sweet spices with pure frankincense; of each shall there be a like weight."
-          },
+          "en": "And the LORD said unto Moses: ‘Take unto thee sweet spices, stacte, and onycha, and galbanum; sweet spices with pure frankincense; of each shall there be a like weight.",
           "ref": "exodus 30:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt make of it incense, a perfume after the art of the perfumer, seasoned with salt, pure and holy."
-          },
+          "en": "And thou shalt make of it incense, a perfume after the art of the perfumer, seasoned with salt, pure and holy.",
           "ref": "exodus 30:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt beat some of it very small, and put of it before the testimony in the tent of meeting, where I will meet with thee; it shall be unto you most holy. ."
-          },
+          "en": "And thou shalt beat some of it very small, and put of it before the testimony in the tent of meeting, where I will meet with thee; it shall be unto you most holy. .",
           "ref": "exodus 30:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": null,
-            "jps1917": "And the incense which thou shalt make, according to the composition thereof ye shall not make for yourselves; it shall be unto thee holy for the LORD."
-          },
+          "en": "And the incense which thou shalt make, according to the composition thereof ye shall not make for yourselves; it shall be unto thee holy for the LORD.",
           "ref": "exodus 30:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": null,
-            "jps1917": "Whosoever shall make like unto that, to smell thereof, he shall be cut off from his people.’"
-          },
+          "en": "Whosoever shall make like unto that, to smell thereof, he shall be cut off from his people.’",
           "ref": "exodus 30:38"
         }
       ]
@@ -7237,146 +4582,92 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses, saying:"
-          },
+          "en": "And the LORD spoke unto Moses, saying:",
           "ref": "exodus 31:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "’See, I have called by name Bezalel the son of Uri, the son of Hur, of the tribe of Judah;"
-          },
+          "en": "’See, I have called by name Bezalel the son of Uri, the son of Hur, of the tribe of Judah;",
           "ref": "exodus 31:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "and I have filled him with the spirit of God, in wisdom, and in understanding, and in knowledge, and in all manner of workmanship,"
-          },
+          "en": "and I have filled him with the spirit of God, in wisdom, and in understanding, and in knowledge, and in all manner of workmanship,",
           "ref": "exodus 31:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "to devise skilful works, to work in gold, and in silver, and in brass,"
-          },
+          "en": "to devise skilful works, to work in gold, and in silver, and in brass,",
           "ref": "exodus 31:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "and in cutting of stones for setting, and in carving of wood, to work in all manner of workmanship."
-          },
+          "en": "and in cutting of stones for setting, and in carving of wood, to work in all manner of workmanship.",
           "ref": "exodus 31:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And I, behold, I have appointed with him Oholiab, the son of Ahisamach, of the tribe of Dan; and in the hearts of all that are wise-hearted I have put wisdom, that they may make all that I have commanded thee:"
-          },
+          "en": "And I, behold, I have appointed with him Oholiab, the son of Ahisamach, of the tribe of Dan; and in the hearts of all that are wise-hearted I have put wisdom, that they may make all that I have commanded thee:",
           "ref": "exodus 31:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "the tent of meeting, and the ark of the testimony, and the ark-cover that is thereupon, and all the furniture of the Tent;"
-          },
+          "en": "the tent of meeting, and the ark of the testimony, and the ark-cover that is thereupon, and all the furniture of the Tent;",
           "ref": "exodus 31:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "and the table and its vessels, and the pure candlestick with all its vessels, and the altar of incense;"
-          },
+          "en": "and the table and its vessels, and the pure candlestick with all its vessels, and the altar of incense;",
           "ref": "exodus 31:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "and the altar of burnt-offering with all its vessels, and the laver and its base;"
-          },
+          "en": "and the altar of burnt-offering with all its vessels, and the laver and its base;",
           "ref": "exodus 31:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "and the plaited garments, and the holy garments for Aaron the priest, and the garments of his sons, to minister in the priest’s office;"
-          },
+          "en": "and the plaited garments, and the holy garments for Aaron the priest, and the garments of his sons, to minister in the priest’s office;",
           "ref": "exodus 31:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "and the anointing oil, and the incense of sweet spices for the holy place; according to all that I have commanded thee shall they do.’"
-          },
+          "en": "and the anointing oil, and the incense of sweet spices for the holy place; according to all that I have commanded thee shall they do.’",
           "ref": "exodus 31:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses, saying:"
-          },
+          "en": "And the LORD spoke unto Moses, saying:",
           "ref": "exodus 31:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "’Speak thou also unto the children of Israel, saying: Verily ye shall keep My sabbaths, for it is a sign between Me and you throughout your generations, that ye may know that I am the LORD who sanctify you."
-          },
+          "en": "’Speak thou also unto the children of Israel, saying: Verily ye shall keep My sabbaths, for it is a sign between Me and you throughout your generations, that ye may know that I am the LORD who sanctify you.",
           "ref": "exodus 31:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "Ye shall keep the sabbath therefore, for it is holy unto you; every one that profaneth it shall surely be put to death; for whosoever doeth any work therein, that soul shall be cut off from among his people."
-          },
+          "en": "Ye shall keep the sabbath therefore, for it is holy unto you; every one that profaneth it shall surely be put to death; for whosoever doeth any work therein, that soul shall be cut off from among his people.",
           "ref": "exodus 31:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "Six days shall work be done; but on the seventh day is a sabbath of solemn rest, holy to the LORD; whosoever doeth any work in the sabbath day, he shall surely be put to death."
-          },
+          "en": "Six days shall work be done; but on the seventh day is a sabbath of solemn rest, holy to the LORD; whosoever doeth any work in the sabbath day, he shall surely be put to death.",
           "ref": "exodus 31:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "Wherefore the children of Israel shall keep the sabbath, to observe the sabbath throughout their generations, for a perpetual covenant."
-          },
+          "en": "Wherefore the children of Israel shall keep the sabbath, to observe the sabbath throughout their generations, for a perpetual covenant.",
           "ref": "exodus 31:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "It is a sign between Me and the children of Israel for ever; for in six days the LORD made heaven and earth, and on the seventh day He ceased from work and rested.’"
-          },
+          "en": "It is a sign between Me and the children of Israel for ever; for in six days the LORD made heaven and earth, and on the seventh day He ceased from work and rested.’",
           "ref": "exodus 31:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And He gave unto Moses, when He had made an end of speaking with him upon mount Sinai, the two tables of the testimony, tables of stone, written with the finger of God."
-          },
+          "en": "And He gave unto Moses, when He had made an end of speaking with him upon mount Sinai, the two tables of the testimony, tables of stone, written with the finger of God.",
           "ref": "exodus 31:18"
         }
       ]
@@ -7386,282 +4677,177 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": "...",
-            "jps1917": "And when the people saw that Moses delayed to come down from the mount, the people gathered themselves together unto Aaron, and said unto him: ‘Up, make us a god who shall go before us; for as for this Moses, the man that brought us up out of the land of Egypt, we know not what is become of him.’"
-          },
+          "en": "And when the people saw that Moses delayed to come down from the mount, the people gathered themselves together unto Aaron, and said unto him: ‘Up, make us a god who shall go before us; for as for this Moses, the man that brought us up out of the land of Egypt, we know not what is become of him.’",
           "ref": "exodus 32:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Aaron said unto them: ‘Break off the golden rings, which are in the ears of your wives, of your sons, and of your daughters, and bring them unto me.’"
-          },
+          "en": "And Aaron said unto them: ‘Break off the golden rings, which are in the ears of your wives, of your sons, and of your daughters, and bring them unto me.’",
           "ref": "exodus 32:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And all the people broke off the golden rings which were in their ears, and brought them unto Aaron."
-          },
+          "en": "And all the people broke off the golden rings which were in their ears, and brought them unto Aaron.",
           "ref": "exodus 32:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And he received it at their hand, and fashioned it with a graving tool, and made it a molten calf; and they said: ‘This is thy god, O Israel, which brought thee up out of the land of Egypt.’"
-          },
+          "en": "And he received it at their hand, and fashioned it with a graving tool, and made it a molten calf; and they said: ‘This is thy god, O Israel, which brought thee up out of the land of Egypt.’",
           "ref": "exodus 32:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Aaron saw this, he built an altar before it; and Aaron made proclamation, and said: ‘To-morrow shall be a feast to the LORD.’"
-          },
+          "en": "And when Aaron saw this, he built an altar before it; and Aaron made proclamation, and said: ‘To-morrow shall be a feast to the LORD.’",
           "ref": "exodus 32:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And they rose up early on the morrow, and offered burnt-offerings, and brought peace-offerings; and the people sat down to eat and to drink, and rose up to make merry."
-          },
+          "en": "And they rose up early on the morrow, and offered burnt-offerings, and brought peace-offerings; and the people sat down to eat and to drink, and rose up to make merry.",
           "ref": "exodus 32:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses: ‘Go, get thee down; for thy people, that thou broughtest up out of the land of Egypt, have dealt corruptly;"
-          },
+          "en": "And the LORD spoke unto Moses: ‘Go, get thee down; for thy people, that thou broughtest up out of the land of Egypt, have dealt corruptly;",
           "ref": "exodus 32:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "they have turned aside quickly out of the way which I commanded them; they have made them a molten calf, and have worshipped it, and have sacrificed unto it, and said: This is thy god, O Israel, which brought thee up out of the land of Egypt.’"
-          },
+          "en": "they have turned aside quickly out of the way which I commanded them; they have made them a molten calf, and have worshipped it, and have sacrificed unto it, and said: This is thy god, O Israel, which brought thee up out of the land of Egypt.’",
           "ref": "exodus 32:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘I have seen this people, and, behold, it is a stiffnecked people."
-          },
+          "en": "And the LORD said unto Moses: ‘I have seen this people, and, behold, it is a stiffnecked people.",
           "ref": "exodus 32:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "Now therefore let Me alone, that My wrath may wax hot against them, and that I may consume them; and I will make of thee a great nation.’"
-          },
+          "en": "Now therefore let Me alone, that My wrath may wax hot against them, and that I may consume them; and I will make of thee a great nation.’",
           "ref": "exodus 32:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses besought the LORD his God, and said: ‘LORD, why doth Thy wrath wax hot against Thy people, that Thou hast brought forth out of the land of Egypt with great power and with a mighty hand?"
-          },
+          "en": "And Moses besought the LORD his God, and said: ‘LORD, why doth Thy wrath wax hot against Thy people, that Thou hast brought forth out of the land of Egypt with great power and with a mighty hand?",
           "ref": "exodus 32:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "Wherefore should the Egyptians speak, saying: For evil did He bring them forth, to slay them in the mountains, and to consume them from the face of the earth? Turn from Thy fierce wrath, and repent of this evil against Thy people."
-          },
+          "en": "Wherefore should the Egyptians speak, saying: For evil did He bring them forth, to slay them in the mountains, and to consume them from the face of the earth? Turn from Thy fierce wrath, and repent of this evil against Thy people.",
           "ref": "exodus 32:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "Remember Abraham, Isaac, and Israel, Thy servants, to whom Thou didst swear by Thine own self, and saidst unto them: I will multiply your seed as the stars of heaven, and all this land that I have spoken of will I give unto your seed, and they shall inherit it for ever.’"
-          },
+          "en": "Remember Abraham, Isaac, and Israel, Thy servants, to whom Thou didst swear by Thine own self, and saidst unto them: I will multiply your seed as the stars of heaven, and all this land that I have spoken of will I give unto your seed, and they shall inherit it for ever.’",
           "ref": "exodus 32:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD repented of the evil which He said He would do unto His people."
-          },
+          "en": "And the LORD repented of the evil which He said He would do unto His people.",
           "ref": "exodus 32:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses turned, and went down from the mount, with the two tables of the testimony in his hand; tables that were written on both their sides; on the one side and on the other were they written."
-          },
+          "en": "And Moses turned, and went down from the mount, with the two tables of the testimony in his hand; tables that were written on both their sides; on the one side and on the other were they written.",
           "ref": "exodus 32:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And the tables were the work of God, and the writing was the writing of God, graven upon the tables."
-          },
+          "en": "And the tables were the work of God, and the writing was the writing of God, graven upon the tables.",
           "ref": "exodus 32:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Joshua heard the noise of the people as they shouted, he said unto Moses: ‘There is a noise of war in the camp.’"
-          },
+          "en": "And when Joshua heard the noise of the people as they shouted, he said unto Moses: ‘There is a noise of war in the camp.’",
           "ref": "exodus 32:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘It is not the voice of them that shout for mastery, neither is it the voice of them that cry for being overcome, but the noise of them that sing do I hear.’"
-          },
+          "en": "And he said: ‘It is not the voice of them that shout for mastery, neither is it the voice of them that cry for being overcome, but the noise of them that sing do I hear.’",
           "ref": "exodus 32:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, as soon as he came nigh unto the camp, that he saw the calf and the dancing; and Moses’anger waxed hot, and he cast the tables out of his hands, and broke them beneath the mount."
-          },
+          "en": "And it came to pass, as soon as he came nigh unto the camp, that he saw the calf and the dancing; and Moses’anger waxed hot, and he cast the tables out of his hands, and broke them beneath the mount.",
           "ref": "exodus 32:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And he took the calf which they had made, and burnt it with fire, and ground it to powder, and strewed it upon the water, and made the children of Israel drink of it."
-          },
+          "en": "And he took the calf which they had made, and burnt it with fire, and ground it to powder, and strewed it upon the water, and made the children of Israel drink of it.",
           "ref": "exodus 32:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto Aaron: ‘What did this people unto thee, that thou hast brought a great sin upon them?’"
-          },
+          "en": "And Moses said unto Aaron: ‘What did this people unto thee, that thou hast brought a great sin upon them?’",
           "ref": "exodus 32:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And Aaron said: ‘Let not the anger of my lord wax hot; thou knowest the people, that they are set on evil."
-          },
+          "en": "And Aaron said: ‘Let not the anger of my lord wax hot; thou knowest the people, that they are set on evil.",
           "ref": "exodus 32:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "So they said unto me: Make us a god, which shall go before us; for as for this Moses, the man that brought us up out of the land of Egypt, we know not what is become of him."
-          },
+          "en": "So they said unto me: Make us a god, which shall go before us; for as for this Moses, the man that brought us up out of the land of Egypt, we know not what is become of him.",
           "ref": "exodus 32:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And I said unto them: Whosoever hath any gold, let them break it off; so they gave it me; and I cast it into the fire, and there came out this calf.’"
-          },
+          "en": "And I said unto them: Whosoever hath any gold, let them break it off; so they gave it me; and I cast it into the fire, and there came out this calf.’",
           "ref": "exodus 32:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Moses saw that the people were broken loose—for Aaron had let them loose for a derision among their enemies—"
-          },
+          "en": "And when Moses saw that the people were broken loose—for Aaron had let them loose for a derision among their enemies—",
           "ref": "exodus 32:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "then Moses stood in the gate of the camp, and said: ‘Whoso is on the LORD’S side, let him come unto me.’ And all the sons of Levi gathered themselves together unto him."
-          },
+          "en": "then Moses stood in the gate of the camp, and said: ‘Whoso is on the LORD’S side, let him come unto me.’ And all the sons of Levi gathered themselves together unto him.",
           "ref": "exodus 32:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto them: ‘Thus saith the LORD, the God of Israel: Put ye every man his sword upon his thigh, and go to and fro from gate to gate throughout the camp, and slay every man his brother, and every man his companion, and every man his neighbour.’"
-          },
+          "en": "And he said unto them: ‘Thus saith the LORD, the God of Israel: Put ye every man his sword upon his thigh, and go to and fro from gate to gate throughout the camp, and slay every man his brother, and every man his companion, and every man his neighbour.’",
           "ref": "exodus 32:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Levi did according to the word of Moses; and there fell of the people that day about three thousand men."
-          },
+          "en": "And the sons of Levi did according to the word of Moses; and there fell of the people that day about three thousand men.",
           "ref": "exodus 32:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said: ‘Consecrate yourselves to-day to the LORD, for every man hath been against his son and against his brother; that He may also bestow upon you a blessing this day.’"
-          },
+          "en": "And Moses said: ‘Consecrate yourselves to-day to the LORD, for every man hath been against his son and against his brother; that He may also bestow upon you a blessing this day.’",
           "ref": "exodus 32:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass on the morrow, that Moses said unto the people: ‘Ye have sinned a great sin; and now I will go up unto the LORD, peradventure I shall make atonement for your sin.’"
-          },
+          "en": "And it came to pass on the morrow, that Moses said unto the people: ‘Ye have sinned a great sin; and now I will go up unto the LORD, peradventure I shall make atonement for your sin.’",
           "ref": "exodus 32:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses returned unto the LORD, and said: ‘Oh, this people have sinned a great sin, and have made them a god of gold."
-          },
+          "en": "And Moses returned unto the LORD, and said: ‘Oh, this people have sinned a great sin, and have made them a god of gold.",
           "ref": "exodus 32:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "Yet now, if Thou wilt forgive their sin—; and if not, blot me, I pray Thee, out of Thy book which Thou hast written.’"
-          },
+          "en": "Yet now, if Thou wilt forgive their sin—; and if not, blot me, I pray Thee, out of Thy book which Thou hast written.’",
           "ref": "exodus 32:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Whosoever hath sinned against Me, him will I blot out of My book."
-          },
+          "en": "And the LORD said unto Moses: ‘Whosoever hath sinned against Me, him will I blot out of My book.",
           "ref": "exodus 32:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And now go, lead the people unto the place of which I have spoken unto thee; behold, Mine angel shall go before thee; nevertheless in the day when I visit, I will visit their sin upon them.’"
-          },
+          "en": "And now go, lead the people unto the place of which I have spoken unto thee; behold, Mine angel shall go before thee; nevertheless in the day when I visit, I will visit their sin upon them.’",
           "ref": "exodus 32:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD smote the people, because they made the calf, which Aaron made."
-          },
+          "en": "And the LORD smote the people, because they made the calf, which Aaron made.",
           "ref": "exodus 32:35"
         }
       ]
@@ -7671,186 +4857,117 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses: ‘Depart, go up hence, thou and the people that thou hast brought up out of the land of Egypt, unto the land of which I swore unto Abraham, to Isaac, and to Jacob, saying: Unto thy seed will I give it—"
-          },
+          "en": "And the LORD spoke unto Moses: ‘Depart, go up hence, thou and the people that thou hast brought up out of the land of Egypt, unto the land of which I swore unto Abraham, to Isaac, and to Jacob, saying: Unto thy seed will I give it—",
           "ref": "exodus 33:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "and I will send an angel before thee; and I will drive out the Canaanite, the Amorite, and the Hittite, and the Perizzite, the Hivite, and the Jebusite—"
-          },
+          "en": "and I will send an angel before thee; and I will drive out the Canaanite, the Amorite, and the Hittite, and the Perizzite, the Hivite, and the Jebusite—",
           "ref": "exodus 33:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "unto a land flowing with milk and honey; for I will not go up in the midst of thee; for thou art a stiffnecked people; lest I consume thee in the way.’"
-          },
+          "en": "unto a land flowing with milk and honey; for I will not go up in the midst of thee; for thou art a stiffnecked people; lest I consume thee in the way.’",
           "ref": "exodus 33:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And when the people heard these evil tidings, they mourned; and no man did put on him his ornaments."
-          },
+          "en": "And when the people heard these evil tidings, they mourned; and no man did put on him his ornaments.",
           "ref": "exodus 33:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Say unto the children of Israel: Ye are a stiffnecked people; if I go up into the midst of thee for one moment, I shall consume thee; therefore now put off thy ornaments from thee, that I may know what to do unto thee.’"
-          },
+          "en": "And the LORD said unto Moses: ‘Say unto the children of Israel: Ye are a stiffnecked people; if I go up into the midst of thee for one moment, I shall consume thee; therefore now put off thy ornaments from thee, that I may know what to do unto thee.’",
           "ref": "exodus 33:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And the children of Israel stripped themselves of their ornaments from mount Horeb onward."
-          },
+          "en": "And the children of Israel stripped themselves of their ornaments from mount Horeb onward.",
           "ref": "exodus 33:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "Now Moses used to take the tent and to pitch it without the camp, afar off from the camp; and he called it The tent of meeting. And it came to pass, that every one that sought the LORD went out unto the tent of meeting, which was without the camp."
-          },
+          "en": "Now Moses used to take the tent and to pitch it without the camp, afar off from the camp; and he called it The tent of meeting. And it came to pass, that every one that sought the LORD went out unto the tent of meeting, which was without the camp.",
           "ref": "exodus 33:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when Moses went out unto the Tent, that all the people rose up, and stood, every man at his tent door, and looked after Moses, until he was gone into the Tent."
-          },
+          "en": "And it came to pass, when Moses went out unto the Tent, that all the people rose up, and stood, every man at his tent door, and looked after Moses, until he was gone into the Tent.",
           "ref": "exodus 33:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when Moses entered into the Tent, the pillar of cloud descended, and stood at the door of the Tent; and [the LORD] spoke with Moses."
-          },
+          "en": "And it came to pass, when Moses entered into the Tent, the pillar of cloud descended, and stood at the door of the Tent; and [the LORD] spoke with Moses.",
           "ref": "exodus 33:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And when all the people saw the pillar of cloud stand at the door of the Tent, all the people rose up and worshipped, every man at his tent door."
-          },
+          "en": "And when all the people saw the pillar of cloud stand at the door of the Tent, all the people rose up and worshipped, every man at his tent door.",
           "ref": "exodus 33:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses face to face, as a man speaketh unto his friend. And he would return into the camp; but his minister Joshua, the son of Nun, a young man, departed not out of the Tent."
-          },
+          "en": "And the LORD spoke unto Moses face to face, as a man speaketh unto his friend. And he would return into the camp; but his minister Joshua, the son of Nun, a young man, departed not out of the Tent.",
           "ref": "exodus 33:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses said unto the LORD: ‘See, Thou sayest unto me: Bring up this people; and Thou hast not let me know whom Thou wilt send with me. Yet Thou hast said: I know thee by name, and thou hast also found grace in My sight."
-          },
+          "en": "And Moses said unto the LORD: ‘See, Thou sayest unto me: Bring up this people; and Thou hast not let me know whom Thou wilt send with me. Yet Thou hast said: I know thee by name, and thou hast also found grace in My sight.",
           "ref": "exodus 33:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "Now therefore, I pray Thee, if I have found grace in Thy sight, show me now Thy ways, that I may know Thee, to the end that I may find grace in Thy sight; and consider that this nation is Thy people.’"
-          },
+          "en": "Now therefore, I pray Thee, if I have found grace in Thy sight, show me now Thy ways, that I may know Thee, to the end that I may find grace in Thy sight; and consider that this nation is Thy people.’",
           "ref": "exodus 33:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And He said: ‘My presence shall go with thee, and I will give thee rest.’"
-          },
+          "en": "And He said: ‘My presence shall go with thee, and I will give thee rest.’",
           "ref": "exodus 33:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto Him: ‘If Thy presence go not with me, carry us not up hence."
-          },
+          "en": "And he said unto Him: ‘If Thy presence go not with me, carry us not up hence.",
           "ref": "exodus 33:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "For wherein now shall it be known that I have found grace in Thy sight, I and Thy people? is it not in that Thou goest with us, so that we are distinguished, I and Thy people, from all the people that are upon the face of the earth?’"
-          },
+          "en": "For wherein now shall it be known that I have found grace in Thy sight, I and Thy people? is it not in that Thou goest with us, so that we are distinguished, I and Thy people, from all the people that are upon the face of the earth?’",
           "ref": "exodus 33:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘I will do this thing also that thou hast spoken, for thou hast found grace in My sight, and I know thee by name.’"
-          },
+          "en": "And the LORD said unto Moses: ‘I will do this thing also that thou hast spoken, for thou hast found grace in My sight, and I know thee by name.’",
           "ref": "exodus 33:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Show me, I pray Thee, Thy glory.’"
-          },
+          "en": "And he said: ‘Show me, I pray Thee, Thy glory.’",
           "ref": "exodus 33:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And He said: ‘I will make all My goodness pass before thee, and will proclaim the name of the LORD before thee; and I will be gracious to whom I will be gracious, and will show mercy on whom I will show mercy.’"
-          },
+          "en": "And He said: ‘I will make all My goodness pass before thee, and will proclaim the name of the LORD before thee; and I will be gracious to whom I will be gracious, and will show mercy on whom I will show mercy.’",
           "ref": "exodus 33:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And He said: ‘Thou canst not see My face, for man shall not see Me and live.’"
-          },
+          "en": "And He said: ‘Thou canst not see My face, for man shall not see Me and live.’",
           "ref": "exodus 33:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said: ‘Behold, there is a place by Me, and thou shalt stand upon the rock."
-          },
+          "en": "And the LORD said: ‘Behold, there is a place by Me, and thou shalt stand upon the rock.",
           "ref": "exodus 33:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall come to pass, while My glory passeth by, that I will put thee in a cleft of the rock, and will cover thee with My hand until I have passed by."
-          },
+          "en": "And it shall come to pass, while My glory passeth by, that I will put thee in a cleft of the rock, and will cover thee with My hand until I have passed by.",
           "ref": "exodus 33:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will take away My hand, and thou shalt see My back; but My face shall not be seen.’"
-          },
+          "en": "And I will take away My hand, and thou shalt see My back; but My face shall not be seen.’",
           "ref": "exodus 33:23"
         }
       ]
@@ -7860,282 +4977,177 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Hew thee two tables of stone like unto the first; and I will write upon the tables the words that were on the first tables, which thou didst break."
-          },
+          "en": "And the LORD said unto Moses: ‘Hew thee two tables of stone like unto the first; and I will write upon the tables the words that were on the first tables, which thou didst break.",
           "ref": "exodus 34:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And be ready by the morning, and come up in the morning unto mount Sinai, and present thyself there to Me on the top of the mount."
-          },
+          "en": "And be ready by the morning, and come up in the morning unto mount Sinai, and present thyself there to Me on the top of the mount.",
           "ref": "exodus 34:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And no man shall come up with thee, neither let any man be seen throughout all the mount; neither let the flocks nor herds feed before that mount.’"
-          },
+          "en": "And no man shall come up with thee, neither let any man be seen throughout all the mount; neither let the flocks nor herds feed before that mount.’",
           "ref": "exodus 34:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And he hewed two tables of stone like unto the first; and Moses rose up early in the morning, and went up unto mount Sinai, as the LORD had commanded him, and took in his hand two tables of stone."
-          },
+          "en": "And he hewed two tables of stone like unto the first; and Moses rose up early in the morning, and went up unto mount Sinai, as the LORD had commanded him, and took in his hand two tables of stone.",
           "ref": "exodus 34:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD descended in the cloud, and stood with him there, and proclaimed the name of the LORD."
-          },
+          "en": "And the LORD descended in the cloud, and stood with him there, and proclaimed the name of the LORD.",
           "ref": "exodus 34:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD passed by before him, and proclaimed: ‘The LORD, the LORD, God, merciful and gracious, long-suffering, and abundant in goodness and truth;"
-          },
+          "en": "And the LORD passed by before him, and proclaimed: ‘The LORD, the LORD, God, merciful and gracious, long-suffering, and abundant in goodness and truth;",
           "ref": "exodus 34:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "keeping mercy unto the thousandth generation, forgiving iniquity and transgression and sin; and that will by no means clear the guilty; visiting the iniquity of the fathers upon the children, and upon the children’s children, unto the third and unto the fourth generation.’"
-          },
+          "en": "keeping mercy unto the thousandth generation, forgiving iniquity and transgression and sin; and that will by no means clear the guilty; visiting the iniquity of the fathers upon the children, and upon the children’s children, unto the third and unto the fourth generation.’",
           "ref": "exodus 34:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses made haste, and bowed his head toward the earth, and worshipped."
-          },
+          "en": "And Moses made haste, and bowed his head toward the earth, and worshipped.",
           "ref": "exodus 34:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘If now I have found grace in Thy sight, O Lord, let the Lord, I pray Thee, go in the midst of us; for it is a stiffnecked people; and pardon our iniquity and our sin, and take us for Thine inheritance.’"
-          },
+          "en": "And he said: ‘If now I have found grace in Thy sight, O Lord, let the Lord, I pray Thee, go in the midst of us; for it is a stiffnecked people; and pardon our iniquity and our sin, and take us for Thine inheritance.’",
           "ref": "exodus 34:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And He said: ‘Behold, I make a covenant; before all thy people I will do marvels, such as have not been wrought in all the earth, nor in any nation; and all the people among which thou art shall see the work of the LORD that I am about to do with thee, that it is tremendous."
-          },
+          "en": "And He said: ‘Behold, I make a covenant; before all thy people I will do marvels, such as have not been wrought in all the earth, nor in any nation; and all the people among which thou art shall see the work of the LORD that I am about to do with thee, that it is tremendous.",
           "ref": "exodus 34:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "Observe thou that which I am commanding thee this day; behold, I am driving out before thee the Amorite, and the Canaanite, and the Hittite, and the Perizzite, and the Hivite, and the Jebusite."
-          },
+          "en": "Observe thou that which I am commanding thee this day; behold, I am driving out before thee the Amorite, and the Canaanite, and the Hittite, and the Perizzite, and the Hivite, and the Jebusite.",
           "ref": "exodus 34:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "Take heed to thyself, lest thou make a covenant with the inhabitants of the land whither thou goest, lest they be for a snare in the midst of thee."
-          },
+          "en": "Take heed to thyself, lest thou make a covenant with the inhabitants of the land whither thou goest, lest they be for a snare in the midst of thee.",
           "ref": "exodus 34:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "But ye shall break down their altars, and dash in pieces their pillars, and ye shall cut down their Asherim."
-          },
+          "en": "But ye shall break down their altars, and dash in pieces their pillars, and ye shall cut down their Asherim.",
           "ref": "exodus 34:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "For thou shalt bow down to no other god; for the LORD, whose name is Jealous, is a jealous God;"
-          },
+          "en": "For thou shalt bow down to no other god; for the LORD, whose name is Jealous, is a jealous God;",
           "ref": "exodus 34:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "lest thou make a covenant with the inhabitants of the land, and they go astray after their gods, and do sacrifice unto their gods, and they call thee, and thou eat of their sacrifice;"
-          },
+          "en": "lest thou make a covenant with the inhabitants of the land, and they go astray after their gods, and do sacrifice unto their gods, and they call thee, and thou eat of their sacrifice;",
           "ref": "exodus 34:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "and thou take of their daughters unto thy sons, and their daughters go astray after their gods, and make thy sons go astray after their gods."
-          },
+          "en": "and thou take of their daughters unto thy sons, and their daughters go astray after their gods, and make thy sons go astray after their gods.",
           "ref": "exodus 34:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt make thee no molten gods."
-          },
+          "en": "Thou shalt make thee no molten gods.",
           "ref": "exodus 34:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "The feast of unleavened bread shalt thou keep. Seven days thou shalt eat unleavened bread, as I commanded thee, at the time appointed in the month Abib, for in the month Abib thou camest out from Egypt."
-          },
+          "en": "The feast of unleavened bread shalt thou keep. Seven days thou shalt eat unleavened bread, as I commanded thee, at the time appointed in the month Abib, for in the month Abib thou camest out from Egypt.",
           "ref": "exodus 34:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "All that openeth the womb is Mine; and of all thy cattle thou shalt sanctify the males, the firstlings of ox and sheep."
-          },
+          "en": "All that openeth the womb is Mine; and of all thy cattle thou shalt sanctify the males, the firstlings of ox and sheep.",
           "ref": "exodus 34:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And the firstling of an ass thou shalt redeem with a lamb; and if thou wilt not redeem it, then thou shalt break its neck. All the first-born of thy sons thou shalt redeem. And none shall appear before Me empty."
-          },
+          "en": "And the firstling of an ass thou shalt redeem with a lamb; and if thou wilt not redeem it, then thou shalt break its neck. All the first-born of thy sons thou shalt redeem. And none shall appear before Me empty.",
           "ref": "exodus 34:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "Six days thou shalt work, but on the seventh day thou shalt rest; in plowing time and in harvest thou shalt rest."
-          },
+          "en": "Six days thou shalt work, but on the seventh day thou shalt rest; in plowing time and in harvest thou shalt rest.",
           "ref": "exodus 34:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt observe the feast of weeks, even of the first-fruits of wheat harvest, and the feast of ingathering at the turn of the year."
-          },
+          "en": "And thou shalt observe the feast of weeks, even of the first-fruits of wheat harvest, and the feast of ingathering at the turn of the year.",
           "ref": "exodus 34:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "Three times in the year shall all thy males appear before the Lord GOD, the God of Israel."
-          },
+          "en": "Three times in the year shall all thy males appear before the Lord GOD, the God of Israel.",
           "ref": "exodus 34:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "For I will cast out nations before thee, and enlarge thy borders; neither shall any man covet thy land, when thou goest up to appear before the LORD thy God three times in the year."
-          },
+          "en": "For I will cast out nations before thee, and enlarge thy borders; neither shall any man covet thy land, when thou goest up to appear before the LORD thy God three times in the year.",
           "ref": "exodus 34:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt not offer the blood of My sacrifice with leavened bread; neither shall the sacrifice of the feast of the passover be left unto the morning."
-          },
+          "en": "Thou shalt not offer the blood of My sacrifice with leavened bread; neither shall the sacrifice of the feast of the passover be left unto the morning.",
           "ref": "exodus 34:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "The choicest first-fruits of thy land thou shalt bring unto the house of the LORD thy God. Thou shalt not seethe a kid in its mother’s milk.’"
-          },
+          "en": "The choicest first-fruits of thy land thou shalt bring unto the house of the LORD thy God. Thou shalt not seethe a kid in its mother’s milk.’",
           "ref": "exodus 34:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Moses: ‘Write thou these words, for after the tenor of these words I have made a covenant with thee and with Israel.’"
-          },
+          "en": "And the LORD said unto Moses: ‘Write thou these words, for after the tenor of these words I have made a covenant with thee and with Israel.’",
           "ref": "exodus 34:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And he was there with the LORD forty days and forty nights; he did neither eat bread, nor drink water. And he wrote upon the tables the words of the covenant, the ten words."
-          },
+          "en": "And he was there with the LORD forty days and forty nights; he did neither eat bread, nor drink water. And he wrote upon the tables the words of the covenant, the ten words.",
           "ref": "exodus 34:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when Moses came down from mount Sinai with the two tables of the testimony in Moses’hand, when he came down from the mount, that Moses knew not that the skin of his face sent forth abeams while He talked with him."
-          },
+          "en": "And it came to pass, when Moses came down from mount Sinai with the two tables of the testimony in Moses’hand, when he came down from the mount, that Moses knew not that the skin of his face sent forth abeams while He talked with him.",
           "ref": "exodus 34:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Aaron and all the children of Israel saw Moses, behold, the skin of his face sent forth beams; and they were afraid to come nigh him."
-          },
+          "en": "And when Aaron and all the children of Israel saw Moses, behold, the skin of his face sent forth beams; and they were afraid to come nigh him.",
           "ref": "exodus 34:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses called unto them; and Aaron and all the rulers of the congregation returned unto him; and Moses spoke to them."
-          },
+          "en": "And Moses called unto them; and Aaron and all the rulers of the congregation returned unto him; and Moses spoke to them.",
           "ref": "exodus 34:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And afterward all the children of Israel came nigh, and he gave them in commandment all that the LORD had spoken with him in mount Sinai."
-          },
+          "en": "And afterward all the children of Israel came nigh, and he gave them in commandment all that the LORD had spoken with him in mount Sinai.",
           "ref": "exodus 34:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Moses had done speaking with them, he put a veil on his face."
-          },
+          "en": "And when Moses had done speaking with them, he put a veil on his face.",
           "ref": "exodus 34:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "But when Moses went in before the LORD that He might speak with him, he took the veil off, until he came out; and he came out; and spoke unto the children of Israel that which he was commanded."
-          },
+          "en": "But when Moses went in before the LORD that He might speak with him, he took the veil off, until he came out; and he came out; and spoke unto the children of Israel that which he was commanded.",
           "ref": "exodus 34:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And the children of Israel saw the face of Moses, that the skin of Moses’face sent forth beams; and Moses put the veil back upon his face, until he went in to speak with Him."
-          },
+          "en": "And the children of Israel saw the face of Moses, that the skin of Moses’face sent forth beams; and Moses put the veil back upon his face, until he went in to speak with Him.",
           "ref": "exodus 34:35"
         }
       ]
@@ -8145,282 +5157,177 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": "Y Moshe reunió a toda la congregación de los hijos de Yisra᾽el, y les dijo: Estas son las palabras que el Señor ha mandado, que las hagáis.",
-            "jps1917": "And Moses assembled all the congregation of the children of Israel, and said unto them: ‘These are the words which the LORD hath commanded, that ye should do them."
-          },
+          "en": "And Moses assembled all the congregation of the children of Israel, and said unto them: ‘These are the words which the LORD hath commanded, that ye should do them.",
           "ref": "exodus 35:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": "Seis días se trabajará, pero el séptimo día será para vosotros un día santo, un sábado de reposo para el Señor: cualquiera que trabaje en él, morirá.",
-            "jps1917": "Six days shall work be done, but on the seventh day there shall be to you a holy day, a sabbath of solemn rest to the LORD; whosoever doeth any work therein shall be put to death."
-          },
+          "en": "Six days shall work be done, but on the seventh day there shall be to you a holy day, a sabbath of solemn rest to the LORD; whosoever doeth any work therein shall be put to death.",
           "ref": "exodus 35:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": "No encenderéis fuego en vuestras habitaciones en día de reposo.",
-            "jps1917": "Ye shall kindle no fire throughout your habitations upon the sabbath day.’"
-          },
+          "en": "Ye shall kindle no fire throughout your habitations upon the sabbath day.’",
           "ref": "exodus 35:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": "Y Moshe habló a toda la congregación de los hijos de Yisra᾽el, diciendo: Esto es lo que mandó el Señor, diciendo:",
-            "jps1917": "And Moses spoke unto all the congregation of the children of Israel, saying: ‘This is the thing which the LORD commanded, saying:"
-          },
+          "en": "And Moses spoke unto all the congregation of the children of Israel, saying: ‘This is the thing which the LORD commanded, saying:",
           "ref": "exodus 35:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": "Tomad de entre vosotros una ofrenda para el Señor; el que tenga un corazón dispuesto, que la traiga, una ofrenda para el Señor; oro, plata y bronce,",
-            "jps1917": "Take ye from among you an offering unto the LORD, whosoever is of a willing heart, let him bring it, the LORD’S offering: gold, and silver, and brass;"
-          },
+          "en": "Take ye from among you an offering unto the LORD, whosoever is of a willing heart, let him bring it, the LORD’S offering: gold, and silver, and brass;",
           "ref": "exodus 35:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": "azul, púrpura, escarlata, lino fino y pelo de cabra,",
-            "jps1917": "and blue, and purple, and scarlet, and fine linen, and goats’hair;"
-          },
+          "en": "and blue, and purple, and scarlet, and fine linen, and goats’hair;",
           "ref": "exodus 35:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": "y pieles de carnero teñidas de rojo, y pieles de taĥash, y madera de acacia,",
-            "jps1917": "and rams’skins dyed red, and sealskins, and acacia-wood;"
-          },
+          "en": "and rams’skins dyed red, and sealskins, and acacia-wood;",
           "ref": "exodus 35:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": "y aceite para el alumbrado, y especias aromáticas para el aceite de la unción, y para el incienso aromático,",
-            "jps1917": "and oil for the light, and spices for the anointing oil, and for the sweet incense;"
-          },
+          "en": "and oil for the light, and spices for the anointing oil, and for the sweet incense;",
           "ref": "exodus 35:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": "y piedras de shoham, y piedras para engastar para el efod, y para el pectoral.",
-            "jps1917": "and onyx stones, and stones to be set, for the ephod, and for the breastplate."
-          },
+          "en": "and onyx stones, and stones to be set, for the ephod, and for the breastplate.",
           "ref": "exodus 35:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": "Y todo hombre sabio de corazón de entre vosotros vendrá, y hará todo lo que el Eterno ha mandado;",
-            "jps1917": "And let every wise-hearted man among you come, and make all that the LORD hath commanded:"
-          },
+          "en": "And let every wise-hearted man among you come, and make all that the LORD hath commanded:",
           "ref": "exodus 35:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": "el tabernáculo, su tienda, su cubierta, sus cerraduras, sus tablas, sus barras, sus columnas y sus basas,",
-            "jps1917": "the tabernacle, its tent, and its covering, its clasps, and its boards, its bars, its pillars, and its sockets;"
-          },
+          "en": "the tabernacle, its tent, and its covering, its clasps, and its boards, its bars, its pillars, and its sockets;",
           "ref": "exodus 35:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": "el arca y sus varas, con la cubierta y el velo de la pantalla,",
-            "jps1917": "the ark, and the staves thereof, the ark-cover, and the veil of the screen;"
-          },
+          "en": "the ark, and the staves thereof, the ark-cover, and the veil of the screen;",
           "ref": "exodus 35:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": "la mesa y sus varas, y todos sus utensilios, y el pan de la proposición,",
-            "jps1917": "the table, and its staves, and all its vessels, and the showbread;"
-          },
+          "en": "the table, and its staves, and all its vessels, and the showbread;",
           "ref": "exodus 35:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": "también el candelero para el alumbrado, sus vasos y sus lámparas, con el aceite para el alumbrado,",
-            "jps1917": "the candlestick also for the light, and its vessels, and its lamps, and the oil for the light;"
-          },
+          "en": "the candlestick also for the light, and its vessels, and its lamps, and the oil for the light;",
           "ref": "exodus 35:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": "y el altar del incienso, y sus varas, y el aceite de la unción, y el incienso de especias aromáticas, y la cortina para la puerta a la entrada del tabernáculo,",
-            "jps1917": "and the altar of incense, and its staves, and the anointing oil, and the sweet incense, and the screen for the door, at the door of the tabernacle;"
-          },
+          "en": "and the altar of incense, and its staves, and the anointing oil, and the sweet incense, and the screen for the door, at the door of the tabernacle;",
           "ref": "exodus 35:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": "el altar del holocausto, con su rejilla de bronce, sus varas y todos sus utensilios, la fuente y su pedestal,",
-            "jps1917": "the altar of burnt-offering, with its grating of brass, its staves, and all its vessels, the laver and its base;"
-          },
+          "en": "the altar of burnt-offering, with its grating of brass, its staves, and all its vessels, the laver and its base;",
           "ref": "exodus 35:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": "las cortinas del atrio, sus columnas y sus basas, y la cortina para la puerta del atrio,",
-            "jps1917": "the hangings of the court, the pillars thereof, and their sockets, and the screen for the gate of the court;"
-          },
+          "en": "the hangings of the court, the pillars thereof, and their sockets, and the screen for the gate of the court;",
           "ref": "exodus 35:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": "las estacas del tabernáculo, y las estacas del atrio, y sus cuerdas,",
-            "jps1917": "the pins of the tabernacle, and the pins of the court, and their cords;"
-          },
+          "en": "the pins of the tabernacle, and the pins of the court, and their cords;",
           "ref": "exodus 35:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": "las ropas para ministrar en el lugar santo, las vestiduras sagradas para el sacerdote Aarón, y las vestiduras de sus hijos para ministrar en el sacerdocio.",
-            "jps1917": "the plaited garments, for ministering in the holy place, the holy garments for Aaron the priest, and the garments of his sons, to minister in the priest’s office.’"
-          },
+          "en": "the plaited garments, for ministering in the holy place, the holy garments for Aaron the priest, and the garments of his sons, to minister in the priest’s office.’",
           "ref": "exodus 35:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": "Y toda la congregación de los hijos de Yisra᾽el se apartó de la presencia de Moshé.",
-            "jps1917": "And all the congregation of the children of Israel departed from the presence of Moses."
-          },
+          "en": "And all the congregation of the children of Israel departed from the presence of Moses.",
           "ref": "exodus 35:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": "Y vino todo aquel cuyo corazón lo motivó, y todo aquel a quien su espíritu dio voluntad, y trajeron la ofrenda del Señor para la obra de la Tienda de Reunión, y para todo su servicio, y para las vestiduras sagradas.",
-            "jps1917": "And they came, every one whose heart stirred him up, and every one whom his spirit made willing, and brought the LORD’S offering, for the work of the tent of meeting, and for all the service thereof, and for the holy garments. ."
-          },
+          "en": "And they came, every one whose heart stirred him up, and every one whom his spirit made willing, and brought the LORD’S offering, for the work of the tent of meeting, and for all the service thereof, and for the holy garments. .",
           "ref": "exodus 35:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": "Y vinieron, tanto hombres como mujeres, todos los de corazón dispuesto, y trajeron brazaletes y zarcillos y anillos y brazaletes, todas las joyas de oro, y todos los hombres que habían ofrecido una ofrenda de oro al Señor.",
-            "jps1917": "And they came, both men and women, as many as were willing-hearted, and brought nose-rings, and ear-rings, and signet-rings, and girdles, all jewels of gold; even every man that brought an offering of gold unto the LORD."
-          },
+          "en": "And they came, both men and women, as many as were willing-hearted, and brought nose-rings, and ear-rings, and signet-rings, and girdles, all jewels of gold; even every man that brought an offering of gold unto the LORD.",
           "ref": "exodus 35:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": "Y todos los hombres que tenían azul, púrpura, escarlata, lino fino, pelo de cabra, pieles rojas de carnero y pieles de tahash, las trajeron.",
-            "jps1917": "And every man, with whom was found blue, and purple, and scarlet, and fine linen, and goats’hair, and rams’skins dyed red, and sealskins, brought them."
-          },
+          "en": "And every man, with whom was found blue, and purple, and scarlet, and fine linen, and goats’hair, and rams’skins dyed red, and sealskins, brought them.",
           "ref": "exodus 35:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": "Todo el que hacía ofrenda de plata y de bronce traía la ofrenda del Eterno; y todo aquel que tenía madera de acacia para cualquier obra del servicio, la traía.",
-            "jps1917": "Every one that did set apart an offering of silver and brass brought the LORD’S offering; and every man, with whom was found acacia-wood for any work of the service, brought it."
-          },
+          "en": "Every one that did set apart an offering of silver and brass brought the LORD’S offering; and every man, with whom was found acacia-wood for any work of the service, brought it.",
           "ref": "exodus 35:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": "Y todas las mujeres sabias de corazón hilaron con sus manos, y trajeron lo que habían hilado, azul, púrpura, escarlata y lino fino.",
-            "jps1917": "And all the women that were wise-hearted did spin with their hands, and brought that which they had spun, the blue, and the purple, the scarlet, and the fine linen."
-          },
+          "en": "And all the women that were wise-hearted did spin with their hands, and brought that which they had spun, the blue, and the purple, the scarlet, and the fine linen.",
           "ref": "exodus 35:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": "Y todas las mujeres cuyo corazón las impulsó a la sabiduría, hilaron pelo de cabra.",
-            "jps1917": "And all the women whose heart stirred them up in wisdom spun the goats’hair."
-          },
+          "en": "And all the women whose heart stirred them up in wisdom spun the goats’hair.",
           "ref": "exodus 35:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": "Y los príncipes trajeron piedras de shoham, y piedras de engaste, para el efod, y para el pectoral;",
-            "jps1917": "And the rulers brought the onyx stones, and the stones to be set, for the ephod, and for the breastplate;"
-          },
+          "en": "And the rulers brought the onyx stones, and the stones to be set, for the ephod, and for the breastplate;",
           "ref": "exodus 35:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": "y especias aromáticas y aceite: para el alumbrado, y para el aceite de la unción, y para el incienso de especias aromáticas.",
-            "jps1917": "and the spice, and the oil, for the light, and for the anointing oil, and for the sweet incense."
-          },
+          "en": "and the spice, and the oil, for the light, and for the anointing oil, and for the sweet incense.",
           "ref": "exodus 35:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": "Los hijos de Yisra᾽el trajeron una ofrenda voluntaria al Señor, todo hombre y mujer, cuyo corazón los hizo dispuestos a traer para toda clase de trabajo, que el Señor había mandado por mano de Moshé que se hiciera.",
-            "jps1917": "The children of Israel brought a freewill-offering unto the LORD; every man and woman, whose heart made them willing to bring for all the work, which the LORD had commanded by the hand of Moses to be made."
-          },
+          "en": "The children of Israel brought a freewill-offering unto the LORD; every man and woman, whose heart made them willing to bring for all the work, which the LORD had commanded by the hand of Moses to be made.",
           "ref": "exodus 35:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": "Y Moshe dijo a los hijos de Yisra᾽el: Mirad, el Señor ha llamado por nombre a Beżal᾽el hijo de Uri, hijo de Ḥur, de la tribu de Yehuda;",
-            "jps1917": "And Moses said unto the children of Israel: ‘See, the LORD hath called by name Bezalel the son of Uri, the son of Hur, of the tribe of Judah."
-          },
+          "en": "And Moses said unto the children of Israel: ‘See, the LORD hath called by name Bezalel the son of Uri, the son of Hur, of the tribe of Judah.",
           "ref": "exodus 35:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": "y lo ha llenado del espíritu de Dios, en sabiduría, en inteligencia, en ciencia y en todo arte;",
-            "jps1917": "And He hath filled him with the spirit of God, in wisdom, in understanding, and in knowledge, and in all manner of workmanship."
-          },
+          "en": "And He hath filled him with the spirit of God, in wisdom, in understanding, and in knowledge, and in all manner of workmanship.",
           "ref": "exodus 35:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": "y para idear obras de arte, para trabajar en oro, en plata y en bronce,",
-            "jps1917": "And to devise skilful works, to work in gold, and in silver, and in brass,"
-          },
+          "en": "And to devise skilful works, to work in gold, and in silver, and in brass,",
           "ref": "exodus 35:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": "y en el tallado de piedras, para engastarlas, y en el tallado de madera, para hacer toda obra de arte.",
-            "jps1917": "and in cutting of stones for setting, and in carving of wood, to work in all manner of skilful workmanship."
-          },
+          "en": "and in cutting of stones for setting, and in carving of wood, to work in all manner of skilful workmanship.",
           "ref": "exodus 35:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": "Y ha puesto en su corazón que puede enseñar, tanto él como Oholi᾽av, el hijo de Aĥisamakh, de la tribu de Dan.",
-            "jps1917": "And He hath put in his heart that he may teach, both he, and Oholiab, the son of Ahisamach, of the tribe of Dan."
-          },
+          "en": "And He hath put in his heart that he may teach, both he, and Oholiab, the son of Ahisamach, of the tribe of Dan.",
           "ref": "exodus 35:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": "Los ha llenado de sabiduría de corazón, para hacer toda obra, de grabador, de artífice y de bordador, en azul, en púrpura, en escarlata, en lino fino, y en tejedor, aun de los que hacen cualquier obra, y de los que idean obra artística.",
-            "jps1917": "Them hath He filled with wisdom of heart, to work all manner of workmanship, of the craftsman, and of the skilful workman, and of the weaver in colours, in blue, and in purple, in scarlet, and in fine linen, and of the weaver, even of them that do any workmanship, and of those that devise skilful works."
-          },
+          "en": "Them hath He filled with wisdom of heart, to work all manner of workmanship, of the craftsman, and of the skilful workman, and of the weaver in colours, in blue, and in purple, in scarlet, and in fine linen, and of the weaver, even of them that do any workmanship, and of those that devise skilful works.",
           "ref": "exodus 35:35"
         }
       ]
@@ -8430,306 +5337,192 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And Bezalel and Oholiab shall work, and every wise-hearted man, in whom the LORD hath put wisdom and understanding to know how to work all the work for the service of the sanctuary, according to all that the LORD hath commanded.’"
-          },
+          "en": "And Bezalel and Oholiab shall work, and every wise-hearted man, in whom the LORD hath put wisdom and understanding to know how to work all the work for the service of the sanctuary, according to all that the LORD hath commanded.’",
           "ref": "exodus 36:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses called Bezalel and Oholiab, and every wise-hearted man, in whose heart the LORD had put wisdom, even every one whose heart stirred him up to come unto the work to do it."
-          },
+          "en": "And Moses called Bezalel and Oholiab, and every wise-hearted man, in whose heart the LORD had put wisdom, even every one whose heart stirred him up to come unto the work to do it.",
           "ref": "exodus 36:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And they received of Moses all the offering, which the children of Israel had brought for the work of the service of the sanctuary, wherewith to make it. And they brought yet unto him freewill-offerings every morning."
-          },
+          "en": "And they received of Moses all the offering, which the children of Israel had brought for the work of the service of the sanctuary, wherewith to make it. And they brought yet unto him freewill-offerings every morning.",
           "ref": "exodus 36:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And all the wise men, that wrought all the work of the sanctuary, came every man from his work which they wrought."
-          },
+          "en": "And all the wise men, that wrought all the work of the sanctuary, came every man from his work which they wrought.",
           "ref": "exodus 36:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And they spoke unto Moses, saying: ‘The people bring much more than enough for the service of the work, which the LORD commanded to make.’"
-          },
+          "en": "And they spoke unto Moses, saying: ‘The people bring much more than enough for the service of the work, which the LORD commanded to make.’",
           "ref": "exodus 36:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses gave commandment, and they caused it to be proclaimed throughout the camp, saying: ‘Let neither man nor woman make any more work for the offering of the sanctuary.’ So the people were restrained from bringing."
-          },
+          "en": "And Moses gave commandment, and they caused it to be proclaimed throughout the camp, saying: ‘Let neither man nor woman make any more work for the offering of the sanctuary.’ So the people were restrained from bringing.",
           "ref": "exodus 36:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "For the stuff they had was sufficient for all the work to make it, and too much."
-          },
+          "en": "For the stuff they had was sufficient for all the work to make it, and too much.",
           "ref": "exodus 36:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And every wise-hearted man among them that wrought the work made the tabernacle with ten curtains: of fine twined linen, and blue, and purple, and scarlet, with cherubim the work of the skilful workman made he them."
-          },
+          "en": "And every wise-hearted man among them that wrought the work made the tabernacle with ten curtains: of fine twined linen, and blue, and purple, and scarlet, with cherubim the work of the skilful workman made he them.",
           "ref": "exodus 36:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "The length of each curtain was eight and twenty cubits, and the breadth of each curtain four cubits; all the curtains had one measure."
-          },
+          "en": "The length of each curtain was eight and twenty cubits, and the breadth of each curtain four cubits; all the curtains had one measure.",
           "ref": "exodus 36:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And he coupled five curtains one to another; and the other five curtains he coupled one to another."
-          },
+          "en": "And he coupled five curtains one to another; and the other five curtains he coupled one to another.",
           "ref": "exodus 36:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made loops of blue upon the edge of the one curtain that was outmost in the first set; likewise he made in the edge of the curtain that was outmost in the second set."
-          },
+          "en": "And he made loops of blue upon the edge of the one curtain that was outmost in the first set; likewise he made in the edge of the curtain that was outmost in the second set.",
           "ref": "exodus 36:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "Fifty loops made he in the one curtain, and fifty loops made he in the edge of the curtain that was in the second set; the loops were opposite one to another."
-          },
+          "en": "Fifty loops made he in the one curtain, and fifty loops made he in the edge of the curtain that was in the second set; the loops were opposite one to another.",
           "ref": "exodus 36:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made fifty clasps of gold, and coupled the curtains one to another with the clasps; so the tabernacle was one."
-          },
+          "en": "And he made fifty clasps of gold, and coupled the curtains one to another with the clasps; so the tabernacle was one.",
           "ref": "exodus 36:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made curtains of goats’hair for a tent over the tabernacle; eleven curtains he made them."
-          },
+          "en": "And he made curtains of goats’hair for a tent over the tabernacle; eleven curtains he made them.",
           "ref": "exodus 36:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "The length of each curtain was thirty cubits, and four cubits the breadth of each curtain; the eleven curtains had one measure."
-          },
+          "en": "The length of each curtain was thirty cubits, and four cubits the breadth of each curtain; the eleven curtains had one measure.",
           "ref": "exodus 36:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And he coupled five curtains by themselves, and six curtains by themselves."
-          },
+          "en": "And he coupled five curtains by themselves, and six curtains by themselves.",
           "ref": "exodus 36:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made fifty loops on the edge of the curtain that was outmost in the first set, and fifty loops made he upon the edge of the curtain which was outmost in the second set."
-          },
+          "en": "And he made fifty loops on the edge of the curtain that was outmost in the first set, and fifty loops made he upon the edge of the curtain which was outmost in the second set.",
           "ref": "exodus 36:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made fifty clasps of brass to couple the tent together, that it might be one."
-          },
+          "en": "And he made fifty clasps of brass to couple the tent together, that it might be one.",
           "ref": "exodus 36:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made a covering for the tent of rams’skins dyed red, and a covering of sealskins above."
-          },
+          "en": "And he made a covering for the tent of rams’skins dyed red, and a covering of sealskins above.",
           "ref": "exodus 36:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the boards for the tabernacle of acacia-wood, standing up."
-          },
+          "en": "And he made the boards for the tabernacle of acacia-wood, standing up.",
           "ref": "exodus 36:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "Ten cubits was the length of a board, and a cubit and a half the breadth of each board."
-          },
+          "en": "Ten cubits was the length of a board, and a cubit and a half the breadth of each board.",
           "ref": "exodus 36:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "Each board had two tenons, joined one to another. Thus did he make for all the boards of the tabernacle."
-          },
+          "en": "Each board had two tenons, joined one to another. Thus did he make for all the boards of the tabernacle.",
           "ref": "exodus 36:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the boards for the tabernacle; twenty boards for the south side southward."
-          },
+          "en": "And he made the boards for the tabernacle; twenty boards for the south side southward.",
           "ref": "exodus 36:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made forty sockets of silver under the twenty boards: two sockets under one board for its two tenons, and two sockets under another board for its two tenons."
-          },
+          "en": "And he made forty sockets of silver under the twenty boards: two sockets under one board for its two tenons, and two sockets under another board for its two tenons.",
           "ref": "exodus 36:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And for the second side of the tabernacle, on the north side, he made twenty boards,"
-          },
+          "en": "And for the second side of the tabernacle, on the north side, he made twenty boards,",
           "ref": "exodus 36:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "and their forty sockets of silver: two sockets under one board, and two sockets under another board."
-          },
+          "en": "and their forty sockets of silver: two sockets under one board, and two sockets under another board.",
           "ref": "exodus 36:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And for the hinder part of the tabernacle westward he made six boards."
-          },
+          "en": "And for the hinder part of the tabernacle westward he made six boards.",
           "ref": "exodus 36:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And two boards made he for the corners of the tabernacle in the hinder part;"
-          },
+          "en": "And two boards made he for the corners of the tabernacle in the hinder part;",
           "ref": "exodus 36:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "that they might be double beneath, and in like manner they should be complete unto the top thereof unto the first ring. Thus he did to both of them in the two corners."
-          },
+          "en": "that they might be double beneath, and in like manner they should be complete unto the top thereof unto the first ring. Thus he did to both of them in the two corners.",
           "ref": "exodus 36:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And there were eight boards, and their sockets of silver, sixteen sockets: under every board two sockets."
-          },
+          "en": "And there were eight boards, and their sockets of silver, sixteen sockets: under every board two sockets.",
           "ref": "exodus 36:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made bars of acacia-wood: five for the boards of the one side of the tabernacle,"
-          },
+          "en": "And he made bars of acacia-wood: five for the boards of the one side of the tabernacle,",
           "ref": "exodus 36:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "and five bars for the boards of the other side of the tabernacle, and five bars for the boards of the tabernacle for the hinder part westward."
-          },
+          "en": "and five bars for the boards of the other side of the tabernacle, and five bars for the boards of the tabernacle for the hinder part westward.",
           "ref": "exodus 36:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the middle bar to pass through in the midst of the boards from the one end to the other."
-          },
+          "en": "And he made the middle bar to pass through in the midst of the boards from the one end to the other.",
           "ref": "exodus 36:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And he overlaid the boards with gold, and made their rings of gold for holders for the bars, and overlaid the bars with gold."
-          },
+          "en": "And he overlaid the boards with gold, and made their rings of gold for holders for the bars, and overlaid the bars with gold.",
           "ref": "exodus 36:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the veil of blue, and purple, and scarlet, and fine twined linen; with the cherubim the work of the skilful workman made he it."
-          },
+          "en": "And he made the veil of blue, and purple, and scarlet, and fine twined linen; with the cherubim the work of the skilful workman made he it.",
           "ref": "exodus 36:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made thereunto four pillars of acacia, and overlaid them with gold, their hooks being of gold; and he cast for them four sockets of silver."
-          },
+          "en": "And he made thereunto four pillars of acacia, and overlaid them with gold, their hooks being of gold; and he cast for them four sockets of silver.",
           "ref": "exodus 36:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made a screen for the door of the Tent, of blue, and purple, and scarlet, and fine twined linen, the work of the weaver in colours;"
-          },
+          "en": "And he made a screen for the door of the Tent, of blue, and purple, and scarlet, and fine twined linen, the work of the weaver in colours;",
           "ref": "exodus 36:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": null,
-            "jps1917": "and the five pillars of it with their hooks; and he overlaid their capitals and their fillets with gold; and their five sockets were of brass."
-          },
+          "en": "and the five pillars of it with their hooks; and he overlaid their capitals and their fillets with gold; and their five sockets were of brass.",
           "ref": "exodus 36:38"
         }
       ]
@@ -8739,234 +5532,147 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And Bezalel made the ark of acacia-wood: two cubits and a half was the length of it, and a cubit and a half the breadth of it, and a cubit and a half the height of it."
-          },
+          "en": "And Bezalel made the ark of acacia-wood: two cubits and a half was the length of it, and a cubit and a half the breadth of it, and a cubit and a half the height of it.",
           "ref": "exodus 37:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And he overlaid it with pure gold within and without, and made a crown of gold to it round about."
-          },
+          "en": "And he overlaid it with pure gold within and without, and made a crown of gold to it round about.",
           "ref": "exodus 37:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And he cast for it four rings of gold, in the four feet thereof: even two rings on the one side of it, and two rings on the other side of it."
-          },
+          "en": "And he cast for it four rings of gold, in the four feet thereof: even two rings on the one side of it, and two rings on the other side of it.",
           "ref": "exodus 37:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made staves of acacia-wood, and overlaid them with gold."
-          },
+          "en": "And he made staves of acacia-wood, and overlaid them with gold.",
           "ref": "exodus 37:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And he put the staves into the rings on the sides of the ark, to bear the ark."
-          },
+          "en": "And he put the staves into the rings on the sides of the ark, to bear the ark.",
           "ref": "exodus 37:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made an ark-cover of pure gold: two cubits and a half was the length thereof, and a cubit and a half the breadth thereof."
-          },
+          "en": "And he made an ark-cover of pure gold: two cubits and a half was the length thereof, and a cubit and a half the breadth thereof.",
           "ref": "exodus 37:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made two cherubim of gold: of beaten work made he them, at the two ends of the ark-cover:"
-          },
+          "en": "And he made two cherubim of gold: of beaten work made he them, at the two ends of the ark-cover:",
           "ref": "exodus 37:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "one cherub at the one end, and one cherub at the other end; of one piece with the ark-cover made he the cherubim at the two ends thereof."
-          },
+          "en": "one cherub at the one end, and one cherub at the other end; of one piece with the ark-cover made he the cherubim at the two ends thereof.",
           "ref": "exodus 37:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And the cherubim spread out their wings on high, screening the ark-cover with their wings, with their faces one to another; toward the ark-cover were the faces of the cherubim."
-          },
+          "en": "And the cherubim spread out their wings on high, screening the ark-cover with their wings, with their faces one to another; toward the ark-cover were the faces of the cherubim.",
           "ref": "exodus 37:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the table of acacia-wood: two cubits was the length thereof, and a cubit the breadth thereof, and a cubit and a half the height thereof."
-          },
+          "en": "And he made the table of acacia-wood: two cubits was the length thereof, and a cubit the breadth thereof, and a cubit and a half the height thereof.",
           "ref": "exodus 37:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And he overlaid it with pure gold, and made thereto a crown of gold round about."
-          },
+          "en": "And he overlaid it with pure gold, and made thereto a crown of gold round about.",
           "ref": "exodus 37:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made unto it a border of a hand-breadth round about, and made a golden crown to the border thereof round about."
-          },
+          "en": "And he made unto it a border of a hand-breadth round about, and made a golden crown to the border thereof round about.",
           "ref": "exodus 37:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And he cast for it four rings of gold, and put the rings in the four corners that were on the four feet thereof."
-          },
+          "en": "And he cast for it four rings of gold, and put the rings in the four corners that were on the four feet thereof.",
           "ref": "exodus 37:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "Close by the border were the rings, the holders for the staves to bear the table."
-          },
+          "en": "Close by the border were the rings, the holders for the staves to bear the table.",
           "ref": "exodus 37:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the staves of acacia-wood, and overlaid them with gold, to bear the table."
-          },
+          "en": "And he made the staves of acacia-wood, and overlaid them with gold, to bear the table.",
           "ref": "exodus 37:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the vessels which were upon the table, the dishes thereof, and the pans thereof, and the bowls thereof, and the jars thereof, wherewith to pour out, of pure gold."
-          },
+          "en": "And he made the vessels which were upon the table, the dishes thereof, and the pans thereof, and the bowls thereof, and the jars thereof, wherewith to pour out, of pure gold.",
           "ref": "exodus 37:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the candlestick of pure gold: of beaten work made he the candlestick, even its base, and its shaft; its cups, its knops, and its flowers, were of one piece with it."
-          },
+          "en": "And he made the candlestick of pure gold: of beaten work made he the candlestick, even its base, and its shaft; its cups, its knops, and its flowers, were of one piece with it.",
           "ref": "exodus 37:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And there were six branches going out of the sides thereof: three branches of the candlestick out of the one side thereof, and three branches of the candlestick out of the other side thereof;"
-          },
+          "en": "And there were six branches going out of the sides thereof: three branches of the candlestick out of the one side thereof, and three branches of the candlestick out of the other side thereof;",
           "ref": "exodus 37:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "three cups made like almond-blossoms in one branch, a knop and a flower; and three cups made like almond-blossoms in the other branch, a knop and a flower. So for the six branches going out of the candlestick."
-          },
+          "en": "three cups made like almond-blossoms in one branch, a knop and a flower; and three cups made like almond-blossoms in the other branch, a knop and a flower. So for the six branches going out of the candlestick.",
           "ref": "exodus 37:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And in the candlestick were four cups made like almond-blossoms, the knops thereof, and the flowers thereof;"
-          },
+          "en": "And in the candlestick were four cups made like almond-blossoms, the knops thereof, and the flowers thereof;",
           "ref": "exodus 37:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "and a knop under two branches of one piece with it, and a knop under two branches of one piece with it, and a knop under two branches of one piece with it, for the six branches going out of it."
-          },
+          "en": "and a knop under two branches of one piece with it, and a knop under two branches of one piece with it, and a knop under two branches of one piece with it, for the six branches going out of it.",
           "ref": "exodus 37:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "Their knops and their branches were of one piece with it; the whole of it was one beaten work of pure gold."
-          },
+          "en": "Their knops and their branches were of one piece with it; the whole of it was one beaten work of pure gold.",
           "ref": "exodus 37:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the lamps thereof, seven, and the tongs thereof, and the snuffdishes thereof, of pure gold."
-          },
+          "en": "And he made the lamps thereof, seven, and the tongs thereof, and the snuffdishes thereof, of pure gold.",
           "ref": "exodus 37:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "Of a talent of pure gold made he it, and all the vessels thereof."
-          },
+          "en": "Of a talent of pure gold made he it, and all the vessels thereof.",
           "ref": "exodus 37:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the altar of incense of acacia-wood: a cubit was the length thereof, and a cubit the breadth thereof, four-square; and two cubits was the height thereof; the horns thereof were of one piece with it."
-          },
+          "en": "And he made the altar of incense of acacia-wood: a cubit was the length thereof, and a cubit the breadth thereof, four-square; and two cubits was the height thereof; the horns thereof were of one piece with it.",
           "ref": "exodus 37:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And he overlaid it with pure gold, the top thereof, and the sides thereof round about, and the horns of it; and he made unto it a crown of gold round about."
-          },
+          "en": "And he overlaid it with pure gold, the top thereof, and the sides thereof round about, and the horns of it; and he made unto it a crown of gold round about.",
           "ref": "exodus 37:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made for it two golden rings under the crown thereof, upon the two ribs thereof, upon the two sides of it, for holders for staves wherewith to bear it."
-          },
+          "en": "And he made for it two golden rings under the crown thereof, upon the two ribs thereof, upon the two sides of it, for holders for staves wherewith to bear it.",
           "ref": "exodus 37:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the staves of acacia-wood, and overlaid them with gold."
-          },
+          "en": "And he made the staves of acacia-wood, and overlaid them with gold.",
           "ref": "exodus 37:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the holy anointing oil, and the pure incense of sweet spices, after the art of the perfumer."
-          },
+          "en": "And he made the holy anointing oil, and the pure incense of sweet spices, after the art of the perfumer.",
           "ref": "exodus 37:29"
         }
       ]
@@ -8976,250 +5682,157 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the altar of burnt-offering of acacia-wood: five cubits was the length thereof, and five cubits the breadth thereof, four-square, and three cubits the height thereof."
-          },
+          "en": "And he made the altar of burnt-offering of acacia-wood: five cubits was the length thereof, and five cubits the breadth thereof, four-square, and three cubits the height thereof.",
           "ref": "exodus 38:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the horns thereof upon the four corners of it; the horns thereof were of one piece with it; and he overlaid it with brass."
-          },
+          "en": "And he made the horns thereof upon the four corners of it; the horns thereof were of one piece with it; and he overlaid it with brass.",
           "ref": "exodus 38:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made all the vessels of the altar, the pots, and the shovels, and the basins, the flesh-hooks, and the fire-pans; all the vessels thereof made he of brass."
-          },
+          "en": "And he made all the vessels of the altar, the pots, and the shovels, and the basins, the flesh-hooks, and the fire-pans; all the vessels thereof made he of brass.",
           "ref": "exodus 38:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made for the altar a grating of network of brass, under the ledge round it beneath, reaching halfway up."
-          },
+          "en": "And he made for the altar a grating of network of brass, under the ledge round it beneath, reaching halfway up.",
           "ref": "exodus 38:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And he cast four rings for the four ends of the grating of brass, to be holders for the staves."
-          },
+          "en": "And he cast four rings for the four ends of the grating of brass, to be holders for the staves.",
           "ref": "exodus 38:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the staves of acacia-wood, and overlaid them with brass."
-          },
+          "en": "And he made the staves of acacia-wood, and overlaid them with brass.",
           "ref": "exodus 38:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And he put the staves into the rings on the sides of the altar, wherewith to bear it; he made it hollow with planks."
-          },
+          "en": "And he put the staves into the rings on the sides of the altar, wherewith to bear it; he made it hollow with planks.",
           "ref": "exodus 38:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the laver of brass, and the base thereof of brass, of the mirrors of the serving women that did service at the door of the tent of meeting."
-          },
+          "en": "And he made the laver of brass, and the base thereof of brass, of the mirrors of the serving women that did service at the door of the tent of meeting.",
           "ref": "exodus 38:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the court; for the south side southward the hangings of the court were of fine twined linen, a hundred cubits."
-          },
+          "en": "And he made the court; for the south side southward the hangings of the court were of fine twined linen, a hundred cubits.",
           "ref": "exodus 38:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "Their pillars were twenty, and their sockets twenty, of brass; the hooks of the pillars and their fillets were of silver."
-          },
+          "en": "Their pillars were twenty, and their sockets twenty, of brass; the hooks of the pillars and their fillets were of silver.",
           "ref": "exodus 38:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And for the north side a hundred cubits, their pillars twenty, and their sockets twenty, of brass; the hooks of the pillars and their fillets of silver."
-          },
+          "en": "And for the north side a hundred cubits, their pillars twenty, and their sockets twenty, of brass; the hooks of the pillars and their fillets of silver.",
           "ref": "exodus 38:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And for the west side were hangings of fifty cubits, their pillars ten, and their sockets ten; the hooks of the pillars and their fillets of silver."
-          },
+          "en": "And for the west side were hangings of fifty cubits, their pillars ten, and their sockets ten; the hooks of the pillars and their fillets of silver.",
           "ref": "exodus 38:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And for the east side eastward fifty cubits."
-          },
+          "en": "And for the east side eastward fifty cubits.",
           "ref": "exodus 38:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "The hangings for the one side [of the gate] were fifteen cubits; their pillars three, and their sockets three."
-          },
+          "en": "The hangings for the one side [of the gate] were fifteen cubits; their pillars three, and their sockets three.",
           "ref": "exodus 38:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And so for the other side; on this hand and that hand by the gate of the court were hangings of fifteen cubits; their pillars three, and their sockets three."
-          },
+          "en": "And so for the other side; on this hand and that hand by the gate of the court were hangings of fifteen cubits; their pillars three, and their sockets three.",
           "ref": "exodus 38:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "All the hangings of the court round about were of fine twined linen."
-          },
+          "en": "All the hangings of the court round about were of fine twined linen.",
           "ref": "exodus 38:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sockets for the pillars were of brass; the hooks of the pillars and their fillets of silver; and the overlaying of their capitals of silver; and all the pillars of the court were filleted with silver."
-          },
+          "en": "And the sockets for the pillars were of brass; the hooks of the pillars and their fillets of silver; and the overlaying of their capitals of silver; and all the pillars of the court were filleted with silver.",
           "ref": "exodus 38:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And the screen for the gate of the court was the work of the weaver in colours, of blue, and purple, and scarlet, and fine twined linen; and twenty cubits was the length, and the height in the breadth was five cubits, answerable to the hangings of the court."
-          },
+          "en": "And the screen for the gate of the court was the work of the weaver in colours, of blue, and purple, and scarlet, and fine twined linen; and twenty cubits was the length, and the height in the breadth was five cubits, answerable to the hangings of the court.",
           "ref": "exodus 38:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And their pillars were four, and their sockets four of brass; their hooks of silver, and the overlaying of their capitals and their fillets of silver."
-          },
+          "en": "And their pillars were four, and their sockets four of brass; their hooks of silver, and the overlaying of their capitals and their fillets of silver.",
           "ref": "exodus 38:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And all the pins of the tabernacle, and of the court round about, were of brass."
-          },
+          "en": "And all the pins of the tabernacle, and of the court round about, were of brass.",
           "ref": "exodus 38:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the accounts of the tabernacle, even the tabernacle of the testimony, as they were rendered according to the commandment of Moses, through the service of the Levites, by the hand of Ithamar, the son of Aaron the priest."
-          },
+          "en": "These are the accounts of the tabernacle, even the tabernacle of the testimony, as they were rendered according to the commandment of Moses, through the service of the Levites, by the hand of Ithamar, the son of Aaron the priest.",
           "ref": "exodus 38:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And Bezalel the son of Uri, the son of Hur, of the tribe of Judah, made all that the LORD commanded Moses."
-          },
+          "en": "And Bezalel the son of Uri, the son of Hur, of the tribe of Judah, made all that the LORD commanded Moses.",
           "ref": "exodus 38:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And with him was Oholiab, the son of Ahisamach, of the tribe of Dan, a craftsman, and a skilful workman, and a weaver in colours, in blue, and in purple, and in scarlet, and fine linen.—"
-          },
+          "en": "And with him was Oholiab, the son of Ahisamach, of the tribe of Dan, a craftsman, and a skilful workman, and a weaver in colours, in blue, and in purple, and in scarlet, and fine linen.—",
           "ref": "exodus 38:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "All the gold that was used for the work in all the work of the sanctuary, even the gold of the offering, was twenty and nine talents, and seven hundred and thirty shekels, after the shekel of the sanctuary."
-          },
+          "en": "All the gold that was used for the work in all the work of the sanctuary, even the gold of the offering, was twenty and nine talents, and seven hundred and thirty shekels, after the shekel of the sanctuary.",
           "ref": "exodus 38:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And the silver of them that were numbered of the congregation was a hundred talents, and a thousand seven hundred and three-score and fifteen shekels, after the shekel of the sanctuary:"
-          },
+          "en": "And the silver of them that were numbered of the congregation was a hundred talents, and a thousand seven hundred and three-score and fifteen shekels, after the shekel of the sanctuary:",
           "ref": "exodus 38:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "a beka a head, that is, half a shekel, after the shekel of the sanctuary, for every one that passed over to them that are numbered, from twenty years old and upward, for six hundred thousand and three thousand and five hundred and fifty men."
-          },
+          "en": "a beka a head, that is, half a shekel, after the shekel of the sanctuary, for every one that passed over to them that are numbered, from twenty years old and upward, for six hundred thousand and three thousand and five hundred and fifty men.",
           "ref": "exodus 38:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And the hundred talents of silver were for casting the sockets of the sanctuary, and the sockets of the veil: a hundred sockets for the hundred talents, a talent for a socket."
-          },
+          "en": "And the hundred talents of silver were for casting the sockets of the sanctuary, and the sockets of the veil: a hundred sockets for the hundred talents, a talent for a socket.",
           "ref": "exodus 38:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And of the thousand seven hundred seventy and five shekels he made hooks for the pillars, and overlaid their capitals, and made fillets for them."
-          },
+          "en": "And of the thousand seven hundred seventy and five shekels he made hooks for the pillars, and overlaid their capitals, and made fillets for them.",
           "ref": "exodus 38:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And the brass of the offering was seventy talents and two thousand and four hundred shekels."
-          },
+          "en": "And the brass of the offering was seventy talents and two thousand and four hundred shekels.",
           "ref": "exodus 38:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And therewith he made the sockets to the door of the tent of meeting, and the brazen altar, and the brazen grating for it, and all the vessels of the altar,"
-          },
+          "en": "And therewith he made the sockets to the door of the tent of meeting, and the brazen altar, and the brazen grating for it, and all the vessels of the altar,",
           "ref": "exodus 38:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "and the sockets of the court round about, and the sockets of the gate of the court, and all the pins of the tabernacle, and all the pins of the court round about."
-          },
+          "en": "and the sockets of the court round about, and the sockets of the gate of the court, and all the pins of the tabernacle, and all the pins of the court round about.",
           "ref": "exodus 38:31"
         }
       ]
@@ -9229,346 +5842,217 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And of the blue, and purple, and scarlet, they made plaited garments, for ministering in the holy place, and made the holy garments for Aaron, as the LORD commanded Moses."
-          },
+          "en": "And of the blue, and purple, and scarlet, they made plaited garments, for ministering in the holy place, and made the holy garments for Aaron, as the LORD commanded Moses.",
           "ref": "exodus 39:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the ephod of gold, blue, and purple, and scarlet, and fine twined linen."
-          },
+          "en": "And he made the ephod of gold, blue, and purple, and scarlet, and fine twined linen.",
           "ref": "exodus 39:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And they did beat the gold into thin plates, and cut it into threads, to work it in the blue, and in the purple, and in the scarlet, and in the fine linen, the work of the skilful workman."
-          },
+          "en": "And they did beat the gold into thin plates, and cut it into threads, to work it in the blue, and in the purple, and in the scarlet, and in the fine linen, the work of the skilful workman.",
           "ref": "exodus 39:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "They made shoulder-pieces for it, joined together; at the two ends was it joined together."
-          },
+          "en": "They made shoulder-pieces for it, joined together; at the two ends was it joined together.",
           "ref": "exodus 39:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And the skilfully woven band, that was upon it, wherewith to gird it on, was of the same piece and like the work thereof: of gold, of blue, and purple, and scarlet, and fine twined linen, as the LORD commanded Moses."
-          },
+          "en": "And the skilfully woven band, that was upon it, wherewith to gird it on, was of the same piece and like the work thereof: of gold, of blue, and purple, and scarlet, and fine twined linen, as the LORD commanded Moses.",
           "ref": "exodus 39:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And they wrought the onyx stones, inclosed in settings of gold, graven with the engravings of a signet, according to the names of the children of Israel."
-          },
+          "en": "And they wrought the onyx stones, inclosed in settings of gold, graven with the engravings of a signet, according to the names of the children of Israel.",
           "ref": "exodus 39:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And he put them on the shoulder-pieces of the ephod, to be stones of memorial for the children of Israel, as the LORD commanded Moses."
-          },
+          "en": "And he put them on the shoulder-pieces of the ephod, to be stones of memorial for the children of Israel, as the LORD commanded Moses.",
           "ref": "exodus 39:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the breastplate, the work of the skilful workman, like the work of the ephod: of gold, of blue, and purple, and scarlet, and fine twined linen."
-          },
+          "en": "And he made the breastplate, the work of the skilful workman, like the work of the ephod: of gold, of blue, and purple, and scarlet, and fine twined linen.",
           "ref": "exodus 39:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "It was four-square; they made the breastplate double; a span was the length thereof, and a span the breadth thereof, being double."
-          },
+          "en": "It was four-square; they made the breastplate double; a span was the length thereof, and a span the breadth thereof, being double.",
           "ref": "exodus 39:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And they set in it four rows of stones: a row of carnelian, topaz, and smaragd was the first row."
-          },
+          "en": "And they set in it four rows of stones: a row of carnelian, topaz, and smaragd was the first row.",
           "ref": "exodus 39:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And the second row, a carbuncle, a sapphire, and an emerald."
-          },
+          "en": "And the second row, a carbuncle, a sapphire, and an emerald.",
           "ref": "exodus 39:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And the third row, a jacinth, an agate, and an amethyst."
-          },
+          "en": "And the third row, a jacinth, an agate, and an amethyst.",
           "ref": "exodus 39:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And the fourth row, a beryl, an onyx, and a jasper; they were inclosed in fittings of gold in their settings."
-          },
+          "en": "And the fourth row, a beryl, an onyx, and a jasper; they were inclosed in fittings of gold in their settings.",
           "ref": "exodus 39:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And the stones were according to the names of the children of Israel, twelve, according to their names, like the engravings of a signet, every one according to his name, for the twelve tribes."
-          },
+          "en": "And the stones were according to the names of the children of Israel, twelve, according to their names, like the engravings of a signet, every one according to his name, for the twelve tribes.",
           "ref": "exodus 39:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And they made upon the breastplate plaited chains, of wreathen work of pure gold."
-          },
+          "en": "And they made upon the breastplate plaited chains, of wreathen work of pure gold.",
           "ref": "exodus 39:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And they made two settings of gold, and two gold rings; and put the two rings on the two ends of the breastplate."
-          },
+          "en": "And they made two settings of gold, and two gold rings; and put the two rings on the two ends of the breastplate.",
           "ref": "exodus 39:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And they put the two wreathen chains of gold on the two rings at the ends of the breastplate."
-          },
+          "en": "And they put the two wreathen chains of gold on the two rings at the ends of the breastplate.",
           "ref": "exodus 39:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And the other two ends of the two wreathen chains they put on the two settings, and put them on the shoulder-pieces of the ephod, in the forepart thereof."
-          },
+          "en": "And the other two ends of the two wreathen chains they put on the two settings, and put them on the shoulder-pieces of the ephod, in the forepart thereof.",
           "ref": "exodus 39:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And they made two rings of gold, and put them upon the two ends of the breastplate, upon the edge thereof, which was toward the side of the ephod inward."
-          },
+          "en": "And they made two rings of gold, and put them upon the two ends of the breastplate, upon the edge thereof, which was toward the side of the ephod inward.",
           "ref": "exodus 39:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And they made two rings of gold, and put them on the two shoulder-pieces of the ephod underneath, in the forepart thereof, close by the coupling thereof, above the skilfully woven band of the ephod."
-          },
+          "en": "And they made two rings of gold, and put them on the two shoulder-pieces of the ephod underneath, in the forepart thereof, close by the coupling thereof, above the skilfully woven band of the ephod.",
           "ref": "exodus 39:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And they did bind the breastplate by the rings thereof unto the rings of the ephod with a thread of blue, that it might be upon the skilfully woven band of the ephod, and that the breastplate might not be loosed from the ephod; as the LORD commanded Moses."
-          },
+          "en": "And they did bind the breastplate by the rings thereof unto the rings of the ephod with a thread of blue, that it might be upon the skilfully woven band of the ephod, and that the breastplate might not be loosed from the ephod; as the LORD commanded Moses.",
           "ref": "exodus 39:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the robe of the ephod of woven work, all of blue;"
-          },
+          "en": "And he made the robe of the ephod of woven work, all of blue;",
           "ref": "exodus 39:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "and the hole of the robe in the midst thereof, as the hole of a coat of mail, with a binding round about the hole of it, that it should not be rent."
-          },
+          "en": "and the hole of the robe in the midst thereof, as the hole of a coat of mail, with a binding round about the hole of it, that it should not be rent.",
           "ref": "exodus 39:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And they made upon the skirts of the robe pomegranates of blue, and purple, and scarlet, and twined linen."
-          },
+          "en": "And they made upon the skirts of the robe pomegranates of blue, and purple, and scarlet, and twined linen.",
           "ref": "exodus 39:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And they made bells of pure gold, and put the bells between the pomegranates upon the skirts of the robe round about, between the pomegranates:"
-          },
+          "en": "And they made bells of pure gold, and put the bells between the pomegranates upon the skirts of the robe round about, between the pomegranates:",
           "ref": "exodus 39:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "a bell and a pomegranate, a bell and a pomegranate, upon the skirts of the robe round about, to minister in; as the LORD commanded Moses."
-          },
+          "en": "a bell and a pomegranate, a bell and a pomegranate, upon the skirts of the robe round about, to minister in; as the LORD commanded Moses.",
           "ref": "exodus 39:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And they made the tunics of fine linen of woven work for Aaron, and for his sons,"
-          },
+          "en": "And they made the tunics of fine linen of woven work for Aaron, and for his sons,",
           "ref": "exodus 39:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "and the mitre of fine linen, and the goodly head-tires of fine linen, and the linen breeches of fine twined linen,"
-          },
+          "en": "and the mitre of fine linen, and the goodly head-tires of fine linen, and the linen breeches of fine twined linen,",
           "ref": "exodus 39:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "and the girdle of fine twined linen, and blue, and purple, and scarlet, the work of the weaver in colours; as the LORD commanded Moses."
-          },
+          "en": "and the girdle of fine twined linen, and blue, and purple, and scarlet, the work of the weaver in colours; as the LORD commanded Moses.",
           "ref": "exodus 39:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And they made the plate of the holy crown of pure gold, and wrote upon it a writing, like the engravings of a signet: HOLY TO THE LORD."
-          },
+          "en": "And they made the plate of the holy crown of pure gold, and wrote upon it a writing, like the engravings of a signet: HOLY TO THE LORD.",
           "ref": "exodus 39:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And they tied unto it a thread of blue, to fasten it upon the mitre above; as the LORD commanded Moses."
-          },
+          "en": "And they tied unto it a thread of blue, to fasten it upon the mitre above; as the LORD commanded Moses.",
           "ref": "exodus 39:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "Thus was finished all the work of the tabernacle of the tent of meeting; and the children of Israel did according to all that the LORD commanded Moses, so did they."
-          },
+          "en": "Thus was finished all the work of the tabernacle of the tent of meeting; and the children of Israel did according to all that the LORD commanded Moses, so did they.",
           "ref": "exodus 39:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And they brought the tabernacle unto Moses, the Tent, and all its furniture, its clasps, its boards, its bars, and its pillars, and its sockets;"
-          },
+          "en": "And they brought the tabernacle unto Moses, the Tent, and all its furniture, its clasps, its boards, its bars, and its pillars, and its sockets;",
           "ref": "exodus 39:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "and the covering of rams’skins dyed red, and the covering of sealskins, and the veil of the screen;"
-          },
+          "en": "and the covering of rams’skins dyed red, and the covering of sealskins, and the veil of the screen;",
           "ref": "exodus 39:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "the ark of the testimony, and the staves thereof, and the ark-cover;"
-          },
+          "en": "the ark of the testimony, and the staves thereof, and the ark-cover;",
           "ref": "exodus 39:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "the table, all the vessels thereof, and the showbread;"
-          },
+          "en": "the table, all the vessels thereof, and the showbread;",
           "ref": "exodus 39:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": null,
-            "jps1917": "the pure candlestick, the lamps thereof, even the lamps to be set in order, and all the vessels thereof, and the oil for the light;"
-          },
+          "en": "the pure candlestick, the lamps thereof, even the lamps to be set in order, and all the vessels thereof, and the oil for the light;",
           "ref": "exodus 39:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": null,
-            "jps1917": "and the golden altar, and the anointing oil, and the sweet incense, and the screen for the door of the Tent;"
-          },
+          "en": "and the golden altar, and the anointing oil, and the sweet incense, and the screen for the door of the Tent;",
           "ref": "exodus 39:38"
         },
         {
           "n": 39,
-          "en": {
-            "sct": null,
-            "jps1917": "the brazen altar, and its grating of brass, its staves, and all its vessels, the laver and its base;"
-          },
+          "en": "the brazen altar, and its grating of brass, its staves, and all its vessels, the laver and its base;",
           "ref": "exodus 39:39"
         },
         {
           "n": 40,
-          "en": {
-            "sct": null,
-            "jps1917": "the hangings of the court, its pillars, and its sockets, and the screen for the gate of the court, the cords thereof, and the pins thereof, and all the instruments of the service of the tabernacle of the tent of meeting;"
-          },
+          "en": "the hangings of the court, its pillars, and its sockets, and the screen for the gate of the court, the cords thereof, and the pins thereof, and all the instruments of the service of the tabernacle of the tent of meeting;",
           "ref": "exodus 39:40"
         },
         {
           "n": 41,
-          "en": {
-            "sct": null,
-            "jps1917": "the plaited garments for ministering in the holy place; the holy garments for Aaron the priest, and the garments of his sons, to minister in the priest’s office."
-          },
+          "en": "the plaited garments for ministering in the holy place; the holy garments for Aaron the priest, and the garments of his sons, to minister in the priest’s office.",
           "ref": "exodus 39:41"
         },
         {
           "n": 42,
-          "en": {
-            "sct": null,
-            "jps1917": "According to all that the LORD commanded Moses, so the children of Israel did all the work."
-          },
+          "en": "According to all that the LORD commanded Moses, so the children of Israel did all the work.",
           "ref": "exodus 39:42"
         },
         {
           "n": 43,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses saw all the work, and, behold, they had done it; as the LORD had commanded, even so had they done it. And Moses blessed them."
-          },
+          "en": "And Moses saw all the work, and, behold, they had done it; as the LORD had commanded, even so had they done it. And Moses blessed them.",
           "ref": "exodus 39:43"
         }
       ]
@@ -9578,306 +6062,192 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD spoke unto Moses, saying:"
-          },
+          "en": "And the LORD spoke unto Moses, saying:",
           "ref": "exodus 40:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "’On the first day of the first month shalt thou rear up the tabernacle of the tent of meeting."
-          },
+          "en": "’On the first day of the first month shalt thou rear up the tabernacle of the tent of meeting.",
           "ref": "exodus 40:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt put therein the ark of the testimony, and thou shalt screen the ark with the veil."
-          },
+          "en": "And thou shalt put therein the ark of the testimony, and thou shalt screen the ark with the veil.",
           "ref": "exodus 40:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt bring in the table, and set in order the bread that is upon it; and thou shalt bring in the candlestick, and light the lamps thereof."
-          },
+          "en": "And thou shalt bring in the table, and set in order the bread that is upon it; and thou shalt bring in the candlestick, and light the lamps thereof.",
           "ref": "exodus 40:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt set the golden altar for incense before the ark of the testimony, and put the screen of the door to the tabernacle."
-          },
+          "en": "And thou shalt set the golden altar for incense before the ark of the testimony, and put the screen of the door to the tabernacle.",
           "ref": "exodus 40:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt set the altar of burnt-offering before the door of the tabernacle of the tent of meeting."
-          },
+          "en": "And thou shalt set the altar of burnt-offering before the door of the tabernacle of the tent of meeting.",
           "ref": "exodus 40:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt set the laver between the tent of meeting and the altar, and shalt put water therein."
-          },
+          "en": "And thou shalt set the laver between the tent of meeting and the altar, and shalt put water therein.",
           "ref": "exodus 40:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt set up the court round about, and hang up the screen of the gate of the court."
-          },
+          "en": "And thou shalt set up the court round about, and hang up the screen of the gate of the court.",
           "ref": "exodus 40:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt take the anointing oil, and anoint the tabernacle, and all that is therein, and shalt hallow it, and all the furniture thereof; and it shall be holy."
-          },
+          "en": "And thou shalt take the anointing oil, and anoint the tabernacle, and all that is therein, and shalt hallow it, and all the furniture thereof; and it shall be holy.",
           "ref": "exodus 40:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt anoint the altar of burnt-offering, and all its vessels, and sanctify the altar; and the altar shall be most holy."
-          },
+          "en": "And thou shalt anoint the altar of burnt-offering, and all its vessels, and sanctify the altar; and the altar shall be most holy.",
           "ref": "exodus 40:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt anoint the laver and its base, and sanctify it."
-          },
+          "en": "And thou shalt anoint the laver and its base, and sanctify it.",
           "ref": "exodus 40:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt bring Aaron and his sons unto the door of the tent of meeting, and shalt wash them with water."
-          },
+          "en": "And thou shalt bring Aaron and his sons unto the door of the tent of meeting, and shalt wash them with water.",
           "ref": "exodus 40:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt put upon Aaron the holy garments; and thou shalt anoint him, and sanctify him, that he may minister unto Me in the priest’s office."
-          },
+          "en": "And thou shalt put upon Aaron the holy garments; and thou shalt anoint him, and sanctify him, that he may minister unto Me in the priest’s office.",
           "ref": "exodus 40:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt bring his sons, and put tunics upon them."
-          },
+          "en": "And thou shalt bring his sons, and put tunics upon them.",
           "ref": "exodus 40:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt anoint them, as thou didst anoint their father, that they may minister unto Me in the priest’s office; and their anointing shall be to them for an everlasting priesthood throughout their generations.’"
-          },
+          "en": "And thou shalt anoint them, as thou didst anoint their father, that they may minister unto Me in the priest’s office; and their anointing shall be to them for an everlasting priesthood throughout their generations.’",
           "ref": "exodus 40:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "Thus did Moses; according to all that the LORD commanded him, so did he."
-          },
+          "en": "Thus did Moses; according to all that the LORD commanded him, so did he.",
           "ref": "exodus 40:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass in the first month in the second year, on the first day of the month, that the tabernacle was reared up."
-          },
+          "en": "And it came to pass in the first month in the second year, on the first day of the month, that the tabernacle was reared up.",
           "ref": "exodus 40:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses reared up the tabernacle, and laid its sockets, and set up the boards thereof, and put in the bars thereof, and reared up its pillars."
-          },
+          "en": "And Moses reared up the tabernacle, and laid its sockets, and set up the boards thereof, and put in the bars thereof, and reared up its pillars.",
           "ref": "exodus 40:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And he spread the tent over the tabernacle, and put the covering of the tent above upon it; as the LORD commanded Moses."
-          },
+          "en": "And he spread the tent over the tabernacle, and put the covering of the tent above upon it; as the LORD commanded Moses.",
           "ref": "exodus 40:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And he took and put the testimony into the ark, and set the staves on the ark, and put the ark-cover above upon the ark."
-          },
+          "en": "And he took and put the testimony into the ark, and set the staves on the ark, and put the ark-cover above upon the ark.",
           "ref": "exodus 40:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And he brought the ark into the tabernacle, and set up the veil of the screen, and screened the ark of the testimony; as the LORD commanded Moses."
-          },
+          "en": "And he brought the ark into the tabernacle, and set up the veil of the screen, and screened the ark of the testimony; as the LORD commanded Moses.",
           "ref": "exodus 40:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And he put the table in the tent of meeting, upon the side of the tabernacle northward, without the veil."
-          },
+          "en": "And he put the table in the tent of meeting, upon the side of the tabernacle northward, without the veil.",
           "ref": "exodus 40:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And he set a row of bread in order upon it before the LORD; as the LORD commanded Moses."
-          },
+          "en": "And he set a row of bread in order upon it before the LORD; as the LORD commanded Moses.",
           "ref": "exodus 40:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And he put the candlestick in the tent of meeting, over against the table, on the side of the tabernacle southward."
-          },
+          "en": "And he put the candlestick in the tent of meeting, over against the table, on the side of the tabernacle southward.",
           "ref": "exodus 40:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And he lighted the lamps before the LORD; as the LORD commanded Moses."
-          },
+          "en": "And he lighted the lamps before the LORD; as the LORD commanded Moses.",
           "ref": "exodus 40:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And he put the golden altar in the tent of meeting before the veil;"
-          },
+          "en": "And he put the golden altar in the tent of meeting before the veil;",
           "ref": "exodus 40:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "and he burnt thereon incense of sweet spices; as the LORD commanded Moses."
-          },
+          "en": "and he burnt thereon incense of sweet spices; as the LORD commanded Moses.",
           "ref": "exodus 40:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And he put the screen of the door to the tabernacle."
-          },
+          "en": "And he put the screen of the door to the tabernacle.",
           "ref": "exodus 40:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And the altar of burnt-offering he set at the door of the tabernacle of the tent of meeting, and offered upon it the burnt-offering and the meal-offering; as the LORD commanded Moses."
-          },
+          "en": "And the altar of burnt-offering he set at the door of the tabernacle of the tent of meeting, and offered upon it the burnt-offering and the meal-offering; as the LORD commanded Moses.",
           "ref": "exodus 40:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And he set the laver between the tent of meeting and the altar, and put water therein, wherewith to wash;"
-          },
+          "en": "And he set the laver between the tent of meeting and the altar, and put water therein, wherewith to wash;",
           "ref": "exodus 40:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "that Moses and Aaron and his sons might wash their hands and their feet thereat;"
-          },
+          "en": "that Moses and Aaron and his sons might wash their hands and their feet thereat;",
           "ref": "exodus 40:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "when they went into the tent of meeting, and when they came near unto the altar, they should wash; as the LORD commanded Moses."
-          },
+          "en": "when they went into the tent of meeting, and when they came near unto the altar, they should wash; as the LORD commanded Moses.",
           "ref": "exodus 40:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And he reared up the court round about the tabernacle and the altar, and set up the screen of the gate of the court. So Moses finished the work."
-          },
+          "en": "And he reared up the court round about the tabernacle and the altar, and set up the screen of the gate of the court. So Moses finished the work.",
           "ref": "exodus 40:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "Then the cloud covered the tent of meeting, and the glory of the LORD filled the tabernacle."
-          },
+          "en": "Then the cloud covered the tent of meeting, and the glory of the LORD filled the tabernacle.",
           "ref": "exodus 40:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And Moses was not able to enter into the tent of meeting, because the cloud abode thereon, and the glory of the LORD filled the tabernacle.—"
-          },
+          "en": "And Moses was not able to enter into the tent of meeting, because the cloud abode thereon, and the glory of the LORD filled the tabernacle.—",
           "ref": "exodus 40:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "And whenever the cloud was taken up from over the tabernacle, the children of Israel went onward, throughout all their journeys."
-          },
+          "en": "And whenever the cloud was taken up from over the tabernacle, the children of Israel went onward, throughout all their journeys.",
           "ref": "exodus 40:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": null,
-            "jps1917": "But if the cloud was not taken up, then they journeyed not till the day that it was taken up."
-          },
+          "en": "But if the cloud was not taken up, then they journeyed not till the day that it was taken up.",
           "ref": "exodus 40:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": null,
-            "jps1917": "For the cloud of the LORD was upon the tabernacle by day, and there was fire therein by night, in the sight of all the house of Israel, throughout all their journeys.—"
-          },
+          "en": "For the cloud of the LORD was upon the tabernacle by day, and there was fire therein by night, in the sight of all the house of Israel, throughout all their journeys.—",
           "ref": "exodus 40:38"
         }
       ]

--- a/app/renderer/data/packs/tanakh/en/books/genesis.json
+++ b/app/renderer/data/packs/tanakh/en/books/genesis.json
@@ -7,250 +7,157 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": "1 Em um princípio criou Deus os céus e a terra.",
-            "jps1917": "In the beginning God created the heaven and the earth."
-          },
+          "en": "In the beginning God created the heaven and the earth.",
           "ref": "genesis 1:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "Now the earth was unformed and void, and darkness was upon the face of the deep; and the spirit of God hovered over the face of the waters."
-          },
+          "en": "Now the earth was unformed and void, and darkness was upon the face of the deep; and the spirit of God hovered over the face of the waters.",
           "ref": "genesis 1:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said: ‘Let there be light.’ And there was light."
-          },
+          "en": "And God said: ‘Let there be light.’ And there was light.",
           "ref": "genesis 1:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And God saw the light, that it was good; and God divided the light from the darkness."
-          },
+          "en": "And God saw the light, that it was good; and God divided the light from the darkness.",
           "ref": "genesis 1:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And God called the light Day, and the darkness He called Night. And there was evening and there was morning, one day."
-          },
+          "en": "And God called the light Day, and the darkness He called Night. And there was evening and there was morning, one day.",
           "ref": "genesis 1:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said: ‘Let there be a firmament in the midst of the waters, and let it divide the waters from the waters.’"
-          },
+          "en": "And God said: ‘Let there be a firmament in the midst of the waters, and let it divide the waters from the waters.’",
           "ref": "genesis 1:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And God made the firmament, and divided the waters which were under the firmament from the waters which were above the firmament; and it was so."
-          },
+          "en": "And God made the firmament, and divided the waters which were under the firmament from the waters which were above the firmament; and it was so.",
           "ref": "genesis 1:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And God called the firmament Heaven. And there was evening and there was morning, a second day."
-          },
+          "en": "And God called the firmament Heaven. And there was evening and there was morning, a second day.",
           "ref": "genesis 1:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said: ‘Let the waters under the heaven be gathered together unto one place, and let the dry land appear.’ And it was so."
-          },
+          "en": "And God said: ‘Let the waters under the heaven be gathered together unto one place, and let the dry land appear.’ And it was so.",
           "ref": "genesis 1:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And God called the dry land Earth, and the gathering together of the waters called He Seas; and God saw that it was good."
-          },
+          "en": "And God called the dry land Earth, and the gathering together of the waters called He Seas; and God saw that it was good.",
           "ref": "genesis 1:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said: ‘Let the earth put forth grass, herb yielding seed, and fruit-tree bearing fruit after its kind, wherein is the seed thereof, upon the earth.’ And it was so."
-          },
+          "en": "And God said: ‘Let the earth put forth grass, herb yielding seed, and fruit-tree bearing fruit after its kind, wherein is the seed thereof, upon the earth.’ And it was so.",
           "ref": "genesis 1:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And the earth brought forth grass, herb yielding seed after its kind, and tree bearing fruit, wherein is the seed thereof, after its kind; and God saw that it was good."
-          },
+          "en": "And the earth brought forth grass, herb yielding seed after its kind, and tree bearing fruit, wherein is the seed thereof, after its kind; and God saw that it was good.",
           "ref": "genesis 1:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And there was evening and there was morning, a third day."
-          },
+          "en": "And there was evening and there was morning, a third day.",
           "ref": "genesis 1:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said: ‘Let there be lights in the firmament of the heaven to divide the day from the night; and let them be for signs, and for seasons, and for days and years;"
-          },
+          "en": "And God said: ‘Let there be lights in the firmament of the heaven to divide the day from the night; and let them be for signs, and for seasons, and for days and years;",
           "ref": "genesis 1:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "and let them be for lights in the firmament of the heaven to give light upon the earth.’ And it was so."
-          },
+          "en": "and let them be for lights in the firmament of the heaven to give light upon the earth.’ And it was so.",
           "ref": "genesis 1:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And God made the two great lights: the greater light to rule the day, and the lesser light to rule the night; and the stars."
-          },
+          "en": "And God made the two great lights: the greater light to rule the day, and the lesser light to rule the night; and the stars.",
           "ref": "genesis 1:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And God set them in the firmament of the heaven to give light upon the earth,"
-          },
+          "en": "And God set them in the firmament of the heaven to give light upon the earth,",
           "ref": "genesis 1:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "and to rule over the day and over the night, and to divide the light from the darkness; and God saw that it was good."
-          },
+          "en": "and to rule over the day and over the night, and to divide the light from the darkness; and God saw that it was good.",
           "ref": "genesis 1:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And there was evening and there was morning, a fourth day."
-          },
+          "en": "And there was evening and there was morning, a fourth day.",
           "ref": "genesis 1:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said: ‘Let the waters swarm with swarms of living creatures, and let fowl fly above the earth in the open firmament of heaven.’"
-          },
+          "en": "And God said: ‘Let the waters swarm with swarms of living creatures, and let fowl fly above the earth in the open firmament of heaven.’",
           "ref": "genesis 1:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And God created the great sea-monsters, and every living creature that creepeth, wherewith the waters swarmed, after its kind, and every winged fowl after its kind; and God saw that it was good."
-          },
+          "en": "And God created the great sea-monsters, and every living creature that creepeth, wherewith the waters swarmed, after its kind, and every winged fowl after its kind; and God saw that it was good.",
           "ref": "genesis 1:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And God blessed them, saying: ‘Be fruitful, and multiply, and fill the waters in the seas, and let fowl multiply in the earth.’"
-          },
+          "en": "And God blessed them, saying: ‘Be fruitful, and multiply, and fill the waters in the seas, and let fowl multiply in the earth.’",
           "ref": "genesis 1:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And there was evening and there was morning, a fifth day."
-          },
+          "en": "And there was evening and there was morning, a fifth day.",
           "ref": "genesis 1:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said: ‘Let the earth bring forth the living creature after its kind, cattle, and creeping thing, and beast of the earth after its kind.’ And it was so."
-          },
+          "en": "And God said: ‘Let the earth bring forth the living creature after its kind, cattle, and creeping thing, and beast of the earth after its kind.’ And it was so.",
           "ref": "genesis 1:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And God made the beast of the earth after its kind, and the cattle after their kind, and every thing that creepeth upon the ground after its kind; and God saw that it was good."
-          },
+          "en": "And God made the beast of the earth after its kind, and the cattle after their kind, and every thing that creepeth upon the ground after its kind; and God saw that it was good.",
           "ref": "genesis 1:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said: ‘Let us make man in our image, after our likeness; and let them have dominion over the fish of the sea, and over the fowl of the air, and over the cattle, and over all the earth, and over every creeping thing that creepeth upon the earth.’"
-          },
+          "en": "And God said: ‘Let us make man in our image, after our likeness; and let them have dominion over the fish of the sea, and over the fowl of the air, and over the cattle, and over all the earth, and over every creeping thing that creepeth upon the earth.’",
           "ref": "genesis 1:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And God created man in His own image, in the image of God created He him; male and female created He them."
-          },
+          "en": "And God created man in His own image, in the image of God created He him; male and female created He them.",
           "ref": "genesis 1:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And God blessed them; and God said unto them: ‘Be fruitful, and multiply, and replenish the earth, and subdue it; and have dominion over the fish of the sea, and over the fowl of the air, and over every living thing that creepeth upon the earth.’"
-          },
+          "en": "And God blessed them; and God said unto them: ‘Be fruitful, and multiply, and replenish the earth, and subdue it; and have dominion over the fish of the sea, and over the fowl of the air, and over every living thing that creepeth upon the earth.’",
           "ref": "genesis 1:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said: ‘Behold, I have given you every herb yielding seed, which is upon the face of all the earth, and every tree, in which is the fruit of a tree yielding seed—to you it shall be for food;"
-          },
+          "en": "And God said: ‘Behold, I have given you every herb yielding seed, which is upon the face of all the earth, and every tree, in which is the fruit of a tree yielding seed—to you it shall be for food;",
           "ref": "genesis 1:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "and to every beast of the earth, and to every fowl of the air, and to every thing that creepeth upon the earth, wherein there is a living soul, [I have given] every green herb for food.’ And it was so."
-          },
+          "en": "and to every beast of the earth, and to every fowl of the air, and to every thing that creepeth upon the earth, wherein there is a living soul, [I have given] every green herb for food.’ And it was so.",
           "ref": "genesis 1:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And God saw every thing that He had made, and, behold, it was very good. And there was evening and there was morning, the sixth day."
-          },
+          "en": "And God saw every thing that He had made, and, behold, it was very good. And there was evening and there was morning, the sixth day.",
           "ref": "genesis 1:31"
         }
       ]
@@ -260,202 +167,127 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": "Assim foram concluídos os céus e a terra, e todos os seus elementos.",
-            "jps1917": "And the heaven and the earth were finished, and all the host of them."
-          },
+          "en": "And the heaven and the earth were finished, and all the host of them.",
           "ref": "genesis 2:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": "E Elohim cessou, no sétimo dia, Sua obra que tinha feito, e cessou no sétimo dia de toda Sua obra que tinha feito.",
-            "jps1917": "And on the seventh day God finished His work which He had made; and He rested on the seventh day from all His work which He had made."
-          },
+          "en": "And on the seventh day God finished His work which He had made; and He rested on the seventh day from all His work which He had made.",
           "ref": "genesis 2:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": "E Elohim abençoou o sétimo dia e o santificou, pois Nele cessou de toda a Sua obra que Elohim criara para ser feita.",
-            "jps1917": "And God blessed the seventh day, and hallowed it; because that in it He rested from all His work which God in creating had made."
-          },
+          "en": "And God blessed the seventh day, and hallowed it; because that in it He rested from all His work which God in creating had made.",
           "ref": "genesis 2:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": "Estas são as gerações dos céus e da terra quando foram criados, no dia em que Hashem Elohim fez a terra e os céus.",
-            "jps1917": "These are the generations of the heaven and of the earth when they were created, in the day that the LORD God made earth and heaven."
-          },
+          "en": "These are the generations of the heaven and of the earth when they were created, in the day that the LORD God made earth and heaven.",
           "ref": "genesis 2:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": "E ainda não havia qualquer arbusto do campo na terra, e ainda não tinha brotado qualquer erva do campo, pois Hashem Elohim não tinha feito chover sobre a terra, e não havia homem para trabalhar o solo.",
-            "jps1917": "No shrub of the field was yet in the earth, and no herb of the field had yet sprung up; for the LORD God had not caused it to rain upon the earth, and there was not a man to till the ground;"
-          },
+          "en": "No shrub of the field was yet in the earth, and no herb of the field had yet sprung up; for the LORD God had not caused it to rain upon the earth, and there was not a man to till the ground;",
           "ref": "genesis 2:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": "E uma névoa subia da terra e regava toda a face do solo.",
-            "jps1917": "but there went up a mist from the earth, and watered the whole face of the ground."
-          },
+          "en": "but there went up a mist from the earth, and watered the whole face of the ground.",
           "ref": "genesis 2:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": "E Hashem Elohim formou o homem do pó da terra, e soprou em suas narinas o sopro de vida, e o homem tornou-se uma alma vivente.",
-            "jps1917": "Then the LORD God formed man of the dust of the ground, and breathed into his nostrils the breath of life; and man became a living soul."
-          },
+          "en": "Then the LORD God formed man of the dust of the ground, and breathed into his nostrils the breath of life; and man became a living soul.",
           "ref": "genesis 2:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": "E Hashem Elohim plantou um jardim em Eden, para o oriente, e colocou ali o homem que Ele formara.",
-            "jps1917": "And the LORD God planted a garden eastward, in Eden; and there He put the man whom He had formed."
-          },
+          "en": "And the LORD God planted a garden eastward, in Eden; and there He put the man whom He had formed.",
           "ref": "genesis 2:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": "E Hashem Elohim fez brotar da terra toda árvore agradável à vista e boa para alimento, e a árvore da vida no meio do jardim, e a árvore do conhecimento do bem e do mal.",
-            "jps1917": "And out of the ground made the LORD God to grow every tree that is pleasant to the sight, and good for food; the tree of life also in the midst of the garden, and the tree of the knowledge of good and evil."
-          },
+          "en": "And out of the ground made the LORD God to grow every tree that is pleasant to the sight, and good for food; the tree of life also in the midst of the garden, and the tree of the knowledge of good and evil.",
           "ref": "genesis 2:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": "E um rio saía de Eden para regar o jardim, e dali se dividia e se tornava em quatro cabeças.",
-            "jps1917": "And a river went out of Eden to water the garden; and from thence it was parted, and became four heads."
-          },
+          "en": "And a river went out of Eden to water the garden; and from thence it was parted, and became four heads.",
           "ref": "genesis 2:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": "O nome de uma é Pishon, que rodeia toda a terra de Chavilá, onde há ouro.",
-            "jps1917": "The name of the first is Pishon; that is it which compasseth the whole land of Havilah, where there is gold;"
-          },
+          "en": "The name of the first is Pishon; that is it which compasseth the whole land of Havilah, where there is gold;",
           "ref": "genesis 2:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": "E o ouro daquela terra é bom, lá também há bdolákh e a pedra shohám.",
-            "jps1917": "and the gold of that land is good; there is bdellium and the onyx stone."
-          },
+          "en": "and the gold of that land is good; there is bdellium and the onyx stone.",
           "ref": "genesis 2:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": "E o nome do segundo rio é Gichon, que rodeia toda a terra de Kush.",
-            "jps1917": "And the name of the second river is Gihon; the same is it that compasseth the whole land of Cush."
-          },
+          "en": "And the name of the second river is Gihon; the same is it that compasseth the whole land of Cush.",
           "ref": "genesis 2:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": "E o nome do terceiro rio é Chidekel, que vai para o leste da Assíria, e o quarto rio é o Perat.",
-            "jps1917": "And the name of the third river is Tigris; that is it which goeth toward the east of Asshur. And the fourth river is the Euphrates."
-          },
+          "en": "And the name of the third river is Tigris; that is it which goeth toward the east of Asshur. And the fourth river is the Euphrates.",
           "ref": "genesis 2:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": "E Hashem Elohim tomou o homem e o colocou no jardim de Eden para cultivá-lo e protegê-lo.",
-            "jps1917": "And the LORD God took the man, and put him into the garden of Eden to dress it and to keep it."
-          },
+          "en": "And the LORD God took the man, and put him into the garden of Eden to dress it and to keep it.",
           "ref": "genesis 2:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": "E Hashem Elohim ordenou ao homem, dizendo: ‘De toda árvore do jardim, certamente poderás comer.",
-            "jps1917": "And the LORD God commanded the man, saying: ‘Of every tree of the garden thou mayest freely eat;"
-          },
+          "en": "And the LORD God commanded the man, saying: ‘Of every tree of the garden thou mayest freely eat;",
           "ref": "genesis 2:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": "Mas da árvore do conhecimento do bem e do mal, dela não comerás, pois no dia em que dela comeres, certamente morrerás.’",
-            "jps1917": "but of the tree of the knowledge of good and evil, thou shalt not eat of it; for in the day that thou eatest thereof thou shalt surely die.’"
-          },
+          "en": "but of the tree of the knowledge of good and evil, thou shalt not eat of it; for in the day that thou eatest thereof thou shalt surely die.’",
           "ref": "genesis 2:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": "E Hashem Elohim disse: ‘Não é bom que o homem esteja só; farei para ele uma ajuda que lhe corresponda.’",
-            "jps1917": "And the LORD God said: ‘It is not good that the man should be alone; I will make him a help meet for him.’"
-          },
+          "en": "And the LORD God said: ‘It is not good that the man should be alone; I will make him a help meet for him.’",
           "ref": "genesis 2:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": "E Hashem Elohim formou, da terra, todos os animais do campo e todas as aves dos céus, e os trouxe ao homem para ver como ele os chamaria; e tudo o que o homem chamasse a cada ser vivente, esse seria seu nome.",
-            "jps1917": "And out of the ground the LORD God formed every beast of the field, and every fowl of the air; and brought them unto the man to see what he would call them; and whatsoever the man would call every living creature, that was to be the name thereof."
-          },
+          "en": "And out of the ground the LORD God formed every beast of the field, and every fowl of the air; and brought them unto the man to see what he would call them; and whatsoever the man would call every living creature, that was to be the name thereof.",
           "ref": "genesis 2:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": "E o homem deu nomes a todo animal doméstico, às aves dos céus e a todos os animais do campo, mas para o homem não encontrou uma ajuda que lhe correspondesse.",
-            "jps1917": "And the man gave names to all cattle, and to the fowl of the air, and to every beast of the field; but for Adam there was not found a help meet for him."
-          },
+          "en": "And the man gave names to all cattle, and to the fowl of the air, and to every beast of the field; but for Adam there was not found a help meet for him.",
           "ref": "genesis 2:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": "Então Hashem Elohim fez cair um sono profundo sobre o homem, e ele dormiu; e Ele tomou um de seus lados e fechou carne em seu lugar.",
-            "jps1917": "And the LORD God caused a deep sleep to fall upon the man, and he slept; and He took one of his ribs, and closed up the place with flesh instead thereof."
-          },
+          "en": "And the LORD God caused a deep sleep to fall upon the man, and he slept; and He took one of his ribs, and closed up the place with flesh instead thereof.",
           "ref": "genesis 2:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": "E Hashem Elohim formou o lado que Ele havia tomado do homem para torná-lo uma mulher, e a trouxe ao homem.",
-            "jps1917": "And the rib, which the LORD God had taken from the man, made He a woman, and brought her unto the man."
-          },
+          "en": "And the rib, which the LORD God had taken from the man, made He a woman, and brought her unto the man.",
           "ref": "genesis 2:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": "E o homem disse: ‘Desta vez, esta é osso dos meus ossos e carne da minha carne; a esta será chamada mulher, pois do homem foi tomada.’",
-            "jps1917": "And the man said: ‘This is now bone of my bones, and flesh of my flesh; she shall be called Woman, because she was taken out of Man.’"
-          },
+          "en": "And the man said: ‘This is now bone of my bones, and flesh of my flesh; she shall be called Woman, because she was taken out of Man.’",
           "ref": "genesis 2:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": "Por isso, deixará o homem seu pai e sua mãe e se unirá à sua mulher, e eles se tornarão uma só carne.",
-            "jps1917": "Therefore shall a man leave his father and his mother, and shall cleave unto his wife, and they shall be one flesh."
-          },
+          "en": "Therefore shall a man leave his father and his mother, and shall cleave unto his wife, and they shall be one flesh.",
           "ref": "genesis 2:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": "E ambos estavam nus, o homem e sua mulher, e não se envergonhavam.",
-            "jps1917": "And they were both naked, the man and his wife, and were not ashamed."
-          },
+          "en": "And they were both naked, the man and his wife, and were not ashamed.",
           "ref": "genesis 2:25"
         }
       ]
@@ -465,194 +297,122 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": "wsss",
-            "jps1917": "Now the serpent was more subtle than any beast of the field which the LORD God had made. And he said unto the woman: ‘Yea, hath God said: Ye shall not eat of any tree of the garden?’"
-          },
+          "en": "Now the serpent was more subtle than any beast of the field which the LORD God had made. And he said unto the woman: ‘Yea, hath God said: Ye shall not eat of any tree of the garden?’",
           "ref": "genesis 3:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And the woman said unto the serpent: ‘Of the fruit of the trees of the garden we may eat;"
-          },
+          "en": "And the woman said unto the serpent: ‘Of the fruit of the trees of the garden we may eat;",
           "ref": "genesis 3:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "but of the fruit of the tree which is in the midst of the garden, God hath said: Ye shall not eat of it, neither shall ye touch it, lest ye die.’"
-          },
+          "en": "but of the fruit of the tree which is in the midst of the garden, God hath said: Ye shall not eat of it, neither shall ye touch it, lest ye die.’",
           "ref": "genesis 3:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And the serpent said unto the woman: ‘Ye shall not surely die;"
-          },
+          "en": "And the serpent said unto the woman: ‘Ye shall not surely die;",
           "ref": "genesis 3:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "for God doth know that in the day ye eat thereof, then your eyes shall be opened, and ye shall be as God, knowing good and evil.’"
-          },
+          "en": "for God doth know that in the day ye eat thereof, then your eyes shall be opened, and ye shall be as God, knowing good and evil.’",
           "ref": "genesis 3:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And when the woman saw that the tree was good for food, and that it was a delight to the eyes, and that the tree was to be desired to make one wise, she took of the fruit thereof, and did eat; and she gave also unto her husband with her, and he did eat."
-          },
+          "en": "And when the woman saw that the tree was good for food, and that it was a delight to the eyes, and that the tree was to be desired to make one wise, she took of the fruit thereof, and did eat; and she gave also unto her husband with her, and he did eat.",
           "ref": "genesis 3:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And the eyes of them both were opened, and they knew that they were naked; and they sewed fig-leaves together, and made themselves girdles."
-          },
+          "en": "And the eyes of them both were opened, and they knew that they were naked; and they sewed fig-leaves together, and made themselves girdles.",
           "ref": "genesis 3:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And they heard the voice of the LORD God walking in the garden toward the cool of the day; and the man and his wife hid themselves from the presence of the LORD God amongst the trees of the garden."
-          },
+          "en": "And they heard the voice of the LORD God walking in the garden toward the cool of the day; and the man and his wife hid themselves from the presence of the LORD God amongst the trees of the garden.",
           "ref": "genesis 3:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD God called unto the man, and said unto him: ‘Where art thou?’"
-          },
+          "en": "And the LORD God called unto the man, and said unto him: ‘Where art thou?’",
           "ref": "genesis 3:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘I heard Thy voice in the garden, and I was afraid, because I was naked; and I hid myself.’"
-          },
+          "en": "And he said: ‘I heard Thy voice in the garden, and I was afraid, because I was naked; and I hid myself.’",
           "ref": "genesis 3:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And He said: ‘Who told thee that thou wast naked? Hast thou eaten of the tree, whereof I commanded thee that thou shouldest not eat?’"
-          },
+          "en": "And He said: ‘Who told thee that thou wast naked? Hast thou eaten of the tree, whereof I commanded thee that thou shouldest not eat?’",
           "ref": "genesis 3:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And the man said: ‘The woman whom Thou gavest to be with me, she gave me of the tree, and I did eat.’"
-          },
+          "en": "And the man said: ‘The woman whom Thou gavest to be with me, she gave me of the tree, and I did eat.’",
           "ref": "genesis 3:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD God said unto the woman: ‘What is this thou hast done?’ And the woman said: ‘The serpent beguiled me, and I did eat.’"
-          },
+          "en": "And the LORD God said unto the woman: ‘What is this thou hast done?’ And the woman said: ‘The serpent beguiled me, and I did eat.’",
           "ref": "genesis 3:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD God said unto the serpent: ‘Because thou hast done this, cursed art thou from among all cattle, and from among all beasts of the field; upon thy belly shalt thou go, and dust shalt thou eat all the days of thy life."
-          },
+          "en": "And the LORD God said unto the serpent: ‘Because thou hast done this, cursed art thou from among all cattle, and from among all beasts of the field; upon thy belly shalt thou go, and dust shalt thou eat all the days of thy life.",
           "ref": "genesis 3:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will put enmity between thee and the woman, and between thy seed and her seed; they shall bruise thy head, and thou shalt bruise their heel.’"
-          },
+          "en": "And I will put enmity between thee and the woman, and between thy seed and her seed; they shall bruise thy head, and thou shalt bruise their heel.’",
           "ref": "genesis 3:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "Unto the woman He said: ‘I will greatly multiply thy pain and thy travail; in pain thou shalt bring forth children; and thy desire shall be to thy husband, and he shall rule over thee.’"
-          },
+          "en": "Unto the woman He said: ‘I will greatly multiply thy pain and thy travail; in pain thou shalt bring forth children; and thy desire shall be to thy husband, and he shall rule over thee.’",
           "ref": "genesis 3:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And unto Adam He said: ‘Because thou hast hearkened unto the voice of thy wife, and hast eaten of the tree, of which I commanded thee, saying: Thou shalt not eat of it; cursed is the ground for thy sake; in toil shalt thou eat of it all the days of thy life."
-          },
+          "en": "And unto Adam He said: ‘Because thou hast hearkened unto the voice of thy wife, and hast eaten of the tree, of which I commanded thee, saying: Thou shalt not eat of it; cursed is the ground for thy sake; in toil shalt thou eat of it all the days of thy life.",
           "ref": "genesis 3:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "Thorns also and thistles shall it bring forth to thee; and thou shalt eat the herb of the field."
-          },
+          "en": "Thorns also and thistles shall it bring forth to thee; and thou shalt eat the herb of the field.",
           "ref": "genesis 3:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "In the sweat of thy face shalt thou eat bread, till thou return unto the ground; for out of it wast thou taken; for dust thou art, and unto dust shalt thou return.’"
-          },
+          "en": "In the sweat of thy face shalt thou eat bread, till thou return unto the ground; for out of it wast thou taken; for dust thou art, and unto dust shalt thou return.’",
           "ref": "genesis 3:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And the man called his wife’s name Eve; because she was the mother of all living."
-          },
+          "en": "And the man called his wife’s name Eve; because she was the mother of all living.",
           "ref": "genesis 3:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD God made for Adam and for his wife garments of skins, and clothed them."
-          },
+          "en": "And the LORD God made for Adam and for his wife garments of skins, and clothed them.",
           "ref": "genesis 3:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD God said: ‘Behold, the man is become as one of us, to know good and evil; and now, lest he put forth his hand, and take also of the tree of life, and eat, and live for ever.’"
-          },
+          "en": "And the LORD God said: ‘Behold, the man is become as one of us, to know good and evil; and now, lest he put forth his hand, and take also of the tree of life, and eat, and live for ever.’",
           "ref": "genesis 3:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "Therefore the LORD God sent him forth from the garden of Eden, to till the ground from whence he was taken."
-          },
+          "en": "Therefore the LORD God sent him forth from the garden of Eden, to till the ground from whence he was taken.",
           "ref": "genesis 3:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "So He drove out the man; and He placed at the east of the garden of Eden the cherubim, and the flaming sword which turned every way, to keep the way to the tree of life."
-          },
+          "en": "So He drove out the man; and He placed at the east of the garden of Eden the cherubim, and the flaming sword which turned every way, to keep the way to the tree of life.",
           "ref": "genesis 3:24"
         }
       ]
@@ -662,210 +422,132 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": "Ora, o Humano conheceu* sua esposa Eva, e ela concebeu e deu à luz Caim, dizendo: “Ganhei* uma pessoa* com a ajuda de* יהוה.”",
-            "jps1917": "And the man knew Eve his wife; and she conceived and bore Cain, and said: ‘I have agotten a man with the help of the LORD.’"
-          },
+          "en": "And the man knew Eve his wife; and she conceived and bore Cain, and said: ‘I have agotten a man with the help of the LORD.’",
           "ref": "genesis 4:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": "Ela então deu à luz seu irmão Abel. Abel tornou-se pastor de ovelhas e Caim lavrador da terra.",
-            "jps1917": "And again she bore his brother Abel. And Abel was a keeper of sheep, but Cain was a tiller of the ground."
-          },
+          "en": "And again she bore his brother Abel. And Abel was a keeper of sheep, but Cain was a tiller of the ground.",
           "ref": "genesis 4:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And in process of time it came to pass, that Cain brought of the fruit of the ground an offering unto the LORD."
-          },
+          "en": "And in process of time it came to pass, that Cain brought of the fruit of the ground an offering unto the LORD.",
           "ref": "genesis 4:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abel, he also brought of the firstlings of his flock and of the fat thereof. And the LORD had respect unto Abel and to his offering;"
-          },
+          "en": "And Abel, he also brought of the firstlings of his flock and of the fat thereof. And the LORD had respect unto Abel and to his offering;",
           "ref": "genesis 4:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "but unto Cain and to his offering He had not respect. And Cain was very wroth, and his countenance fell."
-          },
+          "en": "but unto Cain and to his offering He had not respect. And Cain was very wroth, and his countenance fell.",
           "ref": "genesis 4:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Cain: ‘Why art thou wroth? and why is thy countenance fallen?"
-          },
+          "en": "And the LORD said unto Cain: ‘Why art thou wroth? and why is thy countenance fallen?",
           "ref": "genesis 4:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "If thou doest well, shall it not be lifted up? and if thou doest not well, sin coucheth at the door; and unto thee is its desire, but thou mayest rule over it.’"
-          },
+          "en": "If thou doest well, shall it not be lifted up? and if thou doest not well, sin coucheth at the door; and unto thee is its desire, but thou mayest rule over it.’",
           "ref": "genesis 4:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Cain spoke unto Abel his brother. And it came to pass, when they were in the field, that Cain rose up against Abel his brother, and slew him."
-          },
+          "en": "And Cain spoke unto Abel his brother. And it came to pass, when they were in the field, that Cain rose up against Abel his brother, and slew him.",
           "ref": "genesis 4:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Cain: ‘Where is Abel thy brother?’ And he said: ‘I know not; am I my brother’s keeper?’"
-          },
+          "en": "And the LORD said unto Cain: ‘Where is Abel thy brother?’ And he said: ‘I know not; am I my brother’s keeper?’",
           "ref": "genesis 4:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And He said: ‘What hast thou done? the voice of thy brother’s blood crieth unto Me from the ground."
-          },
+          "en": "And He said: ‘What hast thou done? the voice of thy brother’s blood crieth unto Me from the ground.",
           "ref": "genesis 4:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And now cursed art thou from the ground, which hath opened her mouth to receive thy brother’s blood from thy hand."
-          },
+          "en": "And now cursed art thou from the ground, which hath opened her mouth to receive thy brother’s blood from thy hand.",
           "ref": "genesis 4:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "When thou tillest the ground, it shall not henceforth yield unto thee her strength; a fugitive and a wanderer shalt thou be in the earth.’"
-          },
+          "en": "When thou tillest the ground, it shall not henceforth yield unto thee her strength; a fugitive and a wanderer shalt thou be in the earth.’",
           "ref": "genesis 4:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And Cain said unto the LORD: ‘My punishment is greater than I can bear."
-          },
+          "en": "And Cain said unto the LORD: ‘My punishment is greater than I can bear.",
           "ref": "genesis 4:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "Behold, Thou hast driven me out this day from the face of the land; and from Thy face shall I be hid; and I shall be a fugitive and a wanderer in the earth; and it will come to pass, that whosoever findeth me will slay me.’"
-          },
+          "en": "Behold, Thou hast driven me out this day from the face of the land; and from Thy face shall I be hid; and I shall be a fugitive and a wanderer in the earth; and it will come to pass, that whosoever findeth me will slay me.’",
           "ref": "genesis 4:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto him: ‘Therefore whosoever slayeth Cain, vengeance shall be taken on him sevenfold.’ And the LORD set a sign for Cain, lest any finding him should smite him."
-          },
+          "en": "And the LORD said unto him: ‘Therefore whosoever slayeth Cain, vengeance shall be taken on him sevenfold.’ And the LORD set a sign for Cain, lest any finding him should smite him.",
           "ref": "genesis 4:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And Cain went out from the presence of the LORD, and dwelt in the land of Nod, on the east of Eden."
-          },
+          "en": "And Cain went out from the presence of the LORD, and dwelt in the land of Nod, on the east of Eden.",
           "ref": "genesis 4:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And Cain knew his wife; and she conceived, and bore Enoch; and he builded a city, and called the name of the city after the name of his son Enoch."
-          },
+          "en": "And Cain knew his wife; and she conceived, and bore Enoch; and he builded a city, and called the name of the city after the name of his son Enoch.",
           "ref": "genesis 4:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And unto Enoch was born Irad; and Irad begot Mehujael; and Mehujael begot Methushael; and Methushael begot Lamech."
-          },
+          "en": "And unto Enoch was born Irad; and Irad begot Mehujael; and Mehujael begot Methushael; and Methushael begot Lamech.",
           "ref": "genesis 4:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And Lamech took unto him two wives; the name of one was Adah, and the name of the other Zillah."
-          },
+          "en": "And Lamech took unto him two wives; the name of one was Adah, and the name of the other Zillah.",
           "ref": "genesis 4:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Adah bore Jabal; he was the father of such as dwell in tents and have cattle."
-          },
+          "en": "And Adah bore Jabal; he was the father of such as dwell in tents and have cattle.",
           "ref": "genesis 4:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And his brother’s name was Jubal; he was the father of all such as handle the harp and pipe."
-          },
+          "en": "And his brother’s name was Jubal; he was the father of all such as handle the harp and pipe.",
           "ref": "genesis 4:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And Zillah, she also bore Tubal-cain, the forger of every cutting instrument of brass and iron; and the sister of Tubal-cain was Naamah."
-          },
+          "en": "And Zillah, she also bore Tubal-cain, the forger of every cutting instrument of brass and iron; and the sister of Tubal-cain was Naamah.",
           "ref": "genesis 4:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And Lamech said unto his wives: Adah and Zillah, hear my voice; Ye wives of Lamech, hearken unto my speech; For I have slain a man for wounding me, And a young man for bruising me;"
-          },
+          "en": "And Lamech said unto his wives: Adah and Zillah, hear my voice; Ye wives of Lamech, hearken unto my speech; For I have slain a man for wounding me, And a young man for bruising me;",
           "ref": "genesis 4:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "If Cain shall be avenged sevenfold, Truly Lamech seventy and sevenfold."
-          },
+          "en": "If Cain shall be avenged sevenfold, Truly Lamech seventy and sevenfold.",
           "ref": "genesis 4:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And Adam knew his wife again; and she bore a son, and called his name Seth: ‘for God hath appointed me another seed instead of Abel; for Cain slew him.’"
-          },
+          "en": "And Adam knew his wife again; and she bore a son, and called his name Seth: ‘for God hath appointed me another seed instead of Abel; for Cain slew him.’",
           "ref": "genesis 4:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And to Seth, to him also there was born a son; and he called his name Enosh; then began men to call upon the name of the LORD."
-          },
+          "en": "And to Seth, to him also there was born a son; and he called his name Enosh; then began men to call upon the name of the LORD.",
           "ref": "genesis 4:26"
         }
       ]
@@ -875,258 +557,162 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": "Este é o Sêfer Toldot [pergaminho das gerações/relatos] de Adam. No dia em que o Elohim criou um Adam, [fazendo um ser humano se tornar] à semelhança do Elohim.",
-            "jps1917": "This is the book of the generations of Adam. In the day that God created man, in the likeness of God made He him;"
-          },
+          "en": "This is the book of the generations of Adam. In the day that God created man, in the likeness of God made He him;",
           "ref": "genesis 5:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": "Macho e Fêmea foram criados, e foram abençoados e chamados pelo título: ADAM [derivado do solo]. No dia em que foram criados. (S)",
-            "jps1917": "male and female created He them, and blessed them, and called their name Adam, in the day when they were created."
-          },
+          "en": "male and female created He them, and blessed them, and called their name Adam, in the day when they were created.",
           "ref": "genesis 5:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": "E Adam viveu trinta [com a esposa e] cem anos [separado dela]. E [depois de voltar a viver com ela, foi] gerado [um filho, só que desta vez] à sua imagem [conceitual] semelhança [intelectual], e [ele] chamou seu nome, Shet [concedido].",
-            "jps1917": "And Adam lived a hundred and thirty years, and begot a son in his own likeness, after his image; and called his name Seth."
-          },
+          "en": "And Adam lived a hundred and thirty years, and begot a son in his own likeness, after his image; and called his name Seth.",
           "ref": "genesis 5:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": "E os dias do Adam após o nascimento de Shet foram de oitocentos anos,[durante o qual teve outros] filhos e filhas.",
-            "jps1917": "And the days of Adam after he begot Seth were eight hundred years; and he begot sons and daughters."
-          },
+          "en": "And the days of Adam after he begot Seth were eight hundred years; and he begot sons and daughters.",
           "ref": "genesis 5:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": "E todos os dias - os quais [estava] vivo o Adam, foram: novecentos anos e trinta anos. E morreu. (S)",
-            "jps1917": "And all the days that Adam lived were nine hundred and thirty years; and he died."
-          },
+          "en": "And all the days that Adam lived were nine hundred and thirty years; and he died.",
           "ref": "genesis 5:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": "Shet viveu cinco anos e cem anos. E [lhe foi] gerado [um filho o qual chamou] Enosh.",
-            "jps1917": "And Seth lived a hundred and five years, and begot Enosh."
-          },
+          "en": "And Seth lived a hundred and five years, and begot Enosh.",
           "ref": "genesis 5:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": "E após o nascimento de Enosh, Shet viveu sete anos e oitocentos anos, [durante o qual teve outros] filhos e filhas.",
-            "jps1917": "And Seth lived after he begot Enosh eight hundred and seven years, and begot sons and daughters."
-          },
+          "en": "And Seth lived after he begot Enosh eight hundred and seven years, and begot sons and daughters.",
           "ref": "genesis 5:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": "E todos os dias de Shet foram: Doze anos e Novecentos anos. E morreu. (S)",
-            "jps1917": "And all the days of Seth were nine hundred and twelve years; and he died."
-          },
+          "en": "And all the days of Seth were nine hundred and twelve years; and he died.",
           "ref": "genesis 5:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": "E viveu Enosh noventa anos e [lhe foi gerado um filho ao qual chamou] Kenan.",
-            "jps1917": "And Enosh lived ninety years, and begot Kenan."
-          },
+          "en": "And Enosh lived ninety years, and begot Kenan.",
           "ref": "genesis 5:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": "E viveu Enosh, após ter sido gerado para ele Kenan; quinze anos, e oitocentos anos, [durante o qual teve outros] filhos de filhas.",
-            "jps1917": "And Enosh lived after he begot Kenan eight hundred and fifteen years, and begot sons and daughters."
-          },
+          "en": "And Enosh lived after he begot Kenan eight hundred and fifteen years, and begot sons and daughters.",
           "ref": "genesis 5:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": "E todos os dias de Enosh foram: Cinco anos e Novecentos anos. E morreu. (S)",
-            "jps1917": "And all the days of Enosh were nine hundred and five years; and he died."
-          },
+          "en": "And all the days of Enosh were nine hundred and five years; and he died.",
           "ref": "genesis 5:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": "E viveu Kenan setenta anos e [lhe foi] gerado [o filho chamado] Mahalal'el.",
-            "jps1917": "And Kenan lived seventy years, and begot Mahalalel."
-          },
+          "en": "And Kenan lived seventy years, and begot Mahalalel.",
           "ref": "genesis 5:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": "E viveu Kenan, depois de ter sido gerado Mahalal'el, quarenta anos e oitocentos anos; [durante o qual teve outros] filhos e filhas.",
-            "jps1917": "And Kenan lived after he begot Mahalalel eight hundred and forty years, and begot sons and daughters."
-          },
+          "en": "And Kenan lived after he begot Mahalalel eight hundred and forty years, and begot sons and daughters.",
           "ref": "genesis 5:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": "E todos os dias de Kenan foram: Dez anos e novecentos anos. E morreu. (S)",
-            "jps1917": "And all the days of Kenan were nine hundred and ten years; and he died."
-          },
+          "en": "And all the days of Kenan were nine hundred and ten years; and he died.",
           "ref": "genesis 5:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": "E viveu Mahalal'el cinco anos e sessenta anos e [lhe foi] gerado [o filho chamado] Iored.",
-            "jps1917": "And Mahalalel lived sixty and five years, and begot Jared."
-          },
+          "en": "And Mahalalel lived sixty and five years, and begot Jared.",
           "ref": "genesis 5:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": "E viveu Mahalal'el, depois de ter sido gerado Iored, trinta anos e oitocentos anos; [durante o qual teve outros] filhos e filhas.",
-            "jps1917": "And Mahalalel lived after he begot Jared eight hundred and thirty years, and begot sons and daughters."
-          },
+          "en": "And Mahalalel lived after he begot Jared eight hundred and thirty years, and begot sons and daughters.",
           "ref": "genesis 5:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": "E todos os dias de Mahalal'el foram: Noventa e cinco anos, e Oitocentos anos. E morreu. (S)",
-            "jps1917": "And all the days of Mahalalel were eight hundred ninety and five years; and he died."
-          },
+          "en": "And all the days of Mahalalel were eight hundred ninety and five years; and he died.",
           "ref": "genesis 5:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": "E viveu Iered sessenta e dois anos e [lhe foi] gerado [o filho chamado] Hanokh.",
-            "jps1917": "And Jared lived a hundred sixty and two years, and begot Enoch."
-          },
+          "en": "And Jared lived a hundred sixty and two years, and begot Enoch.",
           "ref": "genesis 5:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": "E viveu Iered, depois de ter sido gerado Hanokh, oitocentos anos; [durante o qual teve outros] filhos de filhas.",
-            "jps1917": "And Jared lived after he begot Enoch eight hundred years, and begot sons and daughters."
-          },
+          "en": "And Jared lived after he begot Enoch eight hundred years, and begot sons and daughters.",
           "ref": "genesis 5:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": "E todos os dias de Iered foram: Sessenta e dois anos e Novecentos anos. E morreu. (S)",
-            "jps1917": "And all the days of Jared were nine hundred sixty and two years; and he died. ."
-          },
+          "en": "And all the days of Jared were nine hundred sixty and two years; and he died. .",
           "ref": "genesis 5:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": "E viveu Hanokh sessenta e cinco anos e [lhe foi] gerado [o filho chamado] Metu'Shelakh.",
-            "jps1917": "And Enoch lived sixty and five years, and begot Methuselah."
-          },
+          "en": "And Enoch lived sixty and five years, and begot Methuselah.",
           "ref": "genesis 5:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": "E caminhou Hanokh com o Elohim; após [lhe ter sido] gerado [o filho chamado] de Metu'Shelakh, por trezentos anos. E [durante este período] teve filhos de filhas.",
-            "jps1917": "And Enoch walked with God after he begot Methuselah three hundred years, and begot sons and daughters."
-          },
+          "en": "And Enoch walked with God after he begot Methuselah three hundred years, and begot sons and daughters.",
           "ref": "genesis 5:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": "E foram todos os dias de Hanokh: Sessenta e cinco anos e trezentos anos.",
-            "jps1917": "And all the days of Enoch were three hundred sixty and five years."
-          },
+          "en": "And all the days of Enoch were three hundred sixty and five years.",
           "ref": "genesis 5:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": "E caminhou Hanokh com este Elohim. E não [existia] mais. Pois o Elohim o havia tomado. (P)",
-            "jps1917": "And Enoch walked with God, and he was not; for God took him."
-          },
+          "en": "And Enoch walked with God, and he was not; for God took him.",
           "ref": "genesis 5:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": "E viveu Metu'Shelakh Oitenta e sete anos e cem anos, e [lhe foi] gerado [o filho que foi chamado de] Lamékh.",
-            "jps1917": "And Methuselah lived a hundred eighty and seven years, and begot Lamech."
-          },
+          "en": "And Methuselah lived a hundred eighty and seven years, and begot Lamech.",
           "ref": "genesis 5:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": "E viveu Metu'Shelakh após lhe ter sido gerado Lemékh, Oitenta e dois anos e Setecentos anos; [durante este período] teve filhos e filhas.",
-            "jps1917": "And Methuselah lived after he begot Lamech seven hundred eighty and two years, and begot sons and daughters."
-          },
+          "en": "And Methuselah lived after he begot Lamech seven hundred eighty and two years, and begot sons and daughters.",
           "ref": "genesis 5:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": "E foram todos os dias de Metu'Shelakh: Sessenta e nove anos e Novecentos anos. E morreu. (P)",
-            "jps1917": "And all the days of Methuselah were nine hundred sixty and nine years; and he died."
-          },
+          "en": "And all the days of Methuselah were nine hundred sixty and nine years; and he died.",
           "ref": "genesis 5:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": "E viveu Lamékh oitenta e dois anos [e lhe foi] gerado um filho.",
-            "jps1917": "And Lamech lived a hundred eighty and two years, and begot a son."
-          },
+          "en": "And Lamech lived a hundred eighty and two years, and begot a son.",
           "ref": "genesis 5:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": "E chamou o seu nome: Noah [descansado] ao dizer: Este nos consolará de nossas ações, e do sofrimento de nossas mãos [por causa] do solo que foi amaldiçoado pelo HaShem!",
-            "jps1917": "And he called his name Noah, saying: ‘This same shall comfort us in our work and in the toil of our hands, which cometh from the ground which the LORD hath cursed.’"
-          },
+          "en": "And he called his name Noah, saying: ‘This same shall comfort us in our work and in the toil of our hands, which cometh from the ground which the LORD hath cursed.’",
           "ref": "genesis 5:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": "E viveu Lemékh, após [lhe ter sido] gerado Noah: Noventa e cinco anos e Quinhentos anos; [e durante este período] teve filhos e filhas.",
-            "jps1917": "And Lamech lived after he begot Noah five hundred ninety and five years, and begot sons and daughters."
-          },
+          "en": "And Lamech lived after he begot Noah five hundred ninety and five years, and begot sons and daughters.",
           "ref": "genesis 5:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": "E todos os dias de Lemékh foram setenta e sete anos, e setecentos anos. E morreu. (S)",
-            "jps1917": "And all the days of Lamech were seven hundred seventy and seven years; and he died."
-          },
+          "en": "And all the days of Lamech were seven hundred seventy and seven years; and he died.",
           "ref": "genesis 5:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": "E Noah estava com quinhentos anos, e [foi] gerado [para] Noah a estes [filhos]: Shem - Hám e Iáfet.",
-            "jps1917": "And Noah was five hundred years old; and Noah begot Shem, Ham, and Japheth."
-          },
+          "en": "And Noah was five hundred years old; and Noah begot Shem, Ham, and Japheth.",
           "ref": "genesis 5:32"
         }
       ]
@@ -1136,178 +722,112 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": "E aconteceu que, quando os homens começaram a multiplicar-se sobre a face da terra, e filhas nasceram para eles,",
-            "jps1917": "And it came to pass, when men began to multiply on the face of the earth, and daughters were born unto them,"
-          },
+          "en": "And it came to pass, when men began to multiply on the face of the earth, and daughters were born unto them,",
           "ref": "genesis 6:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": "viram os filhos de Elohim que as filhas dos homens eram bonitas, e tomaram para si mulheres de todas as que escolheram.",
-            "jps1917": "that the sons of nobles saw the daughters of men that they were fair; and they took them wives, whomsoever they chose."
-          },
+          "en": "that the sons of nobles saw the daughters of men that they were fair; and they took them wives, whomsoever they chose.",
           "ref": "genesis 6:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": "E disse Elohim: \"Não contenderá o meu espírito com o homem para sempre, visto que ele é carne; contudo, seus dias serão cento e vinte anos.\"",
-            "jps1917": "And the LORD said: ‘My spirit shall not abide in man for ever, for that he also is flesh; therefore shall his days be a hundred and twenty years.’"
-          },
+          "en": "And the LORD said: ‘My spirit shall not abide in man for ever, for that he also is flesh; therefore shall his days be a hundred and twenty years.’",
           "ref": "genesis 6:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": "Os nefilim estavam na terra naqueles dias, e também depois, quando os filhos de Elohim se uniram às filhas dos homens e elas lhes deram filhos; estes foram os giborim, os homens de renome, que desde os dias antigos foram homens de nome.",
-            "jps1917": "The Nephilim were in the earth in those days, and also after that, when the sons of nobles came in unto the daughters of men, and they bore children to them; the same were the mighty men that were of old, the men of renown."
-          },
+          "en": "The Nephilim were in the earth in those days, and also after that, when the sons of nobles came in unto the daughters of men, and they bore children to them; the same were the mighty men that were of old, the men of renown.",
           "ref": "genesis 6:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": "E Elohim viu que a maldade do homem era grande na terra, e que toda a imaginação dos pensamentos de seu coração era somente mal continuamente.",
-            "jps1917": "And the LORD saw that the wickedness of man was great in the earth, and that every imagination of the thoughts of his heart was only evil continually."
-          },
+          "en": "And the LORD saw that the wickedness of man was great in the earth, and that every imagination of the thoughts of his heart was only evil continually.",
           "ref": "genesis 6:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": "E Elohim se arrependeu de ter feito o homem sobre a terra, e isso lhe pesou no coração.",
-            "jps1917": "And it repented the LORD that He had made man on the earth, and it grieved Him at His heart."
-          },
+          "en": "And it repented the LORD that He had made man on the earth, and it grieved Him at His heart.",
           "ref": "genesis 6:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": "E Elohim disse: \"Destruirei o homem que criei sobre a face da terra, desde o homem até o animal, até o réptil e até as aves dos céus, porque me arrependo de tê-los feito.\"",
-            "jps1917": "And the LORD said: ‘I will blot out man whom I have created from the face of the earth; both man, and beast, and creeping thing, and fowl of the air; for it repenteth Me that I have made them.’"
-          },
+          "en": "And the LORD said: ‘I will blot out man whom I have created from the face of the earth; both man, and beast, and creeping thing, and fowl of the air; for it repenteth Me that I have made them.’",
           "ref": "genesis 6:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": "Mas Noach encontrou favor aos olhos de Elohim.",
-            "jps1917": "But Noah found grace in the eyes of the LORD."
-          },
+          "en": "But Noah found grace in the eyes of the LORD.",
           "ref": "genesis 6:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": "Estas são as gerações de Noach: Noach era um homem justo, íntegro em suas gerações; Noach andou com Elohim.",
-            "jps1917": "These are the generations of Noah. Noah was in his generations a man righteous and wholehearted; Noah walked with God."
-          },
+          "en": "These are the generations of Noah. Noah was in his generations a man righteous and wholehearted; Noah walked with God.",
           "ref": "genesis 6:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": "E Noach gerou três filhos: Sem, Cham e Yafet.",
-            "jps1917": "And Noah begot three sons, Shem, Ham, and Japheth."
-          },
+          "en": "And Noah begot three sons, Shem, Ham, and Japheth.",
           "ref": "genesis 6:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": "E a terra estava corrompida diante de Elohim, e a terra estava cheia de violência.",
-            "jps1917": "And the earth was corrupt before God, and the earth was filled with violence."
-          },
+          "en": "And the earth was corrupt before God, and the earth was filled with violence.",
           "ref": "genesis 6:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": "E Elohim olhou para a terra, e eis que estava corrompida, pois toda carne havia corrompido seu caminho sobre a terra.",
-            "jps1917": "And God saw the earth, and, behold, it was corrupt; for all flesh had corrupted their way upon the earth. ."
-          },
+          "en": "And God saw the earth, and, behold, it was corrupt; for all flesh had corrupted their way upon the earth. .",
           "ref": "genesis 6:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": "E Elohim disse a Noach: \"O fim de toda carne chegou diante de Mim, pois a terra está cheia de violência por causa deles; eis que os destruirei com a terra.\"",
-            "jps1917": "And God said unto Noah: ‘The end of all flesh is come before Me; for the earth is filled with violence through them; and, behold, I will destroy them with the earth."
-          },
+          "en": "And God said unto Noah: ‘The end of all flesh is come before Me; for the earth is filled with violence through them; and, behold, I will destroy them with the earth.",
           "ref": "genesis 6:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": "Faz para ti uma arca de madeira de cipreste; farás compartimentos na arca e a revestirás por dentro e por fora com betume.",
-            "jps1917": "Make thee an ark of gopher wood; with rooms shalt thou make the ark, and shalt pitch it within and without with pitch."
-          },
+          "en": "Make thee an ark of gopher wood; with rooms shalt thou make the ark, and shalt pitch it within and without with pitch.",
           "ref": "genesis 6:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": "E isto é o que farás: A arca terá trezentos côvados (aproximadamente 137,16 metros) de comprimento, cinquenta côvados (aproximadamente 22,86 metros) de largura e trinta côvados (aproximadamente 13,72 metros) de altura.",
-            "jps1917": "And this is how thou shalt make it: the length of the ark three hundred cubits, the breadth of it fifty cubits, and the height of it thirty cubits."
-          },
+          "en": "And this is how thou shalt make it: the length of the ark three hundred cubits, the breadth of it fifty cubits, and the height of it thirty cubits.",
           "ref": "genesis 6:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": "Farás uma janela para a arca e a terminarás até um côvado (aproximadamente 0,46 metros) de altura; e porás a porta da arca de seu lado; farás um andar inferior, um segundo e um terceiro.",
-            "jps1917": "A light shalt thou make to the ark, and to a cubit shalt thou finish it upward; and the door of the ark shalt thou set in the side thereof; with lower, second, and third stories shalt thou make it."
-          },
+          "en": "A light shalt thou make to the ark, and to a cubit shalt thou finish it upward; and the door of the ark shalt thou set in the side thereof; with lower, second, and third stories shalt thou make it.",
           "ref": "genesis 6:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": "E eu, eis que trago o dilúvio de águas sobre a terra, para destruir toda a carne em que haja espírito de vida debaixo dos céus; tudo o que há na terra expirará.",
-            "jps1917": "And I, behold, I do bring the flood of waters upon the earth, to destroy all flesh, wherein is the breath of life, from under heaven; every thing that is in the earth shall perish."
-          },
+          "en": "And I, behold, I do bring the flood of waters upon the earth, to destroy all flesh, wherein is the breath of life, from under heaven; every thing that is in the earth shall perish.",
           "ref": "genesis 6:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": "Mas estabelecerei a Minha aliança contigo, e entrarás na arca, tu e teus filhos, e tua mulher, e as mulheres de teus filhos contigo.",
-            "jps1917": "But I will establish My covenant with thee; and thou shalt come into the ark, thou, and thy sons, and thy wife, and thy sons’ wives with thee."
-          },
+          "en": "But I will establish My covenant with thee; and thou shalt come into the ark, thou, and thy sons, and thy wife, and thy sons’ wives with thee.",
           "ref": "genesis 6:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": "E de todo ser vivente, de toda carne, dois de cada espécie trarás para a arca, para os manter vivos contigo; macho e fêmea serão.",
-            "jps1917": "And of every living thing of all flesh, two of every sort shalt thou bring into the ark, to keep them alive with thee; they shall be male and female."
-          },
+          "en": "And of every living thing of all flesh, two of every sort shalt thou bring into the ark, to keep them alive with thee; they shall be male and female.",
           "ref": "genesis 6:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": "Das aves, segundo a sua espécie, e dos animais, segundo a sua espécie, e de todo réptil da terra, segundo a sua espécie, dois de cada espécie virão até ti, para os manter vivos.",
-            "jps1917": "Of the fowl after their kind, and of the cattle after their kind, of every creeping thing of the ground after its kind, two of every sort shall come unto thee, to keep them alive."
-          },
+          "en": "Of the fowl after their kind, and of the cattle after their kind, of every creeping thing of the ground after its kind, two of every sort shall come unto thee, to keep them alive.",
           "ref": "genesis 6:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": "E tu, toma para ti de toda a comida que se come, e a ajuntarás para ti; e será para ti e para eles de sustento.",
-            "jps1917": "And take thou unto thee of all food that is eaten, and gather it to thee; and it shall be for food for thee, and for them.’"
-          },
+          "en": "And take thou unto thee of all food that is eaten, and gather it to thee; and it shall be for food for thee, and for them.’",
           "ref": "genesis 6:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": "E Noach fez conforme tudo o que D'us lhe ordenou; assim fez.",
-            "jps1917": "Thus did Noah; according to all that God commanded him, so did he."
-          },
+          "en": "Thus did Noah; according to all that God commanded him, so did he.",
           "ref": "genesis 6:22"
         }
       ]
@@ -1317,194 +837,122 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Noah: ‘Come thou and all thy house into the ark; for thee have I seen righteous before Me in this generation."
-          },
+          "en": "And the LORD said unto Noah: ‘Come thou and all thy house into the ark; for thee have I seen righteous before Me in this generation.",
           "ref": "genesis 7:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "Of every clean beast thou shalt take to thee seven and seven, each with his mate; and of the beasts that are not clean two [and two], each with his mate;"
-          },
+          "en": "Of every clean beast thou shalt take to thee seven and seven, each with his mate; and of the beasts that are not clean two [and two], each with his mate;",
           "ref": "genesis 7:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "of the fowl also of the air, seven and seven, male and female; to keep seed alive upon the face of all the earth."
-          },
+          "en": "of the fowl also of the air, seven and seven, male and female; to keep seed alive upon the face of all the earth.",
           "ref": "genesis 7:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "For yet seven days, and I will cause it to rain upon the earth forty days and forty nights; and every living substance that I have made will I blot out from off the face of the earth.’"
-          },
+          "en": "For yet seven days, and I will cause it to rain upon the earth forty days and forty nights; and every living substance that I have made will I blot out from off the face of the earth.’",
           "ref": "genesis 7:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And Noah did according unto all that the LORD commanded him."
-          },
+          "en": "And Noah did according unto all that the LORD commanded him.",
           "ref": "genesis 7:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Noah was six hundred years old when the flood of waters was upon the earth."
-          },
+          "en": "And Noah was six hundred years old when the flood of waters was upon the earth.",
           "ref": "genesis 7:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Noah went in, and his sons, and his wife, and his sons’ wives with him, into the ark, before the waters of the flood."
-          },
+          "en": "And Noah went in, and his sons, and his wife, and his sons’ wives with him, into the ark, before the waters of the flood.",
           "ref": "genesis 7:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "Of clean beasts, and of beasts that are not clean, and of fowls, and of every thing that creepeth upon the ground,"
-          },
+          "en": "Of clean beasts, and of beasts that are not clean, and of fowls, and of every thing that creepeth upon the ground,",
           "ref": "genesis 7:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "there went in two and two unto Noah into the ark, male and female, as God commanded Noah."
-          },
+          "en": "there went in two and two unto Noah into the ark, male and female, as God commanded Noah.",
           "ref": "genesis 7:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass after the seven days, that the waters of the flood were upon the earth."
-          },
+          "en": "And it came to pass after the seven days, that the waters of the flood were upon the earth.",
           "ref": "genesis 7:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "In the six hundredth year of Noah’s life, in the second month, on the seventeenth day of the month, on the same day were all the fountains of the great deep broken up, and the windows of heaven were opened."
-          },
+          "en": "In the six hundredth year of Noah’s life, in the second month, on the seventeenth day of the month, on the same day were all the fountains of the great deep broken up, and the windows of heaven were opened.",
           "ref": "genesis 7:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And the rain was upon the earth forty days and forty nights."
-          },
+          "en": "And the rain was upon the earth forty days and forty nights.",
           "ref": "genesis 7:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "In the selfsame day entered Noah, and Shem, and Ham, and Japheth, the sons of Noah, and Noah’s wife, and the three wives of his sons with them, into the ark;"
-          },
+          "en": "In the selfsame day entered Noah, and Shem, and Ham, and Japheth, the sons of Noah, and Noah’s wife, and the three wives of his sons with them, into the ark;",
           "ref": "genesis 7:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "they, and every beast after its kind, and all the cattle after their kind, and every creeping thing that creepeth upon the earth after its kind, and every fowl after its kind, every bird of every sort."
-          },
+          "en": "they, and every beast after its kind, and all the cattle after their kind, and every creeping thing that creepeth upon the earth after its kind, and every fowl after its kind, every bird of every sort.",
           "ref": "genesis 7:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And they went in unto Noah into the ark, two and two of all flesh wherein is the breath of life."
-          },
+          "en": "And they went in unto Noah into the ark, two and two of all flesh wherein is the breath of life.",
           "ref": "genesis 7:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And they that went in, went in male and female of all flesh, as God commanded him; and the LORD shut him in."
-          },
+          "en": "And they that went in, went in male and female of all flesh, as God commanded him; and the LORD shut him in.",
           "ref": "genesis 7:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And the flood was forty days upon the earth; and the waters increased, and bore up the ark, and it was lifted up above the earth."
-          },
+          "en": "And the flood was forty days upon the earth; and the waters increased, and bore up the ark, and it was lifted up above the earth.",
           "ref": "genesis 7:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And the waters prevailed, and increased greatly upon the earth; and the ark went upon the face of the waters."
-          },
+          "en": "And the waters prevailed, and increased greatly upon the earth; and the ark went upon the face of the waters.",
           "ref": "genesis 7:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And the waters prevailed exceedingly upon the earth; and all the high mountains that were under the whole heaven were covered."
-          },
+          "en": "And the waters prevailed exceedingly upon the earth; and all the high mountains that were under the whole heaven were covered.",
           "ref": "genesis 7:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "Fifteen cubits upward did the waters prevail; and the mountains were covered."
-          },
+          "en": "Fifteen cubits upward did the waters prevail; and the mountains were covered.",
           "ref": "genesis 7:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And all flesh perished that moved upon the earth, both fowl, and cattle, and beast, and every swarming thing that swarmeth upon the earth, and every man;"
-          },
+          "en": "And all flesh perished that moved upon the earth, both fowl, and cattle, and beast, and every swarming thing that swarmeth upon the earth, and every man;",
           "ref": "genesis 7:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "all in whose nostrils was the breath of the spirit of life, whatsoever was in the dry land, died."
-          },
+          "en": "all in whose nostrils was the breath of the spirit of life, whatsoever was in the dry land, died.",
           "ref": "genesis 7:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": "1",
-            "jps1917": "And He blotted out every living substance which was upon the face of the ground, both man, and cattle, and creeping thing, and fowl of the heaven; and they were blotted out from the earth; and Noah only was left, and they that were with him in the ark."
-          },
+          "en": "And He blotted out every living substance which was upon the face of the ground, both man, and cattle, and creeping thing, and fowl of the heaven; and they were blotted out from the earth; and Noah only was left, and they that were with him in the ark.",
           "ref": "genesis 7:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": "50",
-            "jps1917": "And the waters prevailed upon the earth a hundred and fifty days."
-          },
+          "en": "And the waters prevailed upon the earth a hundred and fifty days.",
           "ref": "genesis 7:24"
         }
       ]
@@ -1514,178 +962,112 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": "abc",
-            "jps1917": "And God remembered Noah, and every living thing, and all the cattle that were with him in the ark; and God made a wind to pass over the earth, and the waters assuaged;"
-          },
+          "en": "And God remembered Noah, and every living thing, and all the cattle that were with him in the ark; and God made a wind to pass over the earth, and the waters assuaged;",
           "ref": "genesis 8:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "the fountains also of the deep and the windows of heaven were stopped, and the rain from heaven was restrained."
-          },
+          "en": "the fountains also of the deep and the windows of heaven were stopped, and the rain from heaven was restrained.",
           "ref": "genesis 8:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And the waters returned from off the earth continually; and after the end of a hundred and fifty days the waters decreased."
-          },
+          "en": "And the waters returned from off the earth continually; and after the end of a hundred and fifty days the waters decreased.",
           "ref": "genesis 8:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And the ark rested in the seventh month, on the seventeenth day of the month, upon the mountains of Ararat."
-          },
+          "en": "And the ark rested in the seventh month, on the seventeenth day of the month, upon the mountains of Ararat.",
           "ref": "genesis 8:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And the waters decreased continually until the tenth month; in the tenth month, on the first day of the month, were the tops of the mountains seen."
-          },
+          "en": "And the waters decreased continually until the tenth month; in the tenth month, on the first day of the month, were the tops of the mountains seen.",
           "ref": "genesis 8:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass at the end of forty days, that Noah opened the window of the ark which he had made."
-          },
+          "en": "And it came to pass at the end of forty days, that Noah opened the window of the ark which he had made.",
           "ref": "genesis 8:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And he sent forth a raven, and it went forth to and fro, until the waters were dried up from off the earth."
-          },
+          "en": "And he sent forth a raven, and it went forth to and fro, until the waters were dried up from off the earth.",
           "ref": "genesis 8:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And he sent forth a dove from him, to see if the waters were abated from off the face of the ground."
-          },
+          "en": "And he sent forth a dove from him, to see if the waters were abated from off the face of the ground.",
           "ref": "genesis 8:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "But the dove found no rest for the sole of her foot, and she returned unto him to the ark, for the waters were on the face of the whole earth; and he put forth his hand, and took her, and brought her in unto him into the ark."
-          },
+          "en": "But the dove found no rest for the sole of her foot, and she returned unto him to the ark, for the waters were on the face of the whole earth; and he put forth his hand, and took her, and brought her in unto him into the ark.",
           "ref": "genesis 8:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And he stayed yet other seven days; and again he sent forth the dove out of the ark."
-          },
+          "en": "And he stayed yet other seven days; and again he sent forth the dove out of the ark.",
           "ref": "genesis 8:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And the dove came in to him at eventide; and lo in her mouth an olive-leaf freshly plucked; so Noah knew that the waters were abated from off the earth."
-          },
+          "en": "And the dove came in to him at eventide; and lo in her mouth an olive-leaf freshly plucked; so Noah knew that the waters were abated from off the earth.",
           "ref": "genesis 8:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And he stayed yet other seven days; and sent forth the dove; and she returned not again unto him any more."
-          },
+          "en": "And he stayed yet other seven days; and sent forth the dove; and she returned not again unto him any more.",
           "ref": "genesis 8:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass in the six hundred and first year, in the first month, the first day of the month, the waters were dried up from off the earth; and Noah removed the covering of the ark, and looked, and behold, the face of the ground was dried."
-          },
+          "en": "And it came to pass in the six hundred and first year, in the first month, the first day of the month, the waters were dried up from off the earth; and Noah removed the covering of the ark, and looked, and behold, the face of the ground was dried.",
           "ref": "genesis 8:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And in the second month, on the seven and twentieth day of the month, was the earth dry."
-          },
+          "en": "And in the second month, on the seven and twentieth day of the month, was the earth dry.",
           "ref": "genesis 8:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And God spoke unto Noah, saying:"
-          },
+          "en": "And God spoke unto Noah, saying:",
           "ref": "genesis 8:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "’Go forth from the ark, thou, and thy wife, and thy sons, and thy sons’ wives with thee."
-          },
+          "en": "’Go forth from the ark, thou, and thy wife, and thy sons, and thy sons’ wives with thee.",
           "ref": "genesis 8:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "Bring forth with thee every living thing that is with thee of all flesh, both fowl, and cattle, and every creeping thing that creepeth upon the earth; that they may swarm in the earth, and be fruitful, and multiply upon the earth.’"
-          },
+          "en": "Bring forth with thee every living thing that is with thee of all flesh, both fowl, and cattle, and every creeping thing that creepeth upon the earth; that they may swarm in the earth, and be fruitful, and multiply upon the earth.’",
           "ref": "genesis 8:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Noah went forth, and his sons, and his wife, and his sons’wives with him;"
-          },
+          "en": "And Noah went forth, and his sons, and his wife, and his sons’wives with him;",
           "ref": "genesis 8:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "every beast, every creeping thing, and every fowl, whatsoever moveth upon the earth, after their families; went forth out of the ark."
-          },
+          "en": "every beast, every creeping thing, and every fowl, whatsoever moveth upon the earth, after their families; went forth out of the ark.",
           "ref": "genesis 8:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Noah builded an altar unto the LORD; and took of every clean beast, and of every clean fowl, and offered burnt-offerings on the altar."
-          },
+          "en": "And Noah builded an altar unto the LORD; and took of every clean beast, and of every clean fowl, and offered burnt-offerings on the altar.",
           "ref": "genesis 8:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD smelled the sweet savour; and the LORD said in His heart: ‘I will not again curse the ground any more for man’s sake; for the imagination of man’s heart is evil from his youth; neither will I again smite any more every thing living, as I have done."
-          },
+          "en": "And the LORD smelled the sweet savour; and the LORD said in His heart: ‘I will not again curse the ground any more for man’s sake; for the imagination of man’s heart is evil from his youth; neither will I again smite any more every thing living, as I have done.",
           "ref": "genesis 8:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "While the earth remaineth, seedtime and harvest, and cold and heat, and summer and winter, and day and night shall not cease.’"
-          },
+          "en": "While the earth remaineth, seedtime and harvest, and cold and heat, and summer and winter, and day and night shall not cease.’",
           "ref": "genesis 8:22"
         }
       ]
@@ -1695,234 +1077,147 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And God blessed Noah and his sons, and said unto them: ‘Be fruitful and multiply, and replenish the earth."
-          },
+          "en": "And God blessed Noah and his sons, and said unto them: ‘Be fruitful and multiply, and replenish the earth.",
           "ref": "genesis 9:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And the fear of you and the dread of you shall be upon every beast of the earth, and upon every fowl of the air, and upon all wherewith the ground teemeth, and upon all the fishes of the sea: into your hand are they delivered."
-          },
+          "en": "And the fear of you and the dread of you shall be upon every beast of the earth, and upon every fowl of the air, and upon all wherewith the ground teemeth, and upon all the fishes of the sea: into your hand are they delivered.",
           "ref": "genesis 9:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "Every moving thing that liveth shall be for food for you; as the green herb have I given you all."
-          },
+          "en": "Every moving thing that liveth shall be for food for you; as the green herb have I given you all.",
           "ref": "genesis 9:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "Only flesh with the life thereof, which is the blood thereof, shall ye not eat."
-          },
+          "en": "Only flesh with the life thereof, which is the blood thereof, shall ye not eat.",
           "ref": "genesis 9:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And surely your blood of your lives will I require; at the hand of every beast will I require it; and at the hand of man, even at the hand of every man’s brother, will I require the life of man."
-          },
+          "en": "And surely your blood of your lives will I require; at the hand of every beast will I require it; and at the hand of man, even at the hand of every man’s brother, will I require the life of man.",
           "ref": "genesis 9:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "Whoso sheddeth man’s blood, by man shall his blood be shed; for in the image of God made He man."
-          },
+          "en": "Whoso sheddeth man’s blood, by man shall his blood be shed; for in the image of God made He man.",
           "ref": "genesis 9:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And you, be ye fruitful, and multiply; swarm in the earth, and multiply therein.’ ."
-          },
+          "en": "And you, be ye fruitful, and multiply; swarm in the earth, and multiply therein.’ .",
           "ref": "genesis 9:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And God spoke unto Noah, and to his sons with him, saying:"
-          },
+          "en": "And God spoke unto Noah, and to his sons with him, saying:",
           "ref": "genesis 9:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "’As for Me, behold, I establish My covenant with you, and with your seed after you;"
-          },
+          "en": "’As for Me, behold, I establish My covenant with you, and with your seed after you;",
           "ref": "genesis 9:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "and with every living creature that is with you, the fowl, the cattle, and every beast of the earth with you; of all that go out of the ark, even every beast of the earth."
-          },
+          "en": "and with every living creature that is with you, the fowl, the cattle, and every beast of the earth with you; of all that go out of the ark, even every beast of the earth.",
           "ref": "genesis 9:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will establish My covenant with you; neither shall all flesh be cut off any more by the waters of the flood; neither shall there any more be a flood to destroy the earth.’"
-          },
+          "en": "And I will establish My covenant with you; neither shall all flesh be cut off any more by the waters of the flood; neither shall there any more be a flood to destroy the earth.’",
           "ref": "genesis 9:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said: ‘This is the token of the covenant which I make between Me and you and every living creature that is with you, for perpetual generations:"
-          },
+          "en": "And God said: ‘This is the token of the covenant which I make between Me and you and every living creature that is with you, for perpetual generations:",
           "ref": "genesis 9:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "I have set My bow in the cloud, and it shall be for a token of a covenant between Me and the earth."
-          },
+          "en": "I have set My bow in the cloud, and it shall be for a token of a covenant between Me and the earth.",
           "ref": "genesis 9:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall come to pass, when I bring clouds over the earth, and the bow is seen in the cloud,"
-          },
+          "en": "And it shall come to pass, when I bring clouds over the earth, and the bow is seen in the cloud,",
           "ref": "genesis 9:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "that I will remember My covenant, which is between Me and you and every living creature of all flesh; and the waters shall no more become a flood to destroy all flesh."
-          },
+          "en": "that I will remember My covenant, which is between Me and you and every living creature of all flesh; and the waters shall no more become a flood to destroy all flesh.",
           "ref": "genesis 9:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And the bow shall be in the cloud; and I will look upon it, that I may remember the everlasting covenant between God and every living creature of all flesh that is upon the earth.’"
-          },
+          "en": "And the bow shall be in the cloud; and I will look upon it, that I may remember the everlasting covenant between God and every living creature of all flesh that is upon the earth.’",
           "ref": "genesis 9:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said unto Noah: ‘This is the token of the covenant which I have established between Me and all flesh that is upon the earth.’"
-          },
+          "en": "And God said unto Noah: ‘This is the token of the covenant which I have established between Me and all flesh that is upon the earth.’",
           "ref": "genesis 9:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Noah, that went forth from the ark, were Shem, and Ham, and Japheth; and Ham is the father of Canaan."
-          },
+          "en": "And the sons of Noah, that went forth from the ark, were Shem, and Ham, and Japheth; and Ham is the father of Canaan.",
           "ref": "genesis 9:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "These three were the sons of Noah, and of these was the whole earth overspread."
-          },
+          "en": "These three were the sons of Noah, and of these was the whole earth overspread.",
           "ref": "genesis 9:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Noah, the man of the land, began and planted a vineyard."
-          },
+          "en": "And Noah, the man of the land, began and planted a vineyard.",
           "ref": "genesis 9:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And he drank of the wine, and was drunken; and he was uncovered within his tent."
-          },
+          "en": "And he drank of the wine, and was drunken; and he was uncovered within his tent.",
           "ref": "genesis 9:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And Ham, the father of Canaan, saw the nakedness of his father, and told his two brethren without."
-          },
+          "en": "And Ham, the father of Canaan, saw the nakedness of his father, and told his two brethren without.",
           "ref": "genesis 9:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And Shem and Japheth took a garment, and laid it upon both their shoulders, and went backward, and covered the nakedness of their father; and their faces were backward, and they saw not their father’s nakedness."
-          },
+          "en": "And Shem and Japheth took a garment, and laid it upon both their shoulders, and went backward, and covered the nakedness of their father; and their faces were backward, and they saw not their father’s nakedness.",
           "ref": "genesis 9:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And Noah awoke from his wine, and knew what his youngest son had done unto him."
-          },
+          "en": "And Noah awoke from his wine, and knew what his youngest son had done unto him.",
           "ref": "genesis 9:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: Cursed be Canaan; a servant of servants shall he be unto his brethren."
-          },
+          "en": "And he said: Cursed be Canaan; a servant of servants shall he be unto his brethren.",
           "ref": "genesis 9:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: Blessed be the LORD, the God of Shem; And let Canaan be their servant."
-          },
+          "en": "And he said: Blessed be the LORD, the God of Shem; And let Canaan be their servant.",
           "ref": "genesis 9:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "God enlarge Japheth, and he shall dwell in the tents of Shem; And let Canaan be their servant."
-          },
+          "en": "God enlarge Japheth, and he shall dwell in the tents of Shem; And let Canaan be their servant.",
           "ref": "genesis 9:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And Noah lived after the flood three hundred and fifty years."
-          },
+          "en": "And Noah lived after the flood three hundred and fifty years.",
           "ref": "genesis 9:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And all the days of Noah were nine hundred and fifty years; and he died."
-          },
+          "en": "And all the days of Noah were nine hundred and fifty years; and he died.",
           "ref": "genesis 9:29"
         }
       ]
@@ -1932,258 +1227,162 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "Now these are the generations of the sons of Noah: Shem, Ham, and Japheth; and unto them were sons born after the flood."
-          },
+          "en": "Now these are the generations of the sons of Noah: Shem, Ham, and Japheth; and unto them were sons born after the flood.",
           "ref": "genesis 10:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "The sons of Japheth: Gomer, and Magog, and Madai, and Javan, and Tubal, and Meshech, and Tiras."
-          },
+          "en": "The sons of Japheth: Gomer, and Magog, and Madai, and Javan, and Tubal, and Meshech, and Tiras.",
           "ref": "genesis 10:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Gomer: Ashkenaz, and Riphath, and Togarmah."
-          },
+          "en": "And the sons of Gomer: Ashkenaz, and Riphath, and Togarmah.",
           "ref": "genesis 10:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Javan: Elishah, and Tarshish, Kittim, and Dodanim."
-          },
+          "en": "And the sons of Javan: Elishah, and Tarshish, Kittim, and Dodanim.",
           "ref": "genesis 10:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "Of these were the isles of the nations divided in their lands, every one after his tongue, after their families, in their nations."
-          },
+          "en": "Of these were the isles of the nations divided in their lands, every one after his tongue, after their families, in their nations.",
           "ref": "genesis 10:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Ham: Cush, and Mizraim, and Put, and Canaan."
-          },
+          "en": "And the sons of Ham: Cush, and Mizraim, and Put, and Canaan.",
           "ref": "genesis 10:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Cush: Seba, and Havilah, and Sabtah, and Raamah, and Sabteca; and the sons of Raamah: Sheba, and Dedan."
-          },
+          "en": "And the sons of Cush: Seba, and Havilah, and Sabtah, and Raamah, and Sabteca; and the sons of Raamah: Sheba, and Dedan.",
           "ref": "genesis 10:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Cush begot Nimrod; he began to be a mighty one in the earth."
-          },
+          "en": "And Cush begot Nimrod; he began to be a mighty one in the earth.",
           "ref": "genesis 10:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "He was a mighty hunter before the LORD; wherefore it is said: ‘Like Nimrod a mighty hunter before the LORD.’"
-          },
+          "en": "He was a mighty hunter before the LORD; wherefore it is said: ‘Like Nimrod a mighty hunter before the LORD.’",
           "ref": "genesis 10:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And the beginning of his kingdom was Babel, and Erech, and Accad, and Calneh, in the land of Shinar."
-          },
+          "en": "And the beginning of his kingdom was Babel, and Erech, and Accad, and Calneh, in the land of Shinar.",
           "ref": "genesis 10:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "Out of that land went forth Asshur, and builded Nineveh, and Rehoboth-ir, and Calah,"
-          },
+          "en": "Out of that land went forth Asshur, and builded Nineveh, and Rehoboth-ir, and Calah,",
           "ref": "genesis 10:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "and Resen between Nineveh and Calah—the same is the great city."
-          },
+          "en": "and Resen between Nineveh and Calah—the same is the great city.",
           "ref": "genesis 10:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And Mizraim begot Ludim, and Anamim, and Lehabim, and Naphtuhim,"
-          },
+          "en": "And Mizraim begot Ludim, and Anamim, and Lehabim, and Naphtuhim,",
           "ref": "genesis 10:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "and Pathrusim, and Casluhim—whence went forth the Philistines—and Caphtorim."
-          },
+          "en": "and Pathrusim, and Casluhim—whence went forth the Philistines—and Caphtorim.",
           "ref": "genesis 10:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And Canaan begot Zidon his firstborn, and Heth;"
-          },
+          "en": "And Canaan begot Zidon his firstborn, and Heth;",
           "ref": "genesis 10:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "and the Jebusite, and the Amorite, and the Girgashite;"
-          },
+          "en": "and the Jebusite, and the Amorite, and the Girgashite;",
           "ref": "genesis 10:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "and the Hivite, and the Arkite, and the Sinite;"
-          },
+          "en": "and the Hivite, and the Arkite, and the Sinite;",
           "ref": "genesis 10:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "and the Arvadite, and the Zemarite, and the Hamathite; and afterward were the families of the Canaanite spread abroad."
-          },
+          "en": "and the Arvadite, and the Zemarite, and the Hamathite; and afterward were the families of the Canaanite spread abroad.",
           "ref": "genesis 10:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And the border of the Canaanite was from Zidon, as thou goest toward Gerar, unto Gaza; as thou goest toward Sodom and Gomorrah and Admah and Zeboiim, unto Lasha."
-          },
+          "en": "And the border of the Canaanite was from Zidon, as thou goest toward Gerar, unto Gaza; as thou goest toward Sodom and Gomorrah and Admah and Zeboiim, unto Lasha.",
           "ref": "genesis 10:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the sons of Ham, after their families, after their tongues, in their lands, in their nations."
-          },
+          "en": "These are the sons of Ham, after their families, after their tongues, in their lands, in their nations.",
           "ref": "genesis 10:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And unto Shem, the father of all the children of Eber, the elder brother of Japheth, to him also were children born."
-          },
+          "en": "And unto Shem, the father of all the children of Eber, the elder brother of Japheth, to him also were children born.",
           "ref": "genesis 10:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "The sons of Shem: Elam, and Asshur, and Arpachshad, and Lud, and Aram."
-          },
+          "en": "The sons of Shem: Elam, and Asshur, and Arpachshad, and Lud, and Aram.",
           "ref": "genesis 10:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Aram: Uz, and Hul, and Gether, and Mash."
-          },
+          "en": "And the sons of Aram: Uz, and Hul, and Gether, and Mash.",
           "ref": "genesis 10:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And Arpachshad begot Shelah; and Shelah begot Eber."
-          },
+          "en": "And Arpachshad begot Shelah; and Shelah begot Eber.",
           "ref": "genesis 10:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And unto Eber were born two sons; the name of the one was Peleg; for in his days was the earth divided; and his brother’s name was Joktan."
-          },
+          "en": "And unto Eber were born two sons; the name of the one was Peleg; for in his days was the earth divided; and his brother’s name was Joktan.",
           "ref": "genesis 10:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joktan begot Almodad, and Sheleph, and Hazarmaveth, and Jerah;"
-          },
+          "en": "And Joktan begot Almodad, and Sheleph, and Hazarmaveth, and Jerah;",
           "ref": "genesis 10:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "and Hadoram, and Uzal, and Diklah;"
-          },
+          "en": "and Hadoram, and Uzal, and Diklah;",
           "ref": "genesis 10:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "and Obal, and Abimael, and Sheba;"
-          },
+          "en": "and Obal, and Abimael, and Sheba;",
           "ref": "genesis 10:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "and Ophir, and Havilah, and Jobab; all these were the sons of Joktan."
-          },
+          "en": "and Ophir, and Havilah, and Jobab; all these were the sons of Joktan.",
           "ref": "genesis 10:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And their dwelling was from Mesha, as thou goest toward Sephar, unto the mountain of the east."
-          },
+          "en": "And their dwelling was from Mesha, as thou goest toward Sephar, unto the mountain of the east.",
           "ref": "genesis 10:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the sons of Shem, after their families, after their tongues, in their lands, after their nations."
-          },
+          "en": "These are the sons of Shem, after their families, after their tongues, in their lands, after their nations.",
           "ref": "genesis 10:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the families of the sons of Noah, after their generations, in their nations; and of these were the nations divided in the earth after the flood."
-          },
+          "en": "These are the families of the sons of Noah, after their generations, in their nations; and of these were the nations divided in the earth after the flood.",
           "ref": "genesis 10:32"
         }
       ]
@@ -2193,258 +1392,162 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the whole earth was of one language and of one speech."
-          },
+          "en": "And the whole earth was of one language and of one speech.",
           "ref": "genesis 11:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, as they journeyed east, that they found a plain in the land of Shinar; and they dwelt there."
-          },
+          "en": "And it came to pass, as they journeyed east, that they found a plain in the land of Shinar; and they dwelt there.",
           "ref": "genesis 11:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said one to another: ‘Come, let us make brick, and burn them thoroughly.’ And they had brick for stone, and slime had they for mortar."
-          },
+          "en": "And they said one to another: ‘Come, let us make brick, and burn them thoroughly.’ And they had brick for stone, and slime had they for mortar.",
           "ref": "genesis 11:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said: ‘Come, let us build us a city, and a tower, with its top in heaven, and let us make us a name; lest we be scattered abroad upon the face of the whole earth.’"
-          },
+          "en": "And they said: ‘Come, let us build us a city, and a tower, with its top in heaven, and let us make us a name; lest we be scattered abroad upon the face of the whole earth.’",
           "ref": "genesis 11:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD came down to see the city and the tower, which the children of men builded."
-          },
+          "en": "And the LORD came down to see the city and the tower, which the children of men builded.",
           "ref": "genesis 11:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said: ‘Behold, they are one people, and they have all one language; and this is what they begin to do; and now nothing will be withholden from them, which they purpose to do."
-          },
+          "en": "And the LORD said: ‘Behold, they are one people, and they have all one language; and this is what they begin to do; and now nothing will be withholden from them, which they purpose to do.",
           "ref": "genesis 11:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "Come, let us go down, and there confound their language, that they may not understand one another’s speech.’"
-          },
+          "en": "Come, let us go down, and there confound their language, that they may not understand one another’s speech.’",
           "ref": "genesis 11:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "So the LORD scattered them abroad from thence upon the face of all the earth; and they left off to build the city."
-          },
+          "en": "So the LORD scattered them abroad from thence upon the face of all the earth; and they left off to build the city.",
           "ref": "genesis 11:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "Therefore was the name of it called Babel; because the LORD did there aconfound the language of all the earth; and from thence did the LORD scatter them abroad upon the face of all the earth."
-          },
+          "en": "Therefore was the name of it called Babel; because the LORD did there aconfound the language of all the earth; and from thence did the LORD scatter them abroad upon the face of all the earth.",
           "ref": "genesis 11:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the generations of Shem. Shem was a hundred years old, and begot Arpachshad two years after the flood."
-          },
+          "en": "These are the generations of Shem. Shem was a hundred years old, and begot Arpachshad two years after the flood.",
           "ref": "genesis 11:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And Shem lived after he begot Arpachshad five hundred years, and begot sons and daughters."
-          },
+          "en": "And Shem lived after he begot Arpachshad five hundred years, and begot sons and daughters.",
           "ref": "genesis 11:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And Arpachshad lived five and thirty years, and begot Shelah."
-          },
+          "en": "And Arpachshad lived five and thirty years, and begot Shelah.",
           "ref": "genesis 11:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And Arpachshad lived after he begot Shelah four hundred and three years, and begot sons and daughters."
-          },
+          "en": "And Arpachshad lived after he begot Shelah four hundred and three years, and begot sons and daughters.",
           "ref": "genesis 11:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And Shelah lived thirty years, and begot Eber."
-          },
+          "en": "And Shelah lived thirty years, and begot Eber.",
           "ref": "genesis 11:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And Shelah lived after he begot Eber four hundred and three years, and begot sons and daughters."
-          },
+          "en": "And Shelah lived after he begot Eber four hundred and three years, and begot sons and daughters.",
           "ref": "genesis 11:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And Eber lived four and thirty years, and begot Peleg."
-          },
+          "en": "And Eber lived four and thirty years, and begot Peleg.",
           "ref": "genesis 11:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And Eber lived after he begot Peleg four hundred and thirty years, and begot sons and daughters."
-          },
+          "en": "And Eber lived after he begot Peleg four hundred and thirty years, and begot sons and daughters.",
           "ref": "genesis 11:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Peleg lived thirty years, and begot Reu."
-          },
+          "en": "And Peleg lived thirty years, and begot Reu.",
           "ref": "genesis 11:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And Peleg lived after he begot Reu two hundred and nine years, and begot sons and daughters."
-          },
+          "en": "And Peleg lived after he begot Reu two hundred and nine years, and begot sons and daughters.",
           "ref": "genesis 11:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Reu lived two and thirty years, and begot Serug."
-          },
+          "en": "And Reu lived two and thirty years, and begot Serug.",
           "ref": "genesis 11:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And Reu lived after he begot Serug two hundred and seven years, and begot sons and daughters."
-          },
+          "en": "And Reu lived after he begot Serug two hundred and seven years, and begot sons and daughters.",
           "ref": "genesis 11:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And Serug lived thirty years, and begot Nahor."
-          },
+          "en": "And Serug lived thirty years, and begot Nahor.",
           "ref": "genesis 11:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And Serug lived after he begot Nahor two hundred years, and begot sons and daughters."
-          },
+          "en": "And Serug lived after he begot Nahor two hundred years, and begot sons and daughters.",
           "ref": "genesis 11:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And Nahor lived nine and twenty years, and begot Terah."
-          },
+          "en": "And Nahor lived nine and twenty years, and begot Terah.",
           "ref": "genesis 11:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And Nahor lived after he begot Terah a hundred and nineteen years, and begot sons and daughters."
-          },
+          "en": "And Nahor lived after he begot Terah a hundred and nineteen years, and begot sons and daughters.",
           "ref": "genesis 11:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And Terah lived seventy years, and begot Abram, Nahor, and Haran."
-          },
+          "en": "And Terah lived seventy years, and begot Abram, Nahor, and Haran.",
           "ref": "genesis 11:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "Now these are the generations of Terah. Terah begot Abram, Nahor, and Haran; and Haran begot Lot."
-          },
+          "en": "Now these are the generations of Terah. Terah begot Abram, Nahor, and Haran; and Haran begot Lot.",
           "ref": "genesis 11:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And Haran died in the presence of his father Terah in the land of his nativity, in Ur of the Chaldees."
-          },
+          "en": "And Haran died in the presence of his father Terah in the land of his nativity, in Ur of the Chaldees.",
           "ref": "genesis 11:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abram and Nahor took them wives: the name of Abram’s wife was Sarai; and the name of Nahor’s wife, Milcah, the daughter of Haran, the father of Milcah, and the father of Iscah."
-          },
+          "en": "And Abram and Nahor took them wives: the name of Abram’s wife was Sarai; and the name of Nahor’s wife, Milcah, the daughter of Haran, the father of Milcah, and the father of Iscah.",
           "ref": "genesis 11:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And Sarai was barren; she had no child."
-          },
+          "en": "And Sarai was barren; she had no child.",
           "ref": "genesis 11:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And Terah took Abram his son, and Lot the son of Haran, his son’s son, and Sarai his daughter-in-law, his son Abram’s wife; and they went forth with them from Ur of the Chaldees, to go into the land of Canaan; and they came unto Haran, and dwelt there."
-          },
+          "en": "And Terah took Abram his son, and Lot the son of Haran, his son’s son, and Sarai his daughter-in-law, his son Abram’s wife; and they went forth with them from Ur of the Chaldees, to go into the land of Canaan; and they came unto Haran, and dwelt there.",
           "ref": "genesis 11:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And the days of Terah were two hundred and five years; and Terah died in Haran."
-          },
+          "en": "And the days of Terah were two hundred and five years; and Terah died in Haran.",
           "ref": "genesis 11:32"
         }
       ]
@@ -2454,162 +1557,102 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": "Hashem said to abram go for yourself (benefit and pleasure)",
-            "jps1917": "Now the LORD said unto Abram: ‘Get thee out of thy country, and from thy kindred, and from thy father’s house, unto the land that I will show thee."
-          },
+          "en": "Now the LORD said unto Abram: ‘Get thee out of thy country, and from thy kindred, and from thy father’s house, unto the land that I will show thee.",
           "ref": "genesis 12:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will make of thee a great nation, and I will bless thee, and make thy name great; and be thou a blessing."
-          },
+          "en": "And I will make of thee a great nation, and I will bless thee, and make thy name great; and be thou a blessing.",
           "ref": "genesis 12:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will bless them that bless thee, and him that curseth thee will I curse; and in thee shall all the families of the earth be blessed.’"
-          },
+          "en": "And I will bless them that bless thee, and him that curseth thee will I curse; and in thee shall all the families of the earth be blessed.’",
           "ref": "genesis 12:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "So Abram went, as the LORD had spoken unto him; and Lot went with him; and Abram was seventy and five years old when he departed out of Haran."
-          },
+          "en": "So Abram went, as the LORD had spoken unto him; and Lot went with him; and Abram was seventy and five years old when he departed out of Haran.",
           "ref": "genesis 12:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abram took Sarai his wife, and Lot his brother’s son, and all their substance that they had gathered, and the souls that they had gotten in Haran; and they went forth to go into the land of Canaan; and into the land of Canaan they came."
-          },
+          "en": "And Abram took Sarai his wife, and Lot his brother’s son, and all their substance that they had gathered, and the souls that they had gotten in Haran; and they went forth to go into the land of Canaan; and into the land of Canaan they came.",
           "ref": "genesis 12:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abram passed through the land unto the place of Shechem, unto the terebinth of Moreh. And the Canaanite was then in the land."
-          },
+          "en": "And Abram passed through the land unto the place of Shechem, unto the terebinth of Moreh. And the Canaanite was then in the land.",
           "ref": "genesis 12:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD appeared unto Abram, and said: ‘Unto thy seed will I give this land’; and he builded there an altar unto the LORD, who appeared unto him."
-          },
+          "en": "And the LORD appeared unto Abram, and said: ‘Unto thy seed will I give this land’; and he builded there an altar unto the LORD, who appeared unto him.",
           "ref": "genesis 12:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And he removed from thence unto the mountain on the east of Beth-el, and pitched his tent, having Beth-el on the west, and Ai on the east; and he builded there an altar unto the LORD, and called upon the name of the LORD."
-          },
+          "en": "And he removed from thence unto the mountain on the east of Beth-el, and pitched his tent, having Beth-el on the west, and Ai on the east; and he builded there an altar unto the LORD, and called upon the name of the LORD.",
           "ref": "genesis 12:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abram journeyed, going on still toward the South."
-          },
+          "en": "And Abram journeyed, going on still toward the South.",
           "ref": "genesis 12:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And there was a famine in the land; and Abram went down into Egypt to sojourn there; for the famine was sore in the land."
-          },
+          "en": "And there was a famine in the land; and Abram went down into Egypt to sojourn there; for the famine was sore in the land.",
           "ref": "genesis 12:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when he was come near to enter into Egypt, that he said unto Sarai his wife: ‘Behold now, I know that thou art a fair woman to look upon."
-          },
+          "en": "And it came to pass, when he was come near to enter into Egypt, that he said unto Sarai his wife: ‘Behold now, I know that thou art a fair woman to look upon.",
           "ref": "genesis 12:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And it will come to pass, when the Egyptians shall see thee, that they will say: This is his wife; and they will kill me, but thee they will keep alive."
-          },
+          "en": "And it will come to pass, when the Egyptians shall see thee, that they will say: This is his wife; and they will kill me, but thee they will keep alive.",
           "ref": "genesis 12:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "Say, I pray thee, thou art my sister; that it may be well with me for thy sake, and that my soul may live because of thee.’"
-          },
+          "en": "Say, I pray thee, thou art my sister; that it may be well with me for thy sake, and that my soul may live because of thee.’",
           "ref": "genesis 12:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, that, when Abram was come into Egypt, the Egyptians beheld the woman that she was very fair."
-          },
+          "en": "And it came to pass, that, when Abram was come into Egypt, the Egyptians beheld the woman that she was very fair.",
           "ref": "genesis 12:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And the princes of Pharaoh saw her, and praised her to Pharaoh; and the woman was taken into Pharaoh’s house."
-          },
+          "en": "And the princes of Pharaoh saw her, and praised her to Pharaoh; and the woman was taken into Pharaoh’s house.",
           "ref": "genesis 12:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And he dealt well with Abram for her sake; and he had sheep, and oxen, and he-asses, and men-servants, and maid-servants, and she-asses, and camels."
-          },
+          "en": "And he dealt well with Abram for her sake; and he had sheep, and oxen, and he-asses, and men-servants, and maid-servants, and she-asses, and camels.",
           "ref": "genesis 12:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD plagued Pharaoh and his house with great plagues because of Sarai Abram’s wife."
-          },
+          "en": "And the LORD plagued Pharaoh and his house with great plagues because of Sarai Abram’s wife.",
           "ref": "genesis 12:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh called Abram, and said: ‘What is this that thou hast done unto me? why didst thou not tell me that she was thy wife?"
-          },
+          "en": "And Pharaoh called Abram, and said: ‘What is this that thou hast done unto me? why didst thou not tell me that she was thy wife?",
           "ref": "genesis 12:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "Why saidst thou: She is my sister? so that I took her to be my wife; now therefore behold thy wife, take her, and go thy way.’"
-          },
+          "en": "Why saidst thou: She is my sister? so that I took her to be my wife; now therefore behold thy wife, take her, and go thy way.’",
           "ref": "genesis 12:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh gave men charge concerning him; and they brought him on the way, and his wife, and all that he had."
-          },
+          "en": "And Pharaoh gave men charge concerning him; and they brought him on the way, and his wife, and all that he had.",
           "ref": "genesis 12:20"
         }
       ]
@@ -2619,146 +1662,92 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abram went up out of Egypt, he, and his wife, and all that he had, and Lot with him, into the South."
-          },
+          "en": "And Abram went up out of Egypt, he, and his wife, and all that he had, and Lot with him, into the South.",
           "ref": "genesis 13:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abram was very rich in cattle, in silver, and in gold."
-          },
+          "en": "And Abram was very rich in cattle, in silver, and in gold.",
           "ref": "genesis 13:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And he went on his journeys from the South even to Beth-el, unto the place where his tent had been at the beginning, between Beth-el and Ai;"
-          },
+          "en": "And he went on his journeys from the South even to Beth-el, unto the place where his tent had been at the beginning, between Beth-el and Ai;",
           "ref": "genesis 13:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "unto the place of the altar, which he had made there at the first; and Abram called there on the name of the LORD."
-          },
+          "en": "unto the place of the altar, which he had made there at the first; and Abram called there on the name of the LORD.",
           "ref": "genesis 13:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And Lot also, who went with Abram, had flocks, and herds, and tents."
-          },
+          "en": "And Lot also, who went with Abram, had flocks, and herds, and tents.",
           "ref": "genesis 13:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And the land was not able to bear them, that they might dwell together; for their substance was great, so that they could not dwell together."
-          },
+          "en": "And the land was not able to bear them, that they might dwell together; for their substance was great, so that they could not dwell together.",
           "ref": "genesis 13:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And there was a strife between the herdmen of Abram’s cattle and the herdmen of Lot’s cattle. And the Canaanite and the Perizzite dwelt then in the land."
-          },
+          "en": "And there was a strife between the herdmen of Abram’s cattle and the herdmen of Lot’s cattle. And the Canaanite and the Perizzite dwelt then in the land.",
           "ref": "genesis 13:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abram said unto Lot: ‘Let there be no strife, I pray thee, between me and thee, and between my herdmen and thy herdmen; for we are brethren."
-          },
+          "en": "And Abram said unto Lot: ‘Let there be no strife, I pray thee, between me and thee, and between my herdmen and thy herdmen; for we are brethren.",
           "ref": "genesis 13:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "Is not the whole land before thee? separate thyself, I pray thee, from me; if thou wilt take the left hand, then I will go to the right; or if thou take the right hand, then I will go to the left.’"
-          },
+          "en": "Is not the whole land before thee? separate thyself, I pray thee, from me; if thou wilt take the left hand, then I will go to the right; or if thou take the right hand, then I will go to the left.’",
           "ref": "genesis 13:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And Lot lifted up his eyes, and beheld all the plain of the Jordan, that it was well watered every where, before the LORD destroyed Sodom and Gomorrah, like the garden of the LORD, like the land of Egypt, as thou goest unto Zoar."
-          },
+          "en": "And Lot lifted up his eyes, and beheld all the plain of the Jordan, that it was well watered every where, before the LORD destroyed Sodom and Gomorrah, like the garden of the LORD, like the land of Egypt, as thou goest unto Zoar.",
           "ref": "genesis 13:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "So Lot chose him all the plain of the Jordan; and Lot journeyed east; and they separated themselves the one from the other."
-          },
+          "en": "So Lot chose him all the plain of the Jordan; and Lot journeyed east; and they separated themselves the one from the other.",
           "ref": "genesis 13:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "Abram dwelt in the land of Canaan, and Lot dwelt in the cities of the Plain, and moved his tent as far as Sodom."
-          },
+          "en": "Abram dwelt in the land of Canaan, and Lot dwelt in the cities of the Plain, and moved his tent as far as Sodom.",
           "ref": "genesis 13:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "Now the men of Sodom were wicked and sinners against the LORD exceedingly."
-          },
+          "en": "Now the men of Sodom were wicked and sinners against the LORD exceedingly.",
           "ref": "genesis 13:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Abram, after that Lot was separated from him: ‘Lift up now thine eyes, and look from the place where thou art, northward and southward and eastward and westward;"
-          },
+          "en": "And the LORD said unto Abram, after that Lot was separated from him: ‘Lift up now thine eyes, and look from the place where thou art, northward and southward and eastward and westward;",
           "ref": "genesis 13:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "for all the land which thou seest, to thee will I give it, and to thy seed for ever."
-          },
+          "en": "for all the land which thou seest, to thee will I give it, and to thy seed for ever.",
           "ref": "genesis 13:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will make thy seed as the dust of the earth; so that if a man can number the dust of the earth, then shall thy seed also be numbered."
-          },
+          "en": "And I will make thy seed as the dust of the earth; so that if a man can number the dust of the earth, then shall thy seed also be numbered.",
           "ref": "genesis 13:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "Arise, walk through the land in the length of it and in the breadth of it; for unto thee will I give it.’"
-          },
+          "en": "Arise, walk through the land in the length of it and in the breadth of it; for unto thee will I give it.’",
           "ref": "genesis 13:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abram moved his tent, and came and dwelt by the terebinths of Mamre, which are in Hebron, and built there an altar unto the LORD."
-          },
+          "en": "And Abram moved his tent, and came and dwelt by the terebinths of Mamre, which are in Hebron, and built there an altar unto the LORD.",
           "ref": "genesis 13:18"
         }
       ]
@@ -2768,194 +1757,122 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass in the days of Amraphel king of Shinar, Arioch king of Ellasar, Chedorlaomer king of Elam, and Tidal king of Goiim,"
-          },
+          "en": "And it came to pass in the days of Amraphel king of Shinar, Arioch king of Ellasar, Chedorlaomer king of Elam, and Tidal king of Goiim,",
           "ref": "genesis 14:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "that they made war with Bera king of Sodom, and with Birsha king of Gomorrah, Shinab king of Admah, and Shemeber king of Zeboiim, and the king of Bela—the same is Zoar."
-          },
+          "en": "that they made war with Bera king of Sodom, and with Birsha king of Gomorrah, Shinab king of Admah, and Shemeber king of Zeboiim, and the king of Bela—the same is Zoar.",
           "ref": "genesis 14:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "All these came as allies unto the vale of Siddim—the same is the Salt Sea."
-          },
+          "en": "All these came as allies unto the vale of Siddim—the same is the Salt Sea.",
           "ref": "genesis 14:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "Twelve years they served Chedorlaomer, and in the thirteenth year they rebelled."
-          },
+          "en": "Twelve years they served Chedorlaomer, and in the thirteenth year they rebelled.",
           "ref": "genesis 14:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And in the fourteenth year came Chedorlaomer and the kings that were with him, and smote the Rephaim in Ashteroth-karnaim, and the Zuzim in Ham, and the Emim in Shaveh-kiriathaim,"
-          },
+          "en": "And in the fourteenth year came Chedorlaomer and the kings that were with him, and smote the Rephaim in Ashteroth-karnaim, and the Zuzim in Ham, and the Emim in Shaveh-kiriathaim,",
           "ref": "genesis 14:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "and the Horites in their mount Seir, unto El-paran, which is by the wilderness."
-          },
+          "en": "and the Horites in their mount Seir, unto El-paran, which is by the wilderness.",
           "ref": "genesis 14:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And they turned back, and came to En-mishpat—the same is Kadesh—and smote all the country of the Amalekites, and also the Amorites, that dwelt in Hazazon-tamar."
-          },
+          "en": "And they turned back, and came to En-mishpat—the same is Kadesh—and smote all the country of the Amalekites, and also the Amorites, that dwelt in Hazazon-tamar.",
           "ref": "genesis 14:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And there went out the king of Sodom, and the king of Gomorrah, and the king of Admah, and the king of Zeboiim, and the king of Bela—the same is Zoar; and they set the battle in array against them in the vale of Siddim;"
-          },
+          "en": "And there went out the king of Sodom, and the king of Gomorrah, and the king of Admah, and the king of Zeboiim, and the king of Bela—the same is Zoar; and they set the battle in array against them in the vale of Siddim;",
           "ref": "genesis 14:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "against Chedorlaomer king of Elam, and Tidal king of Goiim, and Amraphel king of Shinar, and Arioch king of Ellasar; four kings against the five."
-          },
+          "en": "against Chedorlaomer king of Elam, and Tidal king of Goiim, and Amraphel king of Shinar, and Arioch king of Ellasar; four kings against the five.",
           "ref": "genesis 14:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "Now the vale of Siddim was full of slime pits; and the kings of Sodom and Gomorrah fled, and they fell there, and they that remained fled to the mountain."
-          },
+          "en": "Now the vale of Siddim was full of slime pits; and the kings of Sodom and Gomorrah fled, and they fell there, and they that remained fled to the mountain.",
           "ref": "genesis 14:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And they took all the goods of Sodom and Gomorrah, and all their victuals, and went their way."
-          },
+          "en": "And they took all the goods of Sodom and Gomorrah, and all their victuals, and went their way.",
           "ref": "genesis 14:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And they took Lot, Abram’s brother’s son, who dwelt in Sodom, and his goods, and departed."
-          },
+          "en": "And they took Lot, Abram’s brother’s son, who dwelt in Sodom, and his goods, and departed.",
           "ref": "genesis 14:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And there came one that had escaped, and told Abram the Hebrew—now he dwelt by the terebinths of Mamre the Amorite, brother of Eshcol, and brother of Aner; and these were confederate with Abram."
-          },
+          "en": "And there came one that had escaped, and told Abram the Hebrew—now he dwelt by the terebinths of Mamre the Amorite, brother of Eshcol, and brother of Aner; and these were confederate with Abram.",
           "ref": "genesis 14:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Abram heard that his brother was taken captive, he led forth his trained men, born in his house, three hundred and eighteen, and pursued as far as Dan."
-          },
+          "en": "And when Abram heard that his brother was taken captive, he led forth his trained men, born in his house, three hundred and eighteen, and pursued as far as Dan.",
           "ref": "genesis 14:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And he divided himself against them by night, he and his servants, and smote them, and pursued them unto Hobah, which is on the left hand of Damascus."
-          },
+          "en": "And he divided himself against them by night, he and his servants, and smote them, and pursued them unto Hobah, which is on the left hand of Damascus.",
           "ref": "genesis 14:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And he brought back all the goods, and also brought back his brother Lot, and his goods, and the women also, and the people."
-          },
+          "en": "And he brought back all the goods, and also brought back his brother Lot, and his goods, and the women also, and the people.",
           "ref": "genesis 14:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And the king of Sodom went out to meet him, after his return from the slaughter of Chedorlaomer and the kings that were with him, at the vale of Shaveh—the same is the King’s Vale."
-          },
+          "en": "And the king of Sodom went out to meet him, after his return from the slaughter of Chedorlaomer and the kings that were with him, at the vale of Shaveh—the same is the King’s Vale.",
           "ref": "genesis 14:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Melchizedek king of Salem brought forth bread and wine; and he was priest of God the Most High."
-          },
+          "en": "And Melchizedek king of Salem brought forth bread and wine; and he was priest of God the Most High.",
           "ref": "genesis 14:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And he blessed him, and said: ‘Blessed be Abram of God Most High, Maker of heaven and earth;"
-          },
+          "en": "And he blessed him, and said: ‘Blessed be Abram of God Most High, Maker of heaven and earth;",
           "ref": "genesis 14:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "and blessed be God the Most High, who hath delivered thine enemies into thy hand.’ And he gave him a tenth of all."
-          },
+          "en": "and blessed be God the Most High, who hath delivered thine enemies into thy hand.’ And he gave him a tenth of all.",
           "ref": "genesis 14:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And the king of Sodom said unto Abram: ‘Give me the persons, and take the goods to thyself.’"
-          },
+          "en": "And the king of Sodom said unto Abram: ‘Give me the persons, and take the goods to thyself.’",
           "ref": "genesis 14:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abram said to the king of Sodom: ‘I have lifted up my hand unto the LORD, God Most High, Maker of heaven and earth,"
-          },
+          "en": "And Abram said to the king of Sodom: ‘I have lifted up my hand unto the LORD, God Most High, Maker of heaven and earth,",
           "ref": "genesis 14:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "that I will not take a thread nor a shoe-latchet nor aught that is thine, lest thou shouldest say: I have made Abram rich;"
-          },
+          "en": "that I will not take a thread nor a shoe-latchet nor aught that is thine, lest thou shouldest say: I have made Abram rich;",
           "ref": "genesis 14:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "save only that which the young men have eaten, and the portion of the men which went with me, Aner, Eshcol, and Mamre, let them take their portion.’"
-          },
+          "en": "save only that which the young men have eaten, and the portion of the men which went with me, Aner, Eshcol, and Mamre, let them take their portion.’",
           "ref": "genesis 14:24"
         }
       ]
@@ -2965,170 +1882,107 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "After these things the word of the LORD came unto Abram in a vision, saying: ‘Fear not, Abram, I am thy shield, thy reward shall be exceeding great.’"
-          },
+          "en": "After these things the word of the LORD came unto Abram in a vision, saying: ‘Fear not, Abram, I am thy shield, thy reward shall be exceeding great.’",
           "ref": "genesis 15:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abram said: ‘O Lord GOD, what wilt Thou give me, seeing I go hence childless, and he that shall be possessor of my house is Eliezer of Damascus?’"
-          },
+          "en": "And Abram said: ‘O Lord GOD, what wilt Thou give me, seeing I go hence childless, and he that shall be possessor of my house is Eliezer of Damascus?’",
           "ref": "genesis 15:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abram said: ‘Behold, to me Thou hast given no seed, and, lo, one born in my house is to be mine heir.’"
-          },
+          "en": "And Abram said: ‘Behold, to me Thou hast given no seed, and, lo, one born in my house is to be mine heir.’",
           "ref": "genesis 15:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And, behold, the word of the LORD came unto him, saying: ‘This man shall not be thine heir; but he that shall come forth out of thine own bowels shall be thine heir.’"
-          },
+          "en": "And, behold, the word of the LORD came unto him, saying: ‘This man shall not be thine heir; but he that shall come forth out of thine own bowels shall be thine heir.’",
           "ref": "genesis 15:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And He brought him forth abroad, and said: ‘Look now toward heaven, and count the stars, if thou be able to count them’; and He said unto him: ‘So shall thy seed be.’"
-          },
+          "en": "And He brought him forth abroad, and said: ‘Look now toward heaven, and count the stars, if thou be able to count them’; and He said unto him: ‘So shall thy seed be.’",
           "ref": "genesis 15:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And he believed in the LORD; and He counted it to him for righteousness."
-          },
+          "en": "And he believed in the LORD; and He counted it to him for righteousness.",
           "ref": "genesis 15:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And He said unto him: ‘I am the LORD that brought thee out of Ur of the Chaldees, to give thee this land to inherit it.’"
-          },
+          "en": "And He said unto him: ‘I am the LORD that brought thee out of Ur of the Chaldees, to give thee this land to inherit it.’",
           "ref": "genesis 15:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘O Lord GOD, whereby shall I know that I shall inherit it?’"
-          },
+          "en": "And he said: ‘O Lord GOD, whereby shall I know that I shall inherit it?’",
           "ref": "genesis 15:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And He said unto him: ‘Take Me a heifer of three years old, and a she-goat of three years old, and a ram of three years old, and a turtle-dove, and a young pigeon.’"
-          },
+          "en": "And He said unto him: ‘Take Me a heifer of three years old, and a she-goat of three years old, and a ram of three years old, and a turtle-dove, and a young pigeon.’",
           "ref": "genesis 15:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And he took him all these, and divided them in the midst, and laid each half over against the other; but the birds divided he not."
-          },
+          "en": "And he took him all these, and divided them in the midst, and laid each half over against the other; but the birds divided he not.",
           "ref": "genesis 15:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And the birds of prey came down upon the carcasses, and Abram drove them away."
-          },
+          "en": "And the birds of prey came down upon the carcasses, and Abram drove them away.",
           "ref": "genesis 15:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, that, when the sun was going down, a deep sleep fell upon Abram; and, lo, a dread, even a great darkness, fell upon him."
-          },
+          "en": "And it came to pass, that, when the sun was going down, a deep sleep fell upon Abram; and, lo, a dread, even a great darkness, fell upon him.",
           "ref": "genesis 15:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And He said unto Abram: ‘Know of a surety that thy seed shall be a stranger in a land that is not theirs, and shall serve them; and they shall afflict them four hundred years;"
-          },
+          "en": "And He said unto Abram: ‘Know of a surety that thy seed shall be a stranger in a land that is not theirs, and shall serve them; and they shall afflict them four hundred years;",
           "ref": "genesis 15:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "and also that nation, whom they shall serve, will I judge; and afterward shall they come out with great substance."
-          },
+          "en": "and also that nation, whom they shall serve, will I judge; and afterward shall they come out with great substance.",
           "ref": "genesis 15:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "But thou shalt go to thy fathers in peace; thou shalt be buried in a good old age."
-          },
+          "en": "But thou shalt go to thy fathers in peace; thou shalt be buried in a good old age.",
           "ref": "genesis 15:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And in the fourth generation they shall come back hither; for the iniquity of the Amorite is not yet full.’"
-          },
+          "en": "And in the fourth generation they shall come back hither; for the iniquity of the Amorite is not yet full.’",
           "ref": "genesis 15:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, that, when the sun went down, and there was thick darkness, behold a smoking furnace, and a flaming torch that passed between these pieces."
-          },
+          "en": "And it came to pass, that, when the sun went down, and there was thick darkness, behold a smoking furnace, and a flaming torch that passed between these pieces.",
           "ref": "genesis 15:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "In that day the LORD made a covenant with Abram, saying: ‘Unto thy seed have I given this land, from the river of Egypt unto the great river, the river Euphrates;"
-          },
+          "en": "In that day the LORD made a covenant with Abram, saying: ‘Unto thy seed have I given this land, from the river of Egypt unto the great river, the river Euphrates;",
           "ref": "genesis 15:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "the Kenite, and the Kenizzite, and the Kadmonite,"
-          },
+          "en": "the Kenite, and the Kenizzite, and the Kadmonite,",
           "ref": "genesis 15:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "and the Hittite, and the Perizzite, and the Rephaim,"
-          },
+          "en": "and the Hittite, and the Perizzite, and the Rephaim,",
           "ref": "genesis 15:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "and the Amorite, and the Canaanite, and the Girgashite, and the Jebusite.’"
-          },
+          "en": "and the Amorite, and the Canaanite, and the Girgashite, and the Jebusite.’",
           "ref": "genesis 15:21"
         }
       ]
@@ -3138,130 +1992,82 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "Now Sarai Abram’s wife bore him no children; and she had a handmaid, an Egyptian, whose name was Hagar."
-          },
+          "en": "Now Sarai Abram’s wife bore him no children; and she had a handmaid, an Egyptian, whose name was Hagar.",
           "ref": "genesis 16:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Sarai said unto Abram: ‘Behold now, the LORD hath restrained me from bearing; go in, I pray thee, unto my handmaid; it may be that I shall be builded up through her.’ And Abram hearkened to the voice of Sarai."
-          },
+          "en": "And Sarai said unto Abram: ‘Behold now, the LORD hath restrained me from bearing; go in, I pray thee, unto my handmaid; it may be that I shall be builded up through her.’ And Abram hearkened to the voice of Sarai.",
           "ref": "genesis 16:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Sarai Abram’s wife took Hagar the Egyptian, her handmaid, after Abram had dwelt ten years in the land of Canaan, and gave her to Abram her husband to be his wife."
-          },
+          "en": "And Sarai Abram’s wife took Hagar the Egyptian, her handmaid, after Abram had dwelt ten years in the land of Canaan, and gave her to Abram her husband to be his wife.",
           "ref": "genesis 16:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And he went in unto Hagar, and she conceived; and when she saw that she had conceived, her mistress was despised in her eyes."
-          },
+          "en": "And he went in unto Hagar, and she conceived; and when she saw that she had conceived, her mistress was despised in her eyes.",
           "ref": "genesis 16:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And Sarai said unto Abram: ‘My wrong be upon thee: I gave my handmaid into thy bosom; and when she saw that she had conceived, I was despised in her eyes: the LORD judge between me and thee.’"
-          },
+          "en": "And Sarai said unto Abram: ‘My wrong be upon thee: I gave my handmaid into thy bosom; and when she saw that she had conceived, I was despised in her eyes: the LORD judge between me and thee.’",
           "ref": "genesis 16:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "But Abram said unto Sarai: ‘Behold, thy maid is in thy hand; do to her that which is good in thine eyes.’ And Sarai dealt harshly with her, and she fled from her face."
-          },
+          "en": "But Abram said unto Sarai: ‘Behold, thy maid is in thy hand; do to her that which is good in thine eyes.’ And Sarai dealt harshly with her, and she fled from her face.",
           "ref": "genesis 16:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And the angel of the LORD found her by a fountain of water in the wilderness, by the fountain in the way to Shur."
-          },
+          "en": "And the angel of the LORD found her by a fountain of water in the wilderness, by the fountain in the way to Shur.",
           "ref": "genesis 16:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Hagar, Sarai’s handmaid, whence camest thou? and whither goest thou?’ And she said: ‘I flee from the face of my mistress Sarai.’"
-          },
+          "en": "And he said: ‘Hagar, Sarai’s handmaid, whence camest thou? and whither goest thou?’ And she said: ‘I flee from the face of my mistress Sarai.’",
           "ref": "genesis 16:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And the angel of the LORD said unto her: ‘Return to thy mistress, and submit thyself under her hands.’"
-          },
+          "en": "And the angel of the LORD said unto her: ‘Return to thy mistress, and submit thyself under her hands.’",
           "ref": "genesis 16:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And the angel of the LORD said unto her: ‘I will greatly multiply thy seed, that it shall not be numbered for multitude."
-          },
+          "en": "And the angel of the LORD said unto her: ‘I will greatly multiply thy seed, that it shall not be numbered for multitude.",
           "ref": "genesis 16:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And the angel of the LORD said unto her: ‘Behold, thou art with child, and shalt bear a son; and thou shalt call his name Ishmael, because the LORD hath heard thy affliction."
-          },
+          "en": "And the angel of the LORD said unto her: ‘Behold, thou art with child, and shalt bear a son; and thou shalt call his name Ishmael, because the LORD hath heard thy affliction.",
           "ref": "genesis 16:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And he shall be a wild ass of a man: his hand shall be against every man, and every man’s hand against him; and he shall dwell in the face of all his brethren.’"
-          },
+          "en": "And he shall be a wild ass of a man: his hand shall be against every man, and every man’s hand against him; and he shall dwell in the face of all his brethren.’",
           "ref": "genesis 16:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And she called the name of the LORD that spoke unto her, Thou art a God of seeing; for she said: ‘Have I even here seen Him that seeth Me?’"
-          },
+          "en": "And she called the name of the LORD that spoke unto her, Thou art a God of seeing; for she said: ‘Have I even here seen Him that seeth Me?’",
           "ref": "genesis 16:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "Wherefore the well was called Beer-lahai-roi; behold, it is between Kadesh and Bered."
-          },
+          "en": "Wherefore the well was called Beer-lahai-roi; behold, it is between Kadesh and Bered.",
           "ref": "genesis 16:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": "And Hagar bore to Avram a son, and Avram called the name of his son that Hagar bore \"Yishmael\"",
-            "jps1917": "And Hagar bore Abram a son; and Abram called the name of his son, whom Hagar bore, Ishmael."
-          },
+          "en": "And Hagar bore Abram a son; and Abram called the name of his son, whom Hagar bore, Ishmael.",
           "ref": "genesis 16:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abram was fourscore and six years old, when Hagar bore Ishmael to Abram."
-          },
+          "en": "And Abram was fourscore and six years old, when Hagar bore Ishmael to Abram.",
           "ref": "genesis 16:16"
         }
       ]
@@ -3271,218 +2077,137 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Abram was ninety years old and nine, the LORD appeared to Abram, and said unto him: ‘I am God Almighty; walk before Me, and be thou wholehearted."
-          },
+          "en": "And when Abram was ninety years old and nine, the LORD appeared to Abram, and said unto him: ‘I am God Almighty; walk before Me, and be thou wholehearted.",
           "ref": "genesis 17:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will make My covenant between Me and thee, and will multiply thee exceedingly.’"
-          },
+          "en": "And I will make My covenant between Me and thee, and will multiply thee exceedingly.’",
           "ref": "genesis 17:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abram fell on his face; and God talked with him, saying:"
-          },
+          "en": "And Abram fell on his face; and God talked with him, saying:",
           "ref": "genesis 17:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "’As for Me, behold, My covenant is with thee, and thou shalt be the father of a multitude of nations."
-          },
+          "en": "’As for Me, behold, My covenant is with thee, and thou shalt be the father of a multitude of nations.",
           "ref": "genesis 17:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "Neither shall thy name any more be called Abram, but thy name shall be Abraham; for the father of a multitude of nations have I made thee."
-          },
+          "en": "Neither shall thy name any more be called Abram, but thy name shall be Abraham; for the father of a multitude of nations have I made thee.",
           "ref": "genesis 17:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will make thee exceeding fruitful, and I will make nations of thee, and kings shall come out of thee."
-          },
+          "en": "And I will make thee exceeding fruitful, and I will make nations of thee, and kings shall come out of thee.",
           "ref": "genesis 17:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will establish My covenant between Me and thee and thy seed after thee throughout their generations for an everlasting covenant, to be a God unto thee and to thy seed after thee."
-          },
+          "en": "And I will establish My covenant between Me and thee and thy seed after thee throughout their generations for an everlasting covenant, to be a God unto thee and to thy seed after thee.",
           "ref": "genesis 17:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will give unto thee, and to thy seed after thee, the land of thy sojournings, all the land of Canaan, for an everlasting possession; and I will be their God.’"
-          },
+          "en": "And I will give unto thee, and to thy seed after thee, the land of thy sojournings, all the land of Canaan, for an everlasting possession; and I will be their God.’",
           "ref": "genesis 17:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said unto Abraham: ‘And as for thee, thou shalt keep My covenant, thou, and thy seed after thee throughout their generations."
-          },
+          "en": "And God said unto Abraham: ‘And as for thee, thou shalt keep My covenant, thou, and thy seed after thee throughout their generations.",
           "ref": "genesis 17:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "This is My covenant, which ye shall keep, between Me and you and thy seed after thee: every male among you shall be circumcised."
-          },
+          "en": "This is My covenant, which ye shall keep, between Me and you and thy seed after thee: every male among you shall be circumcised.",
           "ref": "genesis 17:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And ye shall be circumcised in the flesh of your foreskin; and it shall be a token of a covenant betwixt Me and you."
-          },
+          "en": "And ye shall be circumcised in the flesh of your foreskin; and it shall be a token of a covenant betwixt Me and you.",
           "ref": "genesis 17:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And he that is eight days old shall be circumcised among you, every male throughout your generations, he that is born in the house, or bought with money of any foreigner, that is not of thy seed."
-          },
+          "en": "And he that is eight days old shall be circumcised among you, every male throughout your generations, he that is born in the house, or bought with money of any foreigner, that is not of thy seed.",
           "ref": "genesis 17:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "He that is born in thy house, and he that is bought with thy money, must needs be circumcised; and My covenant shall be in your flesh for an everlasting covenant."
-          },
+          "en": "He that is born in thy house, and he that is bought with thy money, must needs be circumcised; and My covenant shall be in your flesh for an everlasting covenant.",
           "ref": "genesis 17:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And the uncircumcised male who is not circumcised in the flesh of his foreskin, that soul shall be cut off from his people; he hath broken My covenant.’"
-          },
+          "en": "And the uncircumcised male who is not circumcised in the flesh of his foreskin, that soul shall be cut off from his people; he hath broken My covenant.’",
           "ref": "genesis 17:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said unto Abraham: ‘As for Sarai thy wife, thou shalt not call her name Sarai, but Sarah shall her name be."
-          },
+          "en": "And God said unto Abraham: ‘As for Sarai thy wife, thou shalt not call her name Sarai, but Sarah shall her name be.",
           "ref": "genesis 17:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will bless her, and moreover I will give thee a son of her; yea, I will bless her, and she shall be a mother of nations; kings of peoples shall be of her.’"
-          },
+          "en": "And I will bless her, and moreover I will give thee a son of her; yea, I will bless her, and she shall be a mother of nations; kings of peoples shall be of her.’",
           "ref": "genesis 17:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Abraham fell upon his face, and laughed, and said in his heart: ‘Shall a child be born unto him that is a hundred years old? and shall Sarah, that is ninety years old, bear?’"
-          },
+          "en": "Then Abraham fell upon his face, and laughed, and said in his heart: ‘Shall a child be born unto him that is a hundred years old? and shall Sarah, that is ninety years old, bear?’",
           "ref": "genesis 17:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham said unto God: ‘Oh that Ishmael might live before Thee! ’"
-          },
+          "en": "And Abraham said unto God: ‘Oh that Ishmael might live before Thee! ’",
           "ref": "genesis 17:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said: ‘‘Nay, but Sarah thy wife shall bear thee a son; and thou shalt call his name Isaac; and I will establish My covenant with him for an everlasting covenant for his seed after him."
-          },
+          "en": "And God said: ‘‘Nay, but Sarah thy wife shall bear thee a son; and thou shalt call his name Isaac; and I will establish My covenant with him for an everlasting covenant for his seed after him.",
           "ref": "genesis 17:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And as for Ishmael, I have heard thee; behold, I have blessed him, and will make him fruitful, and will multiply him exceedingly; twelve princes shall he beget, and I will make him a great nation."
-          },
+          "en": "And as for Ishmael, I have heard thee; behold, I have blessed him, and will make him fruitful, and will multiply him exceedingly; twelve princes shall he beget, and I will make him a great nation.",
           "ref": "genesis 17:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "But My covenant will I establish with Isaac, whom Sarah shall bear unto thee at this set time in the next year.’"
-          },
+          "en": "But My covenant will I establish with Isaac, whom Sarah shall bear unto thee at this set time in the next year.’",
           "ref": "genesis 17:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And He left off talking with him, and God went up from Abraham."
-          },
+          "en": "And He left off talking with him, and God went up from Abraham.",
           "ref": "genesis 17:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham took Ishmael his son, and all that were born in his house, and all that were bought with his money, every male among the men of Abraham’s house, and circumcised the flesh of their foreskin in the selfsame day, as God had said unto him."
-          },
+          "en": "And Abraham took Ishmael his son, and all that were born in his house, and all that were bought with his money, every male among the men of Abraham’s house, and circumcised the flesh of their foreskin in the selfsame day, as God had said unto him.",
           "ref": "genesis 17:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham was ninety years old and nine, when he was circumcised in the flesh of his foreskin."
-          },
+          "en": "And Abraham was ninety years old and nine, when he was circumcised in the flesh of his foreskin.",
           "ref": "genesis 17:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And Ishmael his son was thirteen years old, when he was circumcised in the flesh of his foreskin."
-          },
+          "en": "And Ishmael his son was thirteen years old, when he was circumcised in the flesh of his foreskin.",
           "ref": "genesis 17:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "In the selfsame day was Abraham circumcised, and Ishmael his son."
-          },
+          "en": "In the selfsame day was Abraham circumcised, and Ishmael his son.",
           "ref": "genesis 17:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And all the men of his house, those born in the house, and those bought with money of a foreigner, were circumcised with him."
-          },
+          "en": "And all the men of his house, those born in the house, and those bought with money of a foreigner, were circumcised with him.",
           "ref": "genesis 17:27"
         }
       ]
@@ -3492,266 +2217,167 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD appeared unto him by the terebinths of Mamre, as he sat in the tent door in the heat of the day;"
-          },
+          "en": "And the LORD appeared unto him by the terebinths of Mamre, as he sat in the tent door in the heat of the day;",
           "ref": "genesis 18:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "and he lifted up his eyes and looked, and, lo, three men stood over against him; and when he saw them, he ran to meet them from the tent door, and bowed down to the earth,"
-          },
+          "en": "and he lifted up his eyes and looked, and, lo, three men stood over against him; and when he saw them, he ran to meet them from the tent door, and bowed down to the earth,",
           "ref": "genesis 18:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "and said: ‘My lord, if now I have found favour in thy sight, pass not away, I pray thee, from thy servant."
-          },
+          "en": "and said: ‘My lord, if now I have found favour in thy sight, pass not away, I pray thee, from thy servant.",
           "ref": "genesis 18:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "Let now a little water be fetched, and wash your feet, and recline yourselves under the tree."
-          },
+          "en": "Let now a little water be fetched, and wash your feet, and recline yourselves under the tree.",
           "ref": "genesis 18:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will fetch a morsel of bread, and stay ye your heart; after that ye shall pass on; forasmuch as ye are come to your servant.’ And they said: ‘So do, as thou hast said.’"
-          },
+          "en": "And I will fetch a morsel of bread, and stay ye your heart; after that ye shall pass on; forasmuch as ye are come to your servant.’ And they said: ‘So do, as thou hast said.’",
           "ref": "genesis 18:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham hastened into the tent unto Sarah, and said: ‘Make ready quickly three measures of fine meal, knead it, and make cakes.’"
-          },
+          "en": "And Abraham hastened into the tent unto Sarah, and said: ‘Make ready quickly three measures of fine meal, knead it, and make cakes.’",
           "ref": "genesis 18:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham ran unto the herd, and fetched a calf tender and good, and gave it unto the servant; and he hastened to dress it."
-          },
+          "en": "And Abraham ran unto the herd, and fetched a calf tender and good, and gave it unto the servant; and he hastened to dress it.",
           "ref": "genesis 18:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And he took curd, and milk, and the calf which he had dressed, and set it before them; and he stood by them under the tree, and they did eat."
-          },
+          "en": "And he took curd, and milk, and the calf which he had dressed, and set it before them; and he stood by them under the tree, and they did eat.",
           "ref": "genesis 18:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said unto him: ‘Where is Sarah thy wife?’ And he said: ‘Behold, in the tent.’"
-          },
+          "en": "And they said unto him: ‘Where is Sarah thy wife?’ And he said: ‘Behold, in the tent.’",
           "ref": "genesis 18:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And He said: ‘I will certainly return unto thee when the season cometh round; and, lo, Sarah thy wife shall have a son.’ And Sarah heard in the tent door, which was behind him.—"
-          },
+          "en": "And He said: ‘I will certainly return unto thee when the season cometh round; and, lo, Sarah thy wife shall have a son.’ And Sarah heard in the tent door, which was behind him.—",
           "ref": "genesis 18:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "Now Abraham and Sarah were old, and well stricken in age; it had ceased to be with Sarah after the manner of women.—"
-          },
+          "en": "Now Abraham and Sarah were old, and well stricken in age; it had ceased to be with Sarah after the manner of women.—",
           "ref": "genesis 18:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And Sarah laughed within herself, saying: ‘After I am waxed old shall I have pleasure, my lord being old also?’"
-          },
+          "en": "And Sarah laughed within herself, saying: ‘After I am waxed old shall I have pleasure, my lord being old also?’",
           "ref": "genesis 18:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto Abraham: ‘Wherefore did Sarah laugh, saying: Shall I of a surety bear a child, who am old?"
-          },
+          "en": "And the LORD said unto Abraham: ‘Wherefore did Sarah laugh, saying: Shall I of a surety bear a child, who am old?",
           "ref": "genesis 18:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "Is any thing too hard for the LORD. At the set time I will return unto thee, when the season cometh round, and Sarah shall have a son.’"
-          },
+          "en": "Is any thing too hard for the LORD. At the set time I will return unto thee, when the season cometh round, and Sarah shall have a son.’",
           "ref": "genesis 18:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Sarah denied, saying: ‘I laughed not’; for she was afraid. And He said: ‘Nay; but thou didst laugh.’"
-          },
+          "en": "Then Sarah denied, saying: ‘I laughed not’; for she was afraid. And He said: ‘Nay; but thou didst laugh.’",
           "ref": "genesis 18:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And the men rose up from thence, and looked out toward Sodom; and Abraham went with them to bring them on the way."
-          },
+          "en": "And the men rose up from thence, and looked out toward Sodom; and Abraham went with them to bring them on the way.",
           "ref": "genesis 18:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said: ‘Shall I hide from Abraham that which I am doing;"
-          },
+          "en": "And the LORD said: ‘Shall I hide from Abraham that which I am doing;",
           "ref": "genesis 18:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "seeing that Abraham shall surely become a great and mighty nation, and all the nations of the earth shall be blessed in him?"
-          },
+          "en": "seeing that Abraham shall surely become a great and mighty nation, and all the nations of the earth shall be blessed in him?",
           "ref": "genesis 18:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "For I have known him, to the end that he may command his children and his household after him, that they may keep the way of the LORD, to do righteousness and justice; to the end that the LORD may bring upon Abraham that which He hath spoken of him.’"
-          },
+          "en": "For I have known him, to the end that he may command his children and his household after him, that they may keep the way of the LORD, to do righteousness and justice; to the end that the LORD may bring upon Abraham that which He hath spoken of him.’",
           "ref": "genesis 18:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said: ‘Verily, the cry of Sodom and Gomorrah is great, and, verily, their sin is exceeding grievous."
-          },
+          "en": "And the LORD said: ‘Verily, the cry of Sodom and Gomorrah is great, and, verily, their sin is exceeding grievous.",
           "ref": "genesis 18:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "I will go down now, and see whether they have done altogether according to the cry of it, which is come unto Me; and if not, I will know.’"
-          },
+          "en": "I will go down now, and see whether they have done altogether according to the cry of it, which is come unto Me; and if not, I will know.’",
           "ref": "genesis 18:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And the men turned from thence, and went toward Sodom; but Abraham stood yet before the LORD."
-          },
+          "en": "And the men turned from thence, and went toward Sodom; but Abraham stood yet before the LORD.",
           "ref": "genesis 18:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham drew near, and said: ‘Will You indeed sweep away the righteous with the wicked?"
-          },
+          "en": "And Abraham drew near, and said: ‘Will You indeed sweep away the righteous with the wicked?",
           "ref": "genesis 18:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "Peradventure there are fifty righteous within the city; wilt Thou indeed sweep away and not forgive the place for the fifty righteous that are therein?"
-          },
+          "en": "Peradventure there are fifty righteous within the city; wilt Thou indeed sweep away and not forgive the place for the fifty righteous that are therein?",
           "ref": "genesis 18:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "That be far from Thee to do after this manner, to slay the righteous with the wicked, that so the righteous should be as the wicked; that be far from Thee; shall not the judge of all the earth do justly?’"
-          },
+          "en": "That be far from Thee to do after this manner, to slay the righteous with the wicked, that so the righteous should be as the wicked; that be far from Thee; shall not the judge of all the earth do justly?’",
           "ref": "genesis 18:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said: ‘If I find in Sodom fifty righteous within the city, then I will forgive all the place for their sake.’"
-          },
+          "en": "And the LORD said: ‘If I find in Sodom fifty righteous within the city, then I will forgive all the place for their sake.’",
           "ref": "genesis 18:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham answered and said: ‘Behold now, I have taken upon me to speak unto the Lord, who am but dust and ashes."
-          },
+          "en": "And Abraham answered and said: ‘Behold now, I have taken upon me to speak unto the Lord, who am but dust and ashes.",
           "ref": "genesis 18:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "Peradventure there shall lack five of the fifty righteous; wilt Thou destroy all the city for lack of five?’ And He said: ‘I will not destroy it, if I find there forty and five.’"
-          },
+          "en": "Peradventure there shall lack five of the fifty righteous; wilt Thou destroy all the city for lack of five?’ And He said: ‘I will not destroy it, if I find there forty and five.’",
           "ref": "genesis 18:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And he spoke unto Him yet again, and said: ‘Peradventure there shall be forty found there.’ And He said: ‘I will not do it for the forty’s sake.’"
-          },
+          "en": "And he spoke unto Him yet again, and said: ‘Peradventure there shall be forty found there.’ And He said: ‘I will not do it for the forty’s sake.’",
           "ref": "genesis 18:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Oh, let not the Lord be angry, and I will speak. Peradventure there shall thirty be found there.’ And He said: ‘I will not do it, if I find thirty there.’"
-          },
+          "en": "And he said: ‘Oh, let not the Lord be angry, and I will speak. Peradventure there shall thirty be found there.’ And He said: ‘I will not do it, if I find thirty there.’",
           "ref": "genesis 18:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Behold now, I have taken upon me to speak unto the Lord. Peradventure there shall be twenty found there.’ And He said: ‘I will not destroy it for the twenty’s sake.’"
-          },
+          "en": "And he said: ‘Behold now, I have taken upon me to speak unto the Lord. Peradventure there shall be twenty found there.’ And He said: ‘I will not destroy it for the twenty’s sake.’",
           "ref": "genesis 18:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Oh, let not the Lord be angry, and I will speak yet but this once. Peradventure ten shall be found there.’ And He said: ‘I will not destroy it for the ten’s sake.’"
-          },
+          "en": "And he said: ‘Oh, let not the Lord be angry, and I will speak yet but this once. Peradventure ten shall be found there.’ And He said: ‘I will not destroy it for the ten’s sake.’",
           "ref": "genesis 18:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD went His way, as soon as He had left off speaking to Abraham; and Abraham returned unto his place."
-          },
+          "en": "And the LORD went His way, as soon as He had left off speaking to Abraham; and Abraham returned unto his place.",
           "ref": "genesis 18:33"
         }
       ]
@@ -3761,306 +2387,192 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": "1  Los dos ángeles llegaron a Sodoma por la tarde. Lot estaba sentado a la puerta de Sodoma. Al verlos, Lot se levantó a su encuentro y, postrándose rostro en tierra,",
-            "jps1917": "And the two angels came to Sodom at even; and Lot sat in the gate of Sodom; and Lot saw them, and rose up to meet them; and he fell down on his face to the earth;"
-          },
+          "en": "And the two angels came to Sodom at even; and Lot sat in the gate of Sodom; and Lot saw them, and rose up to meet them; and he fell down on his face to the earth;",
           "ref": "genesis 19:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": "2  dijo: \"Os ruego, señores, que vengáis a la casa de este servidor vuestro. Hacéis noche, os laváis los pies, y de madrugada seguiréis vuestro camino.\" Ellos dijeron: \"No; haremos noche en la plaza.\"",
-            "jps1917": "and he said: ‘Behold now, my lords, turn aside, I pray you, into your servant’s house, and tarry all night, and wash your feet, and ye shall rise up early, and go on your way.’ And they said: ‘Nay; but we will abide in the broad place all night.’"
-          },
+          "en": "and he said: ‘Behold now, my lords, turn aside, I pray you, into your servant’s house, and tarry all night, and wash your feet, and ye shall rise up early, and go on your way.’ And they said: ‘Nay; but we will abide in the broad place all night.’",
           "ref": "genesis 19:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": "3  Pero tanto porfió con ellos, que al fin se hospedaron en su casa. Él les preparó una comida cociendo unos panes cenceños y comieron.",
-            "jps1917": "And he urged them greatly; and they turned in unto him, and entered into his house; and he made them a feast, and did bake unleavened bread, and they did eat."
-          },
+          "en": "And he urged them greatly; and they turned in unto him, and entered into his house; and he made them a feast, and did bake unleavened bread, and they did eat.",
           "ref": "genesis 19:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": "4  No bien se habían acostado, cuando los hombres de la ciudad, los sodomitas, rodearon la casa desde el mozo hasta el viejo, todo el pueblo sin excepción.",
-            "jps1917": "But before they lay down, the men of the city, even the men of Sodom, compassed the house round, both young and old, all the people from every quarter."
-          },
+          "en": "But before they lay down, the men of the city, even the men of Sodom, compassed the house round, both young and old, all the people from every quarter.",
           "ref": "genesis 19:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": "5  Llamaron a voces a Lot y le dijeron: \"¿Dónde están los hombres que han venido adonde ti esta noche? Sácalos, para que abusemos de ellos.\"",
-            "jps1917": "And they called unto Lot, and said unto him: ‘Where are the men that came in to thee this night? bring them out unto us, that we may know them.’"
-          },
+          "en": "And they called unto Lot, and said unto him: ‘Where are the men that came in to thee this night? bring them out unto us, that we may know them.’",
           "ref": "genesis 19:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": "6  Lot salió donde ellos a la entrada, cerró la puerta detrás de sí,",
-            "jps1917": "And Lot went out unto them to the door, and shut the door after him."
-          },
+          "en": "And Lot went out unto them to the door, and shut the door after him.",
           "ref": "genesis 19:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": "7  y dijo: \"Por favor, hermanos, no hagáis esta maldad.",
-            "jps1917": "And he said: ‘I pray you, my brethren, do not so wickedly."
-          },
+          "en": "And he said: ‘I pray you, my brethren, do not so wickedly.",
           "ref": "genesis 19:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": "8  Mirad, aquí tengo dos hijas que aún no han conocido varón. Os las sacaré y haced con ellas como bien os parezca; pero a estos hombres no les hagáis nada, que para eso han venido al amparo de mi techo.\"",
-            "jps1917": "Behold now, I have two daughters that have not known man; let me, I pray you, bring them out unto you, and do ye to them as is good in your eyes; only unto these men do nothing; forasmuch as they are come under the shadow of my roof.’"
-          },
+          "en": "Behold now, I have two daughters that have not known man; let me, I pray you, bring them out unto you, and do ye to them as is good in your eyes; only unto these men do nothing; forasmuch as they are come under the shadow of my roof.’",
           "ref": "genesis 19:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": "9  Pero ellos respondieron: \"¡Venga ya! Uno que ha venido a avecindarse, ¿va a meterse a juez? Ahora te trataremos a ti peor que a ellos.\" Y forcejearon con él, con Lot, de tal modo que estaban a punto de romper la puerta.",
-            "jps1917": "And they said: ‘Stand back.’ And they said: ‘This one fellow came in to sojourn, and he will needs play the judge; now will we deal worse with thee, than with them.’ And they pressed sore upon the man, even Lot, and drew near to break the door."
-          },
+          "en": "And they said: ‘Stand back.’ And they said: ‘This one fellow came in to sojourn, and he will needs play the judge; now will we deal worse with thee, than with them.’ And they pressed sore upon the man, even Lot, and drew near to break the door.",
           "ref": "genesis 19:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": "10  Pero los hombres alargaron las manos, tiraron de Lot hacia sí, adentro de la casa, cerraron la puerta,",
-            "jps1917": "But the men put forth their hand, and brought Lot into the house to them, and the door they shut."
-          },
+          "en": "But the men put forth their hand, and brought Lot into the house to them, and the door they shut.",
           "ref": "genesis 19:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": "11  y a los hombres que estaban a la entrada de la casa los dejaron deslumbrados desde el chico hasta el grande, y mal se vieron para encontrar la puerta.",
-            "jps1917": "And they smote the men that were at the door of the house with blindness, both small and great; so that they wearied themselves to find the door."
-          },
+          "en": "And they smote the men that were at the door of the house with blindness, both small and great; so that they wearied themselves to find the door.",
           "ref": "genesis 19:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": "12  Los hombres dijeron a Lot: \"¿A quién más tienes aquí? Saca de este lugar a tus hijos e hijas y a quienquiera que tengas en la ciudad,",
-            "jps1917": "And the men said unto Lot: ‘Hast thou here any besides? son-in-law, and thy sons, and thy daughters, and whomsoever thou hast in the city; bring them out of the place;"
-          },
+          "en": "And the men said unto Lot: ‘Hast thou here any besides? son-in-law, and thy sons, and thy daughters, and whomsoever thou hast in the city; bring them out of the place;",
           "ref": "genesis 19:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": "13  porque vamos a destruir este lugar, que es grave la queja que contra ellos ha llegado a Yahvé, y Yahvé nos ha enviado a destruirlos.\"",
-            "jps1917": "for we will destroy this place, because the cry of them is waxed great before the LORD; and the LORD hath sent us to destroy it.’"
-          },
+          "en": "for we will destroy this place, because the cry of them is waxed great before the LORD; and the LORD hath sent us to destroy it.’",
           "ref": "genesis 19:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": "14  Salió Lot y habló con sus yernos, los prometidos de sus hijas: \"Levantaos, dijo; salid de este lugar, porque Yahvé va a destruir la ciudad.\" Pero sus yernos le tomaron a broma.",
-            "jps1917": "And Lot went out, and spoke unto his sons-in-law, who married his daughters, and said: ‘Up, get you out of this place; for the LORD will destroy the city.’ But he seemed unto his sons-in-law as one that jested."
-          },
+          "en": "And Lot went out, and spoke unto his sons-in-law, who married his daughters, and said: ‘Up, get you out of this place; for the LORD will destroy the city.’ But he seemed unto his sons-in-law as one that jested.",
           "ref": "genesis 19:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": "15  Al rayar el alba, los ángeles apremiaron a Lot diciendo: \"Levántate, toma a tu mujer y a tus dos hijas que se encuentran aquí, no vayas a ser barrido por culpa de la ciudad.\"",
-            "jps1917": "And when the morning arose, then the angels hastened Lot, saying: ‘Arise, take thy wife, and thy two daughters that are here; lest thou be swept away in the iniquity of the city.’"
-          },
+          "en": "And when the morning arose, then the angels hastened Lot, saying: ‘Arise, take thy wife, and thy two daughters that are here; lest thou be swept away in the iniquity of the city.’",
           "ref": "genesis 19:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": "16  Y como él remoloneaba, los hombres le asieron de la mano lo mismo que a su mujer y a sus dos hijas por compasión de Yahvé hacia él, y, sacándolo, lo dejaron fuera de la ciudad.",
-            "jps1917": "But he lingered; and the men laid hold upon his hand, and upon the hand of his wife, and upon the hand of his two daughters; the LORD being merciful unto him. And they brought him forth, and set him without the city."
-          },
+          "en": "But he lingered; and the men laid hold upon his hand, and upon the hand of his wife, and upon the hand of his two daughters; the LORD being merciful unto him. And they brought him forth, and set him without the city.",
           "ref": "genesis 19:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": "17  Mientras los sacaban afuera, dijo uno: \"¡Escápate, por vida tuya! No mires atrás ni te pares en toda la redonda. Escapa al monte, no vayas a ser barrido.\"",
-            "jps1917": "And it came to pass, when they had brought them forth abroad, that he said: ‘Escape for thy life; look not behind thee, neither stay thou in all the Plain; escape to the mountain, lest thou be swept away.’"
-          },
+          "en": "And it came to pass, when they had brought them forth abroad, that he said: ‘Escape for thy life; look not behind thee, neither stay thou in all the Plain; escape to the mountain, lest thou be swept away.’",
           "ref": "genesis 19:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": "18  Lot les dijo: \"No, por favor, Señor mío.",
-            "jps1917": "And Lot said unto them: ‘Oh, not so, my lord;"
-          },
+          "en": "And Lot said unto them: ‘Oh, not so, my lord;",
           "ref": "genesis 19:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": "19  Ya que este servidor tuyo te ha caído en gracia, y me has hecho el gran favor de dejarme con vida, mira que no puedo escaparme al monte sin riesgo de que me alcance el daño y la muerte.",
-            "jps1917": "behold now, thy servant hath found grace in thy sight, and thou hast magnified thy mercy, which thou hast shown unto me in saving my life; and I cannot escape to the mountain, lest the evil overtake me, and I die."
-          },
+          "en": "behold now, thy servant hath found grace in thy sight, and thou hast magnified thy mercy, which thou hast shown unto me in saving my life; and I cannot escape to the mountain, lest the evil overtake me, and I die.",
           "ref": "genesis 19:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": "20  Ahí cerquita está esa ciudad a donde huir. Es una pequeñez. ¡Mira, voy a escaparme allá -¿verdad que es una pequeñez?- y quedaré con vida!\"",
-            "jps1917": "Behold now, this city is near to flee unto, and it is a little one; oh, let me escape thither—is it not a little one?—and my soul shall live.’"
-          },
+          "en": "Behold now, this city is near to flee unto, and it is a little one; oh, let me escape thither—is it not a little one?—and my soul shall live.’",
           "ref": "genesis 19:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": "21  Díjole: \"Bien, te concedo también eso de no arrasar la ciudad que has dicho.",
-            "jps1917": "And he said unto him: ‘See, I have accepted thee concerning this thing also, that I will not overthrow the city of which thou hast spoken."
-          },
+          "en": "And he said unto him: ‘See, I have accepted thee concerning this thing also, that I will not overthrow the city of which thou hast spoken.",
           "ref": "genesis 19:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": "22  Listo, escápate allá, porque no puedo hacer nada hasta que no entres allí.\" Por eso se llamó aquella ciudad Soar.",
-            "jps1917": "Hasten thou, escape thither; for I cannot do any thing till thou be come thither.’—Therefore the name of the city was called Zoar.—"
-          },
+          "en": "Hasten thou, escape thither; for I cannot do any thing till thou be come thither.’—Therefore the name of the city was called Zoar.—",
           "ref": "genesis 19:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": "23  El sol asomaba sobre el horizonte cuando Lot entraba en Soar.",
-            "jps1917": "The sun was risen upon the earth when Lot came unto Zoar."
-          },
+          "en": "The sun was risen upon the earth when Lot came unto Zoar.",
           "ref": "genesis 19:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": "24  Entonces Yahvé hizo llover sobre Sodoma y Gomorra azufre y fuego de parte de Yahvé.",
-            "jps1917": "Then the LORD caused to rain upon Sodom and upon Gomorrah brimstone and fire from the LORD out of heaven;"
-          },
+          "en": "Then the LORD caused to rain upon Sodom and upon Gomorrah brimstone and fire from the LORD out of heaven;",
           "ref": "genesis 19:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": "25  Y arrasó aquellas ciudades y toda la redonda con todos los habitantes de las ciudades y la vegetación del suelo.",
-            "jps1917": "and He overthrow those cities, and all the Plain, and all the inhabitants of the cities, and that which grew upon the ground."
-          },
+          "en": "and He overthrow those cities, and all the Plain, and all the inhabitants of the cities, and that which grew upon the ground.",
           "ref": "genesis 19:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": "26  Su mujer miró hacia atrás y se convirtió en poste de sal.",
-            "jps1917": "But his wife looked back from behind him, and she became a pillar of salt."
-          },
+          "en": "But his wife looked back from behind him, and she became a pillar of salt.",
           "ref": "genesis 19:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": "27  Abrahán se levantó de madrugada y fue al lugar donde había estado en presencia de Yahvé.",
-            "jps1917": "And Abraham got up early in the morning to the place where he had stood before the LORD."
-          },
+          "en": "And Abraham got up early in the morning to the place where he had stood before the LORD.",
           "ref": "genesis 19:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": "28  Dirigió la vista en dirección de Sodoma y Gomorra y de toda la región de la redonda, y, al mirar, vio que subía de la tierra una humareda como la de una fogata.",
-            "jps1917": "And he looked out toward Sodom and Gomorrah, and toward all the land of the Plain, and beheld, and, lo, the smoke of the land went up as the smoke of a furnace."
-          },
+          "en": "And he looked out toward Sodom and Gomorrah, and toward all the land of the Plain, and beheld, and, lo, the smoke of the land went up as the smoke of a furnace.",
           "ref": "genesis 19:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": "29  Así pues, cuando Dios destruyó las ciudades de la redonda, se acordó de Abrahán y puso a Lot a salvo de la catástrofe, cuando arrasó las ciudades en que Lot habitaba.",
-            "jps1917": "And it came to pass, when God destroyed the cities of the Plain, that God remembered Abraham, and sent Lot out of the midst of the overthrow, when He overthrew the cities in which Lot dwelt."
-          },
+          "en": "And it came to pass, when God destroyed the cities of the Plain, that God remembered Abraham, and sent Lot out of the midst of the overthrow, when He overthrew the cities in which Lot dwelt.",
           "ref": "genesis 19:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": "30  Subió Lot desde Soar y se quedó a vivir en el monte con sus dos hijas, temeroso de vivir en Soar. Él y sus dos hijas se instalaron en una cueva.",
-            "jps1917": "And Lot went up out of Zoar, and dwelt in the mountain, and his two daughters with him; for he feared to dwell in Zoar; and he dwelt in a cave, he and his two daughters."
-          },
+          "en": "And Lot went up out of Zoar, and dwelt in the mountain, and his two daughters with him; for he feared to dwell in Zoar; and he dwelt in a cave, he and his two daughters.",
           "ref": "genesis 19:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": "31  La mayor dijo a la pequeña: \"Nuestro padre es viejo y no hay ningún hombre en el país que se una a nosotras, como se hace en todo el mundo.",
-            "jps1917": "And the first-born said unto the younger: ‘Our father is old, and there is not a man in the earth to come in unto us after the manner of all the earth."
-          },
+          "en": "And the first-born said unto the younger: ‘Our father is old, and there is not a man in the earth to come in unto us after the manner of all the earth.",
           "ref": "genesis 19:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": "32  Ven, vamos a darle vino a nuestro padre, nos acostaremos con él y así engendraremos descendencia.\"",
-            "jps1917": "Come, let us make our father drink wine, and we will lie with him, that we may preserve seed of our father.’"
-          },
+          "en": "Come, let us make our father drink wine, and we will lie with him, that we may preserve seed of our father.’",
           "ref": "genesis 19:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": "33  En efecto, aquella misma noche dieron vino a su padre; entró la mayor y se acostó con su padre, sin que él se enterase de cuándo se acostó ni cuándo se levantó.",
-            "jps1917": "And they made their father drink wine that night. And the first-born went in, and lay with her father; and he knew not when she lay down, nor when she arose."
-          },
+          "en": "And they made their father drink wine that night. And the first-born went in, and lay with her father; and he knew not when she lay down, nor when she arose.",
           "ref": "genesis 19:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": "34  Al día siguiente dijo la mayor a la pequeña: \"Mira, yo me he acostado anoche con mi padre. Vamos a darle vino también esta noche, y entras tú a acostarte con él, y así engendraremos de nuestro padre descendencia.\"",
-            "jps1917": "And it came to pass on the morrow, that the first-born said unto the younger: ‘Behold, I lay yesternight with my father. Let us make him drink wine this night also; and go thou in, and lie with him, that we may preserve seed of our father.’"
-          },
+          "en": "And it came to pass on the morrow, that the first-born said unto the younger: ‘Behold, I lay yesternight with my father. Let us make him drink wine this night also; and go thou in, and lie with him, that we may preserve seed of our father.’",
           "ref": "genesis 19:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": "35  Dieron, pues, también aquella noche vino a su padre, y la pequeña se acostó con él, sin que él se enterase de cuándo se acostó ni cuándo se levantó.",
-            "jps1917": "And they made their father drink wine that night also. And the younger arose, and lay with him; and he knew not when she lay down, nor when she arose."
-          },
+          "en": "And they made their father drink wine that night also. And the younger arose, and lay with him; and he knew not when she lay down, nor when she arose.",
           "ref": "genesis 19:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": "36  Las dos hijas de Lot quedaron encinta de su padre.",
-            "jps1917": "Thus were both the daughters of Lot with child by their father."
-          },
+          "en": "Thus were both the daughters of Lot with child by their father.",
           "ref": "genesis 19:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": "37  La mayor dio a luz un hijo, y lo llamó Moab: es el padre de los actuales moabitas.",
-            "jps1917": "And the first-born bore a son, and called his name Moab—the same is the father of the Moabites unto this day."
-          },
+          "en": "And the first-born bore a son, and called his name Moab—the same is the father of the Moabites unto this day.",
           "ref": "genesis 19:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": "38  La pequeña también dio a luz un hijo, y lo llamó Ben Amí: es el padre de los actuales amonitas.",
-            "jps1917": "And the younger, she also bore a son, and called his name Ben-ammi—the same is the father of the children of Ammon unto this day."
-          },
+          "en": "And the younger, she also bore a son, and called his name Ben-ammi—the same is the father of the children of Ammon unto this day.",
           "ref": "genesis 19:38"
         }
       ]
@@ -4070,146 +2582,92 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham journeyed from thence toward the land of the South, and dwelt between Kadesh and Shur; and he sojourned in Gerar."
-          },
+          "en": "And Abraham journeyed from thence toward the land of the South, and dwelt between Kadesh and Shur; and he sojourned in Gerar.",
           "ref": "genesis 20:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham said of Sarah his wife: ‘She is my sister.’ And Abimelech king of Gerar sent, and took Sarah."
-          },
+          "en": "And Abraham said of Sarah his wife: ‘She is my sister.’ And Abimelech king of Gerar sent, and took Sarah.",
           "ref": "genesis 20:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "But God came to Abimelech in a dream of the night, and said to him: ‘Behold, thou shalt die, because of the woman whom thou hast taken; for she is a man’s wife.’"
-          },
+          "en": "But God came to Abimelech in a dream of the night, and said to him: ‘Behold, thou shalt die, because of the woman whom thou hast taken; for she is a man’s wife.’",
           "ref": "genesis 20:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "Now Abimelech had not come near her; and he said: ‘Lord, wilt Thou slay even a righteous nation?"
-          },
+          "en": "Now Abimelech had not come near her; and he said: ‘Lord, wilt Thou slay even a righteous nation?",
           "ref": "genesis 20:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "Said he not himself unto me: She is my sister? and she, even she herself said: He is my brother. In the simplicity of my heart and the innocency of my hands have I done this.’"
-          },
+          "en": "Said he not himself unto me: She is my sister? and she, even she herself said: He is my brother. In the simplicity of my heart and the innocency of my hands have I done this.’",
           "ref": "genesis 20:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said unto him in the dream: ‘Yea, I know that in the simplicity of thy heart thou hast done this, and I also withheld thee from sinning against Me. Therefore suffered I thee not to touch her."
-          },
+          "en": "And God said unto him in the dream: ‘Yea, I know that in the simplicity of thy heart thou hast done this, and I also withheld thee from sinning against Me. Therefore suffered I thee not to touch her.",
           "ref": "genesis 20:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "Now therefore restore the man’s wife; for he is a prophet, and he shall pray for thee, and thou shalt live; and if thou restore her not, know thou that thou shalt surely die, thou, and all that are thine.’"
-          },
+          "en": "Now therefore restore the man’s wife; for he is a prophet, and he shall pray for thee, and thou shalt live; and if thou restore her not, know thou that thou shalt surely die, thou, and all that are thine.’",
           "ref": "genesis 20:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abimelech rose early in the morning, and called all his servants, and told all these things in their ears; and the men were sore afraid."
-          },
+          "en": "And Abimelech rose early in the morning, and called all his servants, and told all these things in their ears; and the men were sore afraid.",
           "ref": "genesis 20:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Abimelech called Abraham, and said unto him: ‘What hast thou done unto us? and wherein have I sinned against thee, that thou hast brought on me and on my kingdom a great sin? thou hast done deeds unto me that ought not to be done.’"
-          },
+          "en": "Then Abimelech called Abraham, and said unto him: ‘What hast thou done unto us? and wherein have I sinned against thee, that thou hast brought on me and on my kingdom a great sin? thou hast done deeds unto me that ought not to be done.’",
           "ref": "genesis 20:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abimelech said unto Abraham: ‘What sawest thou, that thou hast done this thing?’"
-          },
+          "en": "And Abimelech said unto Abraham: ‘What sawest thou, that thou hast done this thing?’",
           "ref": "genesis 20:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham said: ‘Because I thought: Surely the fear of God is not in this place; and they will slay me for my wife’s sake."
-          },
+          "en": "And Abraham said: ‘Because I thought: Surely the fear of God is not in this place; and they will slay me for my wife’s sake.",
           "ref": "genesis 20:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And moreover she is indeed my sister, the daughter of my father, but not the daughter of my mother; and so she became my wife."
-          },
+          "en": "And moreover she is indeed my sister, the daughter of my father, but not the daughter of my mother; and so she became my wife.",
           "ref": "genesis 20:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when God caused me to wander from my father’s house, that I said unto her: This is thy kindness which thou shalt show unto me; at every place whither we shall come, say of me: He is my brother.’"
-          },
+          "en": "And it came to pass, when God caused me to wander from my father’s house, that I said unto her: This is thy kindness which thou shalt show unto me; at every place whither we shall come, say of me: He is my brother.’",
           "ref": "genesis 20:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abimelech took sheep and oxen, and men-servants and women-servants, and gave them unto Abraham, and restored him Sarah his wife."
-          },
+          "en": "And Abimelech took sheep and oxen, and men-servants and women-servants, and gave them unto Abraham, and restored him Sarah his wife.",
           "ref": "genesis 20:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abimelech said: ‘Behold, my land is before thee: dwell where it pleaseth thee.’"
-          },
+          "en": "And Abimelech said: ‘Behold, my land is before thee: dwell where it pleaseth thee.’",
           "ref": "genesis 20:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And unto Sarah he said: ‘Behold, I have given thy brother a thousand pieces of silver; behold, it is for thee a covering of the eyes to all that are with thee; and before all men thou art righted.’"
-          },
+          "en": "And unto Sarah he said: ‘Behold, I have given thy brother a thousand pieces of silver; behold, it is for thee a covering of the eyes to all that are with thee; and before all men thou art righted.’",
           "ref": "genesis 20:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham prayed unto God; and God healed Abimelech, and his wife, and his maid-servants; and they bore children."
-          },
+          "en": "And Abraham prayed unto God; and God healed Abimelech, and his wife, and his maid-servants; and they bore children.",
           "ref": "genesis 20:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "For the LORD had fast closed up all the wombs of the house of Abimelech, because of Sarah Abraham’s wife."
-          },
+          "en": "For the LORD had fast closed up all the wombs of the house of Abimelech, because of Sarah Abraham’s wife.",
           "ref": "genesis 20:18"
         }
       ]
@@ -4219,274 +2677,172 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD remembered Sarah as He had said, and the LORD did unto Sarah as He had spoken."
-          },
+          "en": "And the LORD remembered Sarah as He had said, and the LORD did unto Sarah as He had spoken.",
           "ref": "genesis 21:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Sarah conceived, and bore Abraham a son in his old age, at the set time of which God had spoken to him."
-          },
+          "en": "And Sarah conceived, and bore Abraham a son in his old age, at the set time of which God had spoken to him.",
           "ref": "genesis 21:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham called the name of his son that was born unto him, whom Sarah bore to him, Isaac."
-          },
+          "en": "And Abraham called the name of his son that was born unto him, whom Sarah bore to him, Isaac.",
           "ref": "genesis 21:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham circumcised his son Isaac when he was eight days old, as God had commanded him."
-          },
+          "en": "And Abraham circumcised his son Isaac when he was eight days old, as God had commanded him.",
           "ref": "genesis 21:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham was a hundred years old, when his son Isaac was born unto him."
-          },
+          "en": "And Abraham was a hundred years old, when his son Isaac was born unto him.",
           "ref": "genesis 21:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Sarah said: ‘God hath made laughter for me; every one that heareth will laugh on account of me.’"
-          },
+          "en": "And Sarah said: ‘God hath made laughter for me; every one that heareth will laugh on account of me.’",
           "ref": "genesis 21:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And she said: ‘Who would have said unto Abraham, that Sarah should give children suck? for I have borne him a son in his old age.’"
-          },
+          "en": "And she said: ‘Who would have said unto Abraham, that Sarah should give children suck? for I have borne him a son in his old age.’",
           "ref": "genesis 21:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And the child grew, and was weaned. And Abraham made a great feast on the day that Isaac was weaned."
-          },
+          "en": "And the child grew, and was weaned. And Abraham made a great feast on the day that Isaac was weaned.",
           "ref": "genesis 21:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And Sarah saw the son of Hagar the Egyptian, whom she had borne unto Abraham, making sport."
-          },
+          "en": "And Sarah saw the son of Hagar the Egyptian, whom she had borne unto Abraham, making sport.",
           "ref": "genesis 21:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "Wherefore she said unto Abraham: ‘Cast out this bondwoman and her son; for the son of this bondwoman shall not be heir with my son, even with Isaac.’"
-          },
+          "en": "Wherefore she said unto Abraham: ‘Cast out this bondwoman and her son; for the son of this bondwoman shall not be heir with my son, even with Isaac.’",
           "ref": "genesis 21:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And the thing was very grievous in Abraham’s sight on account of his son."
-          },
+          "en": "And the thing was very grievous in Abraham’s sight on account of his son.",
           "ref": "genesis 21:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said unto Abraham: ‘Let it not be grievous in thy sight because of the lad, and because of thy bondwoman; in all that Sarah saith unto thee, hearken unto her voice; for in Isaac shall seed be called to thee."
-          },
+          "en": "And God said unto Abraham: ‘Let it not be grievous in thy sight because of the lad, and because of thy bondwoman; in all that Sarah saith unto thee, hearken unto her voice; for in Isaac shall seed be called to thee.",
           "ref": "genesis 21:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And also of the son of the bondwoman will I make a nation, because he is thy seed.’"
-          },
+          "en": "And also of the son of the bondwoman will I make a nation, because he is thy seed.’",
           "ref": "genesis 21:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham arose up early in the morning, and took bread and a bottle of water, and gave it unto Hagar, putting it on her shoulder, and the child, and sent her away; and she departed, and strayed in the wilderness of Beer-sheba."
-          },
+          "en": "And Abraham arose up early in the morning, and took bread and a bottle of water, and gave it unto Hagar, putting it on her shoulder, and the child, and sent her away; and she departed, and strayed in the wilderness of Beer-sheba.",
           "ref": "genesis 21:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And the water in the bottle was spent, and she cast the child under one of the shrubs."
-          },
+          "en": "And the water in the bottle was spent, and she cast the child under one of the shrubs.",
           "ref": "genesis 21:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And she went, and sat her down over against him a good way off, as it were a bow-shot; for she said: ‘Let me not look upon the death of the child.’ And she sat over against him, and lifted up her voice, and wept."
-          },
+          "en": "And she went, and sat her down over against him a good way off, as it were a bow-shot; for she said: ‘Let me not look upon the death of the child.’ And she sat over against him, and lifted up her voice, and wept.",
           "ref": "genesis 21:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And God heard the voice of the lad; and the angel of God called to Hagar out of heaven, and said unto her: ‘What aileth thee, Hagar? fear not; for God hath heard the voice of the lad where he is."
-          },
+          "en": "And God heard the voice of the lad; and the angel of God called to Hagar out of heaven, and said unto her: ‘What aileth thee, Hagar? fear not; for God hath heard the voice of the lad where he is.",
           "ref": "genesis 21:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "Arise, lift up the lad, and hold him fast by thy hand; for I will make him a great nation.’"
-          },
+          "en": "Arise, lift up the lad, and hold him fast by thy hand; for I will make him a great nation.’",
           "ref": "genesis 21:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And God opened her eyes, and she saw a well of water; and she went, and filled the bottle with water, and gave the lad drink."
-          },
+          "en": "And God opened her eyes, and she saw a well of water; and she went, and filled the bottle with water, and gave the lad drink.",
           "ref": "genesis 21:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And God was with the lad, and he grew; and he dwelt in the wilderness, and became an archer."
-          },
+          "en": "And God was with the lad, and he grew; and he dwelt in the wilderness, and became an archer.",
           "ref": "genesis 21:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And he dwelt in the wilderness of Paran; and his mother took him a wife out of the land of Egypt."
-          },
+          "en": "And he dwelt in the wilderness of Paran; and his mother took him a wife out of the land of Egypt.",
           "ref": "genesis 21:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass at that time, that Abimelech and Phicol the captain of his host spoke unto Abraham, saying: ‘God is with thee in all that thou doest."
-          },
+          "en": "And it came to pass at that time, that Abimelech and Phicol the captain of his host spoke unto Abraham, saying: ‘God is with thee in all that thou doest.",
           "ref": "genesis 21:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "Now therefore swear unto me here by God that thou wilt not deal falsely with me, nor with my son, nor with my son’s son; but according to the kindness that I have done unto thee, thou shalt do unto me, and to the land wherein thou hast sojourned.’"
-          },
+          "en": "Now therefore swear unto me here by God that thou wilt not deal falsely with me, nor with my son, nor with my son’s son; but according to the kindness that I have done unto thee, thou shalt do unto me, and to the land wherein thou hast sojourned.’",
           "ref": "genesis 21:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham said: ‘I will swear.’"
-          },
+          "en": "And Abraham said: ‘I will swear.’",
           "ref": "genesis 21:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham reproved Abimelech because of the well of water, which Abimelech’s servants had violently taken away."
-          },
+          "en": "And Abraham reproved Abimelech because of the well of water, which Abimelech’s servants had violently taken away.",
           "ref": "genesis 21:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abimelech said: ‘I know not who hath done this thing; neither didst thou tell me, neither yet heard I of it, but to-day.’"
-          },
+          "en": "And Abimelech said: ‘I know not who hath done this thing; neither didst thou tell me, neither yet heard I of it, but to-day.’",
           "ref": "genesis 21:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham took sheep and oxen, and gave them unto Abimelech; and they two made a covenant."
-          },
+          "en": "And Abraham took sheep and oxen, and gave them unto Abimelech; and they two made a covenant.",
           "ref": "genesis 21:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham set seven ewe-lambs of the flock by themselves."
-          },
+          "en": "And Abraham set seven ewe-lambs of the flock by themselves.",
           "ref": "genesis 21:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abimelech said unto Abraham: ‘What mean these seven ewe-lambs which thou hast set by themselves?’"
-          },
+          "en": "And Abimelech said unto Abraham: ‘What mean these seven ewe-lambs which thou hast set by themselves?’",
           "ref": "genesis 21:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Verily, these seven ewe-lambs shalt thou take of my hand, that it may be a witness unto me, that I have digged this well.’"
-          },
+          "en": "And he said: ‘Verily, these seven ewe-lambs shalt thou take of my hand, that it may be a witness unto me, that I have digged this well.’",
           "ref": "genesis 21:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "Wherefore that place was called Beer-sheba; because there they swore both of them."
-          },
+          "en": "Wherefore that place was called Beer-sheba; because there they swore both of them.",
           "ref": "genesis 21:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "So they made a covenant at Beer-sheba; and Abimelech rose up, and Phicol the captain of his host, and they returned into the land of the Philistines."
-          },
+          "en": "So they made a covenant at Beer-sheba; and Abimelech rose up, and Phicol the captain of his host, and they returned into the land of the Philistines.",
           "ref": "genesis 21:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham planted a tamarisk-tree in Beer-sheba, and called there on the name of the LORD, the Everlasting God."
-          },
+          "en": "And Abraham planted a tamarisk-tree in Beer-sheba, and called there on the name of the LORD, the Everlasting God.",
           "ref": "genesis 21:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham sojourned in the land of the Philistines many days."
-          },
+          "en": "And Abraham sojourned in the land of the Philistines many days.",
           "ref": "genesis 21:34"
         }
       ]
@@ -4496,194 +2852,122 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass after these things, that God did prove Abraham, and said unto him: ‘Abraham’; and he said: ‘Here am I.’"
-          },
+          "en": "And it came to pass after these things, that God did prove Abraham, and said unto him: ‘Abraham’; and he said: ‘Here am I.’",
           "ref": "genesis 22:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": "...“Take your son, your favored one, Isaac, whom you love, And you shall change his name to Levi, For this is what I, God of your father Abraham, Yitzchok, And Yaakov Command,  and go to the land of Moriah, and offer him there as a burnt offering on one of the heights that I will point out to you.",
-            "jps1917": "And He said: ‘Take now thy son, thine only son, whom thou lovest, even Isaac, and get thee into the land of Moriah; and offer him there for a burnt-offering upon one of the mountains which I will tell thee of.’"
-          },
+          "en": "And He said: ‘Take now thy son, thine only son, whom thou lovest, even Isaac, and get thee into the land of Moriah; and offer him there for a burnt-offering upon one of the mountains which I will tell thee of.’",
           "ref": "genesis 22:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham rose early in the morning, and saddled his ass, and took two of his young men with him, and Isaac his son; and he cleaved the wood for the burnt-offering, and rose up, and went unto the place of which God had told him."
-          },
+          "en": "And Abraham rose early in the morning, and saddled his ass, and took two of his young men with him, and Isaac his son; and he cleaved the wood for the burnt-offering, and rose up, and went unto the place of which God had told him.",
           "ref": "genesis 22:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "On the third day Abraham lifted up his eyes, and saw the place afar off."
-          },
+          "en": "On the third day Abraham lifted up his eyes, and saw the place afar off.",
           "ref": "genesis 22:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham said unto his young men: ‘Abide ye here with the ass, and I and the lad will go yonder; and we will worship, and come back to you.’"
-          },
+          "en": "And Abraham said unto his young men: ‘Abide ye here with the ass, and I and the lad will go yonder; and we will worship, and come back to you.’",
           "ref": "genesis 22:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham took the wood of the burnt-offering, and laid it upon Isaac his son; and he took in his hand the fire and the knife; and they went both of them together."
-          },
+          "en": "And Abraham took the wood of the burnt-offering, and laid it upon Isaac his son; and he took in his hand the fire and the knife; and they went both of them together.",
           "ref": "genesis 22:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac spoke unto Abraham his father, and said: ‘My father.’ And he said: ‘Here am I, my son.’ And he said: ‘Behold the fire and the wood; but where is the lamb for a burnt-offering?’"
-          },
+          "en": "And Isaac spoke unto Abraham his father, and said: ‘My father.’ And he said: ‘Here am I, my son.’ And he said: ‘Behold the fire and the wood; but where is the lamb for a burnt-offering?’",
           "ref": "genesis 22:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham said: ‘God will aprovide Himself the lamb for a burnt-offering, my son.’ So they went both of them together."
-          },
+          "en": "And Abraham said: ‘God will aprovide Himself the lamb for a burnt-offering, my son.’ So they went both of them together.",
           "ref": "genesis 22:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And they came to the place which God had told him of; and Abraham built the altar there, and laid the wood in order, and bound Isaac his son, and laid him on the altar, upon the wood."
-          },
+          "en": "And they came to the place which God had told him of; and Abraham built the altar there, and laid the wood in order, and bound Isaac his son, and laid him on the altar, upon the wood.",
           "ref": "genesis 22:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham stretched forth his hand, and took the knife to slay his son."
-          },
+          "en": "And Abraham stretched forth his hand, and took the knife to slay his son.",
           "ref": "genesis 22:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And the angel of the LORD called unto him out of heaven, and said: ‘Abraham, Abraham.’ And he said: ‘Here am I.’"
-          },
+          "en": "And the angel of the LORD called unto him out of heaven, and said: ‘Abraham, Abraham.’ And he said: ‘Here am I.’",
           "ref": "genesis 22:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Lay not thy hand upon the lad, neither do thou any thing unto him; for now I know that thou art a God-fearing man, seeing thou hast not withheld thy son, thine only son, from Me.’"
-          },
+          "en": "And he said: ‘Lay not thy hand upon the lad, neither do thou any thing unto him; for now I know that thou art a God-fearing man, seeing thou hast not withheld thy son, thine only son, from Me.’",
           "ref": "genesis 22:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham lifted up his eyes, and looked, and behold behind him a ram caught in the thicket by his horns. And Abraham went and took the ram, and offered him up for a burnt-offering in the stead of his son."
-          },
+          "en": "And Abraham lifted up his eyes, and looked, and behold behind him a ram caught in the thicket by his horns. And Abraham went and took the ram, and offered him up for a burnt-offering in the stead of his son.",
           "ref": "genesis 22:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham called the name of that place Adonai-jireh; as it is said to this day: ‘In the mount where the LORD is seen.’"
-          },
+          "en": "And Abraham called the name of that place Adonai-jireh; as it is said to this day: ‘In the mount where the LORD is seen.’",
           "ref": "genesis 22:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And the angel of the LORD called unto Abraham a second time out of heaven,"
-          },
+          "en": "And the angel of the LORD called unto Abraham a second time out of heaven,",
           "ref": "genesis 22:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "and said: ‘By Myself have I sworn, saith the LORD, because thou hast done this thing, and hast not withheld thy son, thine only son,"
-          },
+          "en": "and said: ‘By Myself have I sworn, saith the LORD, because thou hast done this thing, and hast not withheld thy son, thine only son,",
           "ref": "genesis 22:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "that in blessing I will bless thee, and in multiplying I will multiply thy seed as the stars of the heaven, and as the sand which is upon the seashore; and thy seed shall possess the gate of his enemies;"
-          },
+          "en": "that in blessing I will bless thee, and in multiplying I will multiply thy seed as the stars of the heaven, and as the sand which is upon the seashore; and thy seed shall possess the gate of his enemies;",
           "ref": "genesis 22:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "and in thy seed shall all the nations of the earth be blessed; because thou hast hearkened to My voice.’"
-          },
+          "en": "and in thy seed shall all the nations of the earth be blessed; because thou hast hearkened to My voice.’",
           "ref": "genesis 22:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "So Abraham returned unto his young men, and they rose up and went together to Beer- sheba; and Abraham dwelt at Beer-sheba."
-          },
+          "en": "So Abraham returned unto his young men, and they rose up and went together to Beer- sheba; and Abraham dwelt at Beer-sheba.",
           "ref": "genesis 22:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass after these things, that it was told Abraham, saying: ‘Behold, Milcah, she also hath borne children unto thy brother Nahor:"
-          },
+          "en": "And it came to pass after these things, that it was told Abraham, saying: ‘Behold, Milcah, she also hath borne children unto thy brother Nahor:",
           "ref": "genesis 22:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "Uz his first-born, and Buz his brother, and Kemuel the father of Aram;"
-          },
+          "en": "Uz his first-born, and Buz his brother, and Kemuel the father of Aram;",
           "ref": "genesis 22:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "and Chesed, and Hazo, and Pildash, and Jidlaph, and Bethuel.’"
-          },
+          "en": "and Chesed, and Hazo, and Pildash, and Jidlaph, and Bethuel.’",
           "ref": "genesis 22:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And Bethuel begot Rebekah; these eight did Milcah bear to Nahor, Abraham’s brother."
-          },
+          "en": "And Bethuel begot Rebekah; these eight did Milcah bear to Nahor, Abraham’s brother.",
           "ref": "genesis 22:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And his concubine, whose name was Reumah, she also bore Tebah, and Gaham, and Tahash, and Maacah."
-          },
+          "en": "And his concubine, whose name was Reumah, she also bore Tebah, and Gaham, and Tahash, and Maacah.",
           "ref": "genesis 22:24"
         }
       ]
@@ -4693,162 +2977,102 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the life of Sarah was a hundred and seven and twenty years; these were the years of the life of Sarah."
-          },
+          "en": "And the life of Sarah was a hundred and seven and twenty years; these were the years of the life of Sarah.",
           "ref": "genesis 23:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Sarah died in Kiriatharba—the same is Hebron—in the land of Canaan; and Abraham came to mourn for Sarah, and to weep for her."
-          },
+          "en": "And Sarah died in Kiriatharba—the same is Hebron—in the land of Canaan; and Abraham came to mourn for Sarah, and to weep for her.",
           "ref": "genesis 23:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham rose up from before his dead, and spoke unto the children of Heth, saying:"
-          },
+          "en": "And Abraham rose up from before his dead, and spoke unto the children of Heth, saying:",
           "ref": "genesis 23:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "’I am a stranger and a sojourner with you: give me a possession of a burying-place with you, that I may bury my dead out of my sight.’"
-          },
+          "en": "’I am a stranger and a sojourner with you: give me a possession of a burying-place with you, that I may bury my dead out of my sight.’",
           "ref": "genesis 23:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And the children of Heth answered Abraham, saying unto him:"
-          },
+          "en": "And the children of Heth answered Abraham, saying unto him:",
           "ref": "genesis 23:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "’Hear us, my lord: thou art a mighty prince among us; in the choice of our sepulchres bury thy dead; none of us shall withhold from thee his sepulchre, but that thou mayest bury thy dead.’"
-          },
+          "en": "’Hear us, my lord: thou art a mighty prince among us; in the choice of our sepulchres bury thy dead; none of us shall withhold from thee his sepulchre, but that thou mayest bury thy dead.’",
           "ref": "genesis 23:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham rose up, and bowed down to the people of the land, even to the children of Heth."
-          },
+          "en": "And Abraham rose up, and bowed down to the people of the land, even to the children of Heth.",
           "ref": "genesis 23:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And he spoke with them, saying: ‘If it be your mind that I should bury my dead out of my sight, hear me, and entreat for me to Ephron the son of Zohar,"
-          },
+          "en": "And he spoke with them, saying: ‘If it be your mind that I should bury my dead out of my sight, hear me, and entreat for me to Ephron the son of Zohar,",
           "ref": "genesis 23:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "that he may give me the cave of Machpelah, which he hath, which is in the end of his field; for the full price let him give it to me in the midst of you for a possession of a burying-place.’"
-          },
+          "en": "that he may give me the cave of Machpelah, which he hath, which is in the end of his field; for the full price let him give it to me in the midst of you for a possession of a burying-place.’",
           "ref": "genesis 23:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "Now Ephron was sitting in the midst of the children of Heth; and Ephron the Hittite answered Abraham in the hearing of the children of Heth, even of all that went in at the gate of his city, saying:"
-          },
+          "en": "Now Ephron was sitting in the midst of the children of Heth; and Ephron the Hittite answered Abraham in the hearing of the children of Heth, even of all that went in at the gate of his city, saying:",
           "ref": "genesis 23:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "’Nay, my lord, hear me: the field give I thee, and the cave that is therein, I give it thee; in the presence of the sons of my people give I it thee; bury thy dead.’"
-          },
+          "en": "’Nay, my lord, hear me: the field give I thee, and the cave that is therein, I give it thee; in the presence of the sons of my people give I it thee; bury thy dead.’",
           "ref": "genesis 23:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham bowed down before the people of the land."
-          },
+          "en": "And Abraham bowed down before the people of the land.",
           "ref": "genesis 23:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And he spoke unto Ephron in the hearing of the people of the land, saying: ‘But if thou wilt, I pray thee, hear me: I will give the price of the field; take it of me, and I will bury my dead there.’"
-          },
+          "en": "And he spoke unto Ephron in the hearing of the people of the land, saying: ‘But if thou wilt, I pray thee, hear me: I will give the price of the field; take it of me, and I will bury my dead there.’",
           "ref": "genesis 23:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And Ephron answered Abraham, saying unto him:"
-          },
+          "en": "And Ephron answered Abraham, saying unto him:",
           "ref": "genesis 23:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "’My lord, hearken unto me: a piece of land worth four hundred shekels of silver, what is that betwixt me and thee? bury therefore thy dead.’"
-          },
+          "en": "’My lord, hearken unto me: a piece of land worth four hundred shekels of silver, what is that betwixt me and thee? bury therefore thy dead.’",
           "ref": "genesis 23:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham hearkened unto Ephron; and Abraham weighed to Ephron the silver, which he had named in the hearing of the children of Heth, four hundred shekels of silver, current money with the merchant."
-          },
+          "en": "And Abraham hearkened unto Ephron; and Abraham weighed to Ephron the silver, which he had named in the hearing of the children of Heth, four hundred shekels of silver, current money with the merchant.",
           "ref": "genesis 23:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "So the field of Ephron, which was in Machpelah, which was before Mamre, the field, and the cave which was therein, and all the trees that were in the field, that were in all the border thereof round about, were made sure"
-          },
+          "en": "So the field of Ephron, which was in Machpelah, which was before Mamre, the field, and the cave which was therein, and all the trees that were in the field, that were in all the border thereof round about, were made sure",
           "ref": "genesis 23:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "unto Abraham for a possession in the presence of the children of Heth, before all that went in at the gate of his city."
-          },
+          "en": "unto Abraham for a possession in the presence of the children of Heth, before all that went in at the gate of his city.",
           "ref": "genesis 23:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And after this, Abraham buried Sarah his wife in the cave of the field of Machpelah before Mamre—the same is Hebron—in the land of Canaan."
-          },
+          "en": "And after this, Abraham buried Sarah his wife in the cave of the field of Machpelah before Mamre—the same is Hebron—in the land of Canaan.",
           "ref": "genesis 23:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And the field, and the cave that is therein, were made sure unto Abraham for a possession of a burying-place by the children of Heth."
-          },
+          "en": "And the field, and the cave that is therein, were made sure unto Abraham for a possession of a burying-place by the children of Heth.",
           "ref": "genesis 23:20"
         }
       ]
@@ -4858,538 +3082,337 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham was old, well stricken in age; and the LORD had blessed Abraham in all things."
-          },
+          "en": "And Abraham was old, well stricken in age; and the LORD had blessed Abraham in all things.",
           "ref": "genesis 24:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham said unto his servant, the elder of his house, that ruled over all that he had: ‘Put, I pray thee, thy hand under my thigh."
-          },
+          "en": "And Abraham said unto his servant, the elder of his house, that ruled over all that he had: ‘Put, I pray thee, thy hand under my thigh.",
           "ref": "genesis 24:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And I will make thee swear by the LORD, the God of heaven and the God of the earth, that thou shalt not take a wife for my son of the daughters of the Canaanites, among whom I dwell."
-          },
+          "en": "And I will make thee swear by the LORD, the God of heaven and the God of the earth, that thou shalt not take a wife for my son of the daughters of the Canaanites, among whom I dwell.",
           "ref": "genesis 24:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "But thou shalt go unto my country, and to my kindred, and take a wife for my son, even for Isaac.’"
-          },
+          "en": "But thou shalt go unto my country, and to my kindred, and take a wife for my son, even for Isaac.’",
           "ref": "genesis 24:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And the servant said unto him: ‘Peradventure the woman will not be willing to follow me unto this land; must I needs bring thy son back unto the land from whence thou camest?’"
-          },
+          "en": "And the servant said unto him: ‘Peradventure the woman will not be willing to follow me unto this land; must I needs bring thy son back unto the land from whence thou camest?’",
           "ref": "genesis 24:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham said unto him: ‘Beware thou that thou bring not my son back thither."
-          },
+          "en": "And Abraham said unto him: ‘Beware thou that thou bring not my son back thither.",
           "ref": "genesis 24:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "The LORD, the God of heaven, who took me from my father’s house, and from the land of my nativity, and who spoke unto me, and who swore unto me, saying: Unto thy seed will I give this land; He will send His angel before thee, and thou shalt take a wife for my son from thence."
-          },
+          "en": "The LORD, the God of heaven, who took me from my father’s house, and from the land of my nativity, and who spoke unto me, and who swore unto me, saying: Unto thy seed will I give this land; He will send His angel before thee, and thou shalt take a wife for my son from thence.",
           "ref": "genesis 24:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And if the woman be not willing to follow thee, then thou shalt be clear from this my oath; only thou shalt not bring my son back thither.’"
-          },
+          "en": "And if the woman be not willing to follow thee, then thou shalt be clear from this my oath; only thou shalt not bring my son back thither.’",
           "ref": "genesis 24:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And the servant put his hand under the thigh of Abraham his master, and swore to him concerning this matter."
-          },
+          "en": "And the servant put his hand under the thigh of Abraham his master, and swore to him concerning this matter.",
           "ref": "genesis 24:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And the servant took ten camels, of the camels of his master, and departed; having all goodly things of his master’s in his hand; and he arose, and went to Aram-naharaim, unto the city of Nahor."
-          },
+          "en": "And the servant took ten camels, of the camels of his master, and departed; having all goodly things of his master’s in his hand; and he arose, and went to Aram-naharaim, unto the city of Nahor.",
           "ref": "genesis 24:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made the camels to kneel down without the city by the well of water at the time of evening, the time that women go out to draw water."
-          },
+          "en": "And he made the camels to kneel down without the city by the well of water at the time of evening, the time that women go out to draw water.",
           "ref": "genesis 24:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘O LORD, the God of my master Abraham, send me, I pray Thee, good speed this day, and show kindness unto my master Abraham."
-          },
+          "en": "And he said: ‘O LORD, the God of my master Abraham, send me, I pray Thee, good speed this day, and show kindness unto my master Abraham.",
           "ref": "genesis 24:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "Behold, I stand by the fountain of water; and the daughters of the men of the city come out to draw water."
-          },
+          "en": "Behold, I stand by the fountain of water; and the daughters of the men of the city come out to draw water.",
           "ref": "genesis 24:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "So let it come to pass, that the damsel to whom I shall say: Let down thy pitcher, I pray thee, that I may drink; and she shall say: Drink, and I will give thy camels drink also; let the same be she that Thou hast appointed for Thy servant, even for Isaac; and thereby shall I know that Thou hast shown kindness unto my master.’"
-          },
+          "en": "So let it come to pass, that the damsel to whom I shall say: Let down thy pitcher, I pray thee, that I may drink; and she shall say: Drink, and I will give thy camels drink also; let the same be she that Thou hast appointed for Thy servant, even for Isaac; and thereby shall I know that Thou hast shown kindness unto my master.’",
           "ref": "genesis 24:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, before he had done speaking, that, behold, Rebekah came out, who was born to Bethuel the son of Milcah, the wife of Nahor, Abraham’s brother, with her pitcher upon her shoulder."
-          },
+          "en": "And it came to pass, before he had done speaking, that, behold, Rebekah came out, who was born to Bethuel the son of Milcah, the wife of Nahor, Abraham’s brother, with her pitcher upon her shoulder.",
           "ref": "genesis 24:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And the damsel was very fair to look upon, a virgin, neither had any man known her; and she went down to the fountain, and filled her pitcher, and came up."
-          },
+          "en": "And the damsel was very fair to look upon, a virgin, neither had any man known her; and she went down to the fountain, and filled her pitcher, and came up.",
           "ref": "genesis 24:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And the servant ran to meet her, and said: ‘Give me to drink, I pray thee, a little water of thy pitcher.’"
-          },
+          "en": "And the servant ran to meet her, and said: ‘Give me to drink, I pray thee, a little water of thy pitcher.’",
           "ref": "genesis 24:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And she said: ‘Drink, my lord’; and she hastened, and let down her pitcher upon her hand, and gave him drink."
-          },
+          "en": "And she said: ‘Drink, my lord’; and she hastened, and let down her pitcher upon her hand, and gave him drink.",
           "ref": "genesis 24:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And when she had done giving him drink, she said: ‘I will draw for thy camels also, until they have done drinking.’"
-          },
+          "en": "And when she had done giving him drink, she said: ‘I will draw for thy camels also, until they have done drinking.’",
           "ref": "genesis 24:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And she hastened, and emptied her pitcher into the trough, and ran again unto the well to draw, and drew for all his camels."
-          },
+          "en": "And she hastened, and emptied her pitcher into the trough, and ran again unto the well to draw, and drew for all his camels.",
           "ref": "genesis 24:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And the man looked stedfastly on her; holding his peace, to know whether the LORD had made his journey prosperous or not."
-          },
+          "en": "And the man looked stedfastly on her; holding his peace, to know whether the LORD had made his journey prosperous or not.",
           "ref": "genesis 24:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, as the camels had done drinking, that the man took a golden ring of half a shekel weight, and two bracelets for her hands of ten shekels weight of gold;"
-          },
+          "en": "And it came to pass, as the camels had done drinking, that the man took a golden ring of half a shekel weight, and two bracelets for her hands of ten shekels weight of gold;",
           "ref": "genesis 24:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "and said: ‘Whose daughter art thou? tell me, I pray thee. Is there room in thy father’s house for us to lodge in?’"
-          },
+          "en": "and said: ‘Whose daughter art thou? tell me, I pray thee. Is there room in thy father’s house for us to lodge in?’",
           "ref": "genesis 24:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And she said unto him: ‘I am the daughter of Bethuel the son of Milcah, whom she bore unto Nahor.’"
-          },
+          "en": "And she said unto him: ‘I am the daughter of Bethuel the son of Milcah, whom she bore unto Nahor.’",
           "ref": "genesis 24:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "She said moreover unto him: ‘We have both straw and provender enough, and room to lodge in.’"
-          },
+          "en": "She said moreover unto him: ‘We have both straw and provender enough, and room to lodge in.’",
           "ref": "genesis 24:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And the man bowed his head, and prostrated himself before the LORD."
-          },
+          "en": "And the man bowed his head, and prostrated himself before the LORD.",
           "ref": "genesis 24:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Blessed be the LORD, the God of my master Abraham, who hath not forsaken His mercy and His truth toward my master; as for me, the LORD hath led me in the way to the house of my master’s brethren.’"
-          },
+          "en": "And he said: ‘Blessed be the LORD, the God of my master Abraham, who hath not forsaken His mercy and His truth toward my master; as for me, the LORD hath led me in the way to the house of my master’s brethren.’",
           "ref": "genesis 24:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And the damsel ran, and told her mother’s house according to these words."
-          },
+          "en": "And the damsel ran, and told her mother’s house according to these words.",
           "ref": "genesis 24:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And Rebekah had a brother, and his name was Laban; and Laban ran out unto the man, unto the fountain."
-          },
+          "en": "And Rebekah had a brother, and his name was Laban; and Laban ran out unto the man, unto the fountain.",
           "ref": "genesis 24:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when he saw the ring, and the bracelets upon his sister’s hands, and when he heard the words of Rebekah his sister, saying: ‘Thus spoke the man unto me, ‘that he came unto the man; and, behold, he stood by the camels at the fountain."
-          },
+          "en": "And it came to pass, when he saw the ring, and the bracelets upon his sister’s hands, and when he heard the words of Rebekah his sister, saying: ‘Thus spoke the man unto me, ‘that he came unto the man; and, behold, he stood by the camels at the fountain.",
           "ref": "genesis 24:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Come in, thou blessed of the LORD; wherefore standest thou without? for I have cleared the house, and made room for the camels.’"
-          },
+          "en": "And he said: ‘Come in, thou blessed of the LORD; wherefore standest thou without? for I have cleared the house, and made room for the camels.’",
           "ref": "genesis 24:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And the man came into the house, and he ungirded the camels; and he gave straw and provender for the camels, and water to wash his feet and the feet of the men that were with him."
-          },
+          "en": "And the man came into the house, and he ungirded the camels; and he gave straw and provender for the camels, and water to wash his feet and the feet of the men that were with him.",
           "ref": "genesis 24:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And there was set food before him to eat; but he said: ‘I will not eat, until I have told mine errand.’ And he said: ‘Speak on.’"
-          },
+          "en": "And there was set food before him to eat; but he said: ‘I will not eat, until I have told mine errand.’ And he said: ‘Speak on.’",
           "ref": "genesis 24:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘I am Abraham’s servant."
-          },
+          "en": "And he said: ‘I am Abraham’s servant.",
           "ref": "genesis 24:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD hath blessed my master greatly; and he is become great; and He hath given him flocks and herds, and silver and gold, and men-servants and maid-servants, and camels and asses."
-          },
+          "en": "And the LORD hath blessed my master greatly; and he is become great; and He hath given him flocks and herds, and silver and gold, and men-servants and maid-servants, and camels and asses.",
           "ref": "genesis 24:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "And Sarah my master’s wife bore a son to my master when she was old; and unto him hath he given all that he hath."
-          },
+          "en": "And Sarah my master’s wife bore a son to my master when she was old; and unto him hath he given all that he hath.",
           "ref": "genesis 24:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": null,
-            "jps1917": "And my master made me swear, saying: Thou shalt not take a wife for my son of the daughters of the Canaanites, in whose land I dwell."
-          },
+          "en": "And my master made me swear, saying: Thou shalt not take a wife for my son of the daughters of the Canaanites, in whose land I dwell.",
           "ref": "genesis 24:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": null,
-            "jps1917": "But thou shalt go unto my father’s house, and to my kindred, and take a wife for my son."
-          },
+          "en": "But thou shalt go unto my father’s house, and to my kindred, and take a wife for my son.",
           "ref": "genesis 24:38"
         },
         {
           "n": 39,
-          "en": {
-            "sct": null,
-            "jps1917": "And I said unto my master: Peradventure the woman will not follow me."
-          },
+          "en": "And I said unto my master: Peradventure the woman will not follow me.",
           "ref": "genesis 24:39"
         },
         {
           "n": 40,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto me: The LORD, before whom I walk, will send His angel with thee, and prosper thy way; and thou shalt take a wife for my son of my kindred, and of my father’s house;"
-          },
+          "en": "And he said unto me: The LORD, before whom I walk, will send His angel with thee, and prosper thy way; and thou shalt take a wife for my son of my kindred, and of my father’s house;",
           "ref": "genesis 24:40"
         },
         {
           "n": 41,
-          "en": {
-            "sct": null,
-            "jps1917": "then shalt thou be clear from my oath, when thou comest to my kindred; and if they give her not to thee, thou shalt be clear from my oath."
-          },
+          "en": "then shalt thou be clear from my oath, when thou comest to my kindred; and if they give her not to thee, thou shalt be clear from my oath.",
           "ref": "genesis 24:41"
         },
         {
           "n": 42,
-          "en": {
-            "sct": null,
-            "jps1917": "And I came this day unto the fountain, and said: O LORD, the God of my master Abraham, if now Thou do prosper my way which I go:"
-          },
+          "en": "And I came this day unto the fountain, and said: O LORD, the God of my master Abraham, if now Thou do prosper my way which I go:",
           "ref": "genesis 24:42"
         },
         {
           "n": 43,
-          "en": {
-            "sct": null,
-            "jps1917": "behold, I stand by the fountain of water; and let it come to pass, that the maiden that cometh forth to draw, to whom I shall say: Give me, I pray thee, a little water from thy pitcher to drink;"
-          },
+          "en": "behold, I stand by the fountain of water; and let it come to pass, that the maiden that cometh forth to draw, to whom I shall say: Give me, I pray thee, a little water from thy pitcher to drink;",
           "ref": "genesis 24:43"
         },
         {
           "n": 44,
-          "en": {
-            "sct": null,
-            "jps1917": "and she shall say to me: Both drink thou, and I will also draw for thy camels; let the same be the woman whom the LORD hath appointed for my master’s son."
-          },
+          "en": "and she shall say to me: Both drink thou, and I will also draw for thy camels; let the same be the woman whom the LORD hath appointed for my master’s son.",
           "ref": "genesis 24:44"
         },
         {
           "n": 45,
-          "en": {
-            "sct": null,
-            "jps1917": "And before I had done speaking to my heart, behold, Rebekah came forth with her pitcher on her shoulder; and she went down unto the fountain, and drew. And I said unto her: Let me drink, I pray thee."
-          },
+          "en": "And before I had done speaking to my heart, behold, Rebekah came forth with her pitcher on her shoulder; and she went down unto the fountain, and drew. And I said unto her: Let me drink, I pray thee.",
           "ref": "genesis 24:45"
         },
         {
           "n": 46,
-          "en": {
-            "sct": null,
-            "jps1917": "And she made haste, and let down her pitcher from her shoulder, and said: Drink, and I will give thy camels drink also. So I drank, and she made the camels drink also."
-          },
+          "en": "And she made haste, and let down her pitcher from her shoulder, and said: Drink, and I will give thy camels drink also. So I drank, and she made the camels drink also.",
           "ref": "genesis 24:46"
         },
         {
           "n": 47,
-          "en": {
-            "sct": null,
-            "jps1917": "And I asked her, and said: Whose daughter art thou? And she said: The daughter of Bethuel, Nahor’s son, whom Milcah bore unto him. And I put the ring upon her nose, and the bracelets upon her hands."
-          },
+          "en": "And I asked her, and said: Whose daughter art thou? And she said: The daughter of Bethuel, Nahor’s son, whom Milcah bore unto him. And I put the ring upon her nose, and the bracelets upon her hands.",
           "ref": "genesis 24:47"
         },
         {
           "n": 48,
-          "en": {
-            "sct": null,
-            "jps1917": "And I bowed my head, and prostrated myself before the LORD, and blessed the LORD, the God of my master Abraham, who had led me in the right way to take my master’s brother’s daughter for his son."
-          },
+          "en": "And I bowed my head, and prostrated myself before the LORD, and blessed the LORD, the God of my master Abraham, who had led me in the right way to take my master’s brother’s daughter for his son.",
           "ref": "genesis 24:48"
         },
         {
           "n": 49,
-          "en": {
-            "sct": null,
-            "jps1917": "And now if ye will deal kindly and truly with my master, tell me; and if not, tell me; that I may turn to the right hand, or to the left.’"
-          },
+          "en": "And now if ye will deal kindly and truly with my master, tell me; and if not, tell me; that I may turn to the right hand, or to the left.’",
           "ref": "genesis 24:49"
         },
         {
           "n": 50,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Laban and Bethuel answered and said: ‘The thing proceedeth from the LORD; we cannot speak unto thee bad or good."
-          },
+          "en": "Then Laban and Bethuel answered and said: ‘The thing proceedeth from the LORD; we cannot speak unto thee bad or good.",
           "ref": "genesis 24:50"
         },
         {
           "n": 51,
-          "en": {
-            "sct": null,
-            "jps1917": "Behold, Rebekah is before thee, take her, and go, and let her be thy master’s son’s wife, as the LORD hath spoken.’"
-          },
+          "en": "Behold, Rebekah is before thee, take her, and go, and let her be thy master’s son’s wife, as the LORD hath spoken.’",
           "ref": "genesis 24:51"
         },
         {
           "n": 52,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, that, when Abraham’s servant heard their words, he bowed himself down to the earth unto the LORD."
-          },
+          "en": "And it came to pass, that, when Abraham’s servant heard their words, he bowed himself down to the earth unto the LORD.",
           "ref": "genesis 24:52"
         },
         {
           "n": 53,
-          "en": {
-            "sct": null,
-            "jps1917": "And the servant brought forth jewels of silver, and jewels of gold, and raiment, and gave them to Rebekah; he gave also to her brother and to her mother precious things."
-          },
+          "en": "And the servant brought forth jewels of silver, and jewels of gold, and raiment, and gave them to Rebekah; he gave also to her brother and to her mother precious things.",
           "ref": "genesis 24:53"
         },
         {
           "n": 54,
-          "en": {
-            "sct": null,
-            "jps1917": "And they did eat and drink, he and the men that were with him, and tarried all night; and they rose up in the morning, and he said: ‘Send me away unto my master.’"
-          },
+          "en": "And they did eat and drink, he and the men that were with him, and tarried all night; and they rose up in the morning, and he said: ‘Send me away unto my master.’",
           "ref": "genesis 24:54"
         },
         {
           "n": 55,
-          "en": {
-            "sct": null,
-            "jps1917": "And her brother and her mother said: ‘Let the damsel abide with us a few days, at the least ten; after that she shall go.’"
-          },
+          "en": "And her brother and her mother said: ‘Let the damsel abide with us a few days, at the least ten; after that she shall go.’",
           "ref": "genesis 24:55"
         },
         {
           "n": 56,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto them: ‘Delay me not, seeing the LORD hath prospered my way; send me away that I may go to my master.’"
-          },
+          "en": "And he said unto them: ‘Delay me not, seeing the LORD hath prospered my way; send me away that I may go to my master.’",
           "ref": "genesis 24:56"
         },
         {
           "n": 57,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said: ‘We will call the damsel, and inquire at her mouth.’"
-          },
+          "en": "And they said: ‘We will call the damsel, and inquire at her mouth.’",
           "ref": "genesis 24:57"
         },
         {
           "n": 58,
-          "en": {
-            "sct": null,
-            "jps1917": "And they called Rebekah, and said unto her: ‘Wilt thou go with this man?’ And she said: ‘I will go.’"
-          },
+          "en": "And they called Rebekah, and said unto her: ‘Wilt thou go with this man?’ And she said: ‘I will go.’",
           "ref": "genesis 24:58"
         },
         {
           "n": 59,
-          "en": {
-            "sct": null,
-            "jps1917": "And they sent away Rebekah their sister, and her nurse, and Abraham’s servant, and his men."
-          },
+          "en": "And they sent away Rebekah their sister, and her nurse, and Abraham’s servant, and his men.",
           "ref": "genesis 24:59"
         },
         {
           "n": 60,
-          "en": {
-            "sct": null,
-            "jps1917": "And they blessed Rebekah, and said unto her: ‘Our sister, be thou the mother of thousands of ten thousands, and let thy seed possess the gate of those that hate them.’"
-          },
+          "en": "And they blessed Rebekah, and said unto her: ‘Our sister, be thou the mother of thousands of ten thousands, and let thy seed possess the gate of those that hate them.’",
           "ref": "genesis 24:60"
         },
         {
           "n": 61,
-          "en": {
-            "sct": null,
-            "jps1917": "And Rebekah arose, and her damsels, and they rode upon the camels, and followed the man. And the servant took Rebekah, and went his way."
-          },
+          "en": "And Rebekah arose, and her damsels, and they rode upon the camels, and followed the man. And the servant took Rebekah, and went his way.",
           "ref": "genesis 24:61"
         },
         {
           "n": 62,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac came from the way of Beer-lahai-roi; for he dwelt in the land of the South."
-          },
+          "en": "And Isaac came from the way of Beer-lahai-roi; for he dwelt in the land of the South.",
           "ref": "genesis 24:62"
         },
         {
           "n": 63,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac went out to meditate in the field at the eventide; and he lifted up his eyes, and saw, and, behold, there were camels coming."
-          },
+          "en": "And Isaac went out to meditate in the field at the eventide; and he lifted up his eyes, and saw, and, behold, there were camels coming.",
           "ref": "genesis 24:63"
         },
         {
           "n": 64,
-          "en": {
-            "sct": null,
-            "jps1917": "And Rebekah lifted up her eyes, and when she saw Isaac, she alighted from the camel."
-          },
+          "en": "And Rebekah lifted up her eyes, and when she saw Isaac, she alighted from the camel.",
           "ref": "genesis 24:64"
         },
         {
           "n": 65,
-          "en": {
-            "sct": null,
-            "jps1917": "And she said unto the servant: ‘What man is this that walketh in the field to meet us?’ And the servant said: ‘It is my master.’ And she took her veil, and covered herself."
-          },
+          "en": "And she said unto the servant: ‘What man is this that walketh in the field to meet us?’ And the servant said: ‘It is my master.’ And she took her veil, and covered herself.",
           "ref": "genesis 24:65"
         },
         {
           "n": 66,
-          "en": {
-            "sct": null,
-            "jps1917": "And the servant told Isaac all the things that he had done."
-          },
+          "en": "And the servant told Isaac all the things that he had done.",
           "ref": "genesis 24:66"
         },
         {
           "n": 67,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac brought her into his mother Sarah’s tent, and took Rebekah, and she became his wife; and he loved her. And Isaac was comforted for his mother."
-          },
+          "en": "And Isaac brought her into his mother Sarah’s tent, and took Rebekah, and she became his wife; and he loved her. And Isaac was comforted for his mother.",
           "ref": "genesis 24:67"
         }
       ]
@@ -5399,274 +3422,172 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham took another wife, and her name was Keturah."
-          },
+          "en": "And Abraham took another wife, and her name was Keturah.",
           "ref": "genesis 25:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And she bore him Zimran, and Jokshan, and Medan, and Midian, and Ishbak, and Shuah."
-          },
+          "en": "And she bore him Zimran, and Jokshan, and Medan, and Midian, and Ishbak, and Shuah.",
           "ref": "genesis 25:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jokshan begot Sheba, and Dedan. And the sons of Dedan were Asshurim, and Letushim, and Leummim."
-          },
+          "en": "And Jokshan begot Sheba, and Dedan. And the sons of Dedan were Asshurim, and Letushim, and Leummim.",
           "ref": "genesis 25:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Midian: Ephah, and Epher, and Hanoch, and Abida, and Eldaah. All these were the children of Keturah."
-          },
+          "en": "And the sons of Midian: Ephah, and Epher, and Hanoch, and Abida, and Eldaah. All these were the children of Keturah.",
           "ref": "genesis 25:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham gave all that he had unto Isaac."
-          },
+          "en": "And Abraham gave all that he had unto Isaac.",
           "ref": "genesis 25:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "But unto the sons of the concubines, that Abraham had, Abraham gave gifts; and he sent them away from Isaac his son, while he yet lived, eastward, unto the east country."
-          },
+          "en": "But unto the sons of the concubines, that Abraham had, Abraham gave gifts; and he sent them away from Isaac his son, while he yet lived, eastward, unto the east country.",
           "ref": "genesis 25:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the days of the years of Abraham’s life which he lived, a hundred threescore and fifteen years."
-          },
+          "en": "And these are the days of the years of Abraham’s life which he lived, a hundred threescore and fifteen years.",
           "ref": "genesis 25:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abraham expired, and died in a good old age, an old man, and full of years; and was gathered to his people."
-          },
+          "en": "And Abraham expired, and died in a good old age, an old man, and full of years; and was gathered to his people.",
           "ref": "genesis 25:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac and Ishmael his sons buried him in the cave of Machpelah, in the field of Ephron the son of Zohar the Hittite, which is before Mamre;"
-          },
+          "en": "And Isaac and Ishmael his sons buried him in the cave of Machpelah, in the field of Ephron the son of Zohar the Hittite, which is before Mamre;",
           "ref": "genesis 25:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "the field which Abraham purchased of the children of Heth; there was Abraham buried, and Sarah his wife."
-          },
+          "en": "the field which Abraham purchased of the children of Heth; there was Abraham buried, and Sarah his wife.",
           "ref": "genesis 25:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": "And it came to pass after the death of Abraham that God blessed his son Isaac; and Isaac dwelt by Beer-lachai-roi.",
-            "jps1917": "And it came to pass after the death of Abraham, that God blessed Isaac his son; and Isaac dwelt by Beer-lahai-roi."
-          },
+          "en": "And it came to pass after the death of Abraham, that God blessed Isaac his son; and Isaac dwelt by Beer-lahai-roi.",
           "ref": "genesis 25:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "Now these are the generations of Ishmael, Abraham’s son, whom Hagar the Egyptian, Sarah’s handmaid, bore unto Abraham."
-          },
+          "en": "Now these are the generations of Ishmael, Abraham’s son, whom Hagar the Egyptian, Sarah’s handmaid, bore unto Abraham.",
           "ref": "genesis 25:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the names of the sons of Ishmael, by their names, according to their generations: the first-born of Ishmael, Nebaioth; and Kedar, and Adbeel, and Mibsam,"
-          },
+          "en": "And these are the names of the sons of Ishmael, by their names, according to their generations: the first-born of Ishmael, Nebaioth; and Kedar, and Adbeel, and Mibsam,",
           "ref": "genesis 25:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "and Mishma, and Dumah, and Massa;"
-          },
+          "en": "and Mishma, and Dumah, and Massa;",
           "ref": "genesis 25:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "Hadad, and Tema, Jetur, Naphish, and Kedem;"
-          },
+          "en": "Hadad, and Tema, Jetur, Naphish, and Kedem;",
           "ref": "genesis 25:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "these are the sons of Ishmael, and these are their names, by their villages, and by their encampments; twelve princes according to their nations."
-          },
+          "en": "these are the sons of Ishmael, and these are their names, by their villages, and by their encampments; twelve princes according to their nations.",
           "ref": "genesis 25:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the years of the life of Ishmael, a hundred and thirty and seven years; and he expired and died; and was gathered unto his people."
-          },
+          "en": "And these are the years of the life of Ishmael, a hundred and thirty and seven years; and he expired and died; and was gathered unto his people.",
           "ref": "genesis 25:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And they dwelt from Havilah unto Shur that is before Egypt, as thou goest toward Asshur: over against all his brethren he did settle."
-          },
+          "en": "And they dwelt from Havilah unto Shur that is before Egypt, as thou goest toward Asshur: over against all his brethren he did settle.",
           "ref": "genesis 25:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the generations of Isaac, Abraham’s son: Abraham begot Isaac."
-          },
+          "en": "And these are the generations of Isaac, Abraham’s son: Abraham begot Isaac.",
           "ref": "genesis 25:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac was forty years old when he took Rebekah, the daughter of Bethuel the Aramean, of Paddan-aram, the sister of Laban the Aramean, to be his wife."
-          },
+          "en": "And Isaac was forty years old when he took Rebekah, the daughter of Bethuel the Aramean, of Paddan-aram, the sister of Laban the Aramean, to be his wife.",
           "ref": "genesis 25:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac entreated the LORD for his wife, because she was barren; and the LORD let Himself be entreated of him, and Rebekah his wife conceived."
-          },
+          "en": "And Isaac entreated the LORD for his wife, because she was barren; and the LORD let Himself be entreated of him, and Rebekah his wife conceived.",
           "ref": "genesis 25:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And the children struggled together within her; and she said: ‘If it be so, wherefore do I live?’ And she went to inquire of the LORD."
-          },
+          "en": "And the children struggled together within her; and she said: ‘If it be so, wherefore do I live?’ And she went to inquire of the LORD.",
           "ref": "genesis 25:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD said unto her: Two nations are in thy womb, And two peoples shall be separated from thy bowels; And the one people shall be stronger than the other people; And the elder shall serve the younger."
-          },
+          "en": "And the LORD said unto her: Two nations are in thy womb, And two peoples shall be separated from thy bowels; And the one people shall be stronger than the other people; And the elder shall serve the younger.",
           "ref": "genesis 25:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And when her days to be delivered were fulfilled, behold, there were twins in her womb."
-          },
+          "en": "And when her days to be delivered were fulfilled, behold, there were twins in her womb.",
           "ref": "genesis 25:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And the first came forth ruddy, all over like a hairy mantle; and they called his name Esau."
-          },
+          "en": "And the first came forth ruddy, all over like a hairy mantle; and they called his name Esau.",
           "ref": "genesis 25:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And after that came forth his brother, and his hand had hold on Esau’s heel; and his name was called Jacob. And Isaac was threescore years old when she bore them."
-          },
+          "en": "And after that came forth his brother, and his hand had hold on Esau’s heel; and his name was called Jacob. And Isaac was threescore years old when she bore them.",
           "ref": "genesis 25:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And the boys grew; and Esau was a cunning hunter, a man of the field; and Jacob was a quiet man, dwelling in tents."
-          },
+          "en": "And the boys grew; and Esau was a cunning hunter, a man of the field; and Jacob was a quiet man, dwelling in tents.",
           "ref": "genesis 25:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "Now Isaac loved Esau, because he did eat of his venison; and Rebekah loved Jacob."
-          },
+          "en": "Now Isaac loved Esau, because he did eat of his venison; and Rebekah loved Jacob.",
           "ref": "genesis 25:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob sod pottage; and Esau came in from the field, and he was faint."
-          },
+          "en": "And Jacob sod pottage; and Esau came in from the field, and he was faint.",
           "ref": "genesis 25:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And Esau said to Jacob: ‘Let me swallow, I pray thee, some of this red, red pottage; for I am faint.’ Therefore was his name called Edom."
-          },
+          "en": "And Esau said to Jacob: ‘Let me swallow, I pray thee, some of this red, red pottage; for I am faint.’ Therefore was his name called Edom.",
           "ref": "genesis 25:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob said: ‘Sell me first thy birth right.’"
-          },
+          "en": "And Jacob said: ‘Sell me first thy birth right.’",
           "ref": "genesis 25:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And Esau said: ‘Behold, I am at the point to die; and what profit shall the birthright do to me?’"
-          },
+          "en": "And Esau said: ‘Behold, I am at the point to die; and what profit shall the birthright do to me?’",
           "ref": "genesis 25:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob said: ‘Swear to me first’; and he swore unto him; and he sold his birthright unto Jacob."
-          },
+          "en": "And Jacob said: ‘Swear to me first’; and he swore unto him; and he sold his birthright unto Jacob.",
           "ref": "genesis 25:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob gave Esau bread and pottage of lentils; and he did eat and drink, and rose up, and went his way. So Esau despised his birthright."
-          },
+          "en": "And Jacob gave Esau bread and pottage of lentils; and he did eat and drink, and rose up, and went his way. So Esau despised his birthright.",
           "ref": "genesis 25:34"
         }
       ]
@@ -5676,282 +3597,177 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And there was a famine in the land, beside the first famine that was in the days of Abraham. And Isaac went unto Abimelech king of the Philistines unto Gerar."
-          },
+          "en": "And there was a famine in the land, beside the first famine that was in the days of Abraham. And Isaac went unto Abimelech king of the Philistines unto Gerar.",
           "ref": "genesis 26:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD appeared unto him, and said: ‘Go not down unto Egypt; dwell in the land which I shall tell thee of."
-          },
+          "en": "And the LORD appeared unto him, and said: ‘Go not down unto Egypt; dwell in the land which I shall tell thee of.",
           "ref": "genesis 26:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "Sojourn in this land, and I will be with thee, and will bless thee; for unto thee, and unto thy seed, I will give all these lands, and I will establish the oath which I swore unto Abraham thy father;"
-          },
+          "en": "Sojourn in this land, and I will be with thee, and will bless thee; for unto thee, and unto thy seed, I will give all these lands, and I will establish the oath which I swore unto Abraham thy father;",
           "ref": "genesis 26:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "and I will multiply thy seed as the stars of heaven, and will give unto thy seed all these lands; and by thy seed shall all the nations of the earth bless themselves;"
-          },
+          "en": "and I will multiply thy seed as the stars of heaven, and will give unto thy seed all these lands; and by thy seed shall all the nations of the earth bless themselves;",
           "ref": "genesis 26:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "because that Abraham hearkened to My voice, and kept My charge, My commandments, My statutes, and My laws.’"
-          },
+          "en": "because that Abraham hearkened to My voice, and kept My charge, My commandments, My statutes, and My laws.’",
           "ref": "genesis 26:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac dwelt in Gerar."
-          },
+          "en": "And Isaac dwelt in Gerar.",
           "ref": "genesis 26:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And the men of the place asked him of his wife; and he said: ‘She is my sister’; for he feared to say: ‘My wife’; ‘lest the men of the place should kill me for Rebekah, because she is fair to look upon.’"
-          },
+          "en": "And the men of the place asked him of his wife; and he said: ‘She is my sister’; for he feared to say: ‘My wife’; ‘lest the men of the place should kill me for Rebekah, because she is fair to look upon.’",
           "ref": "genesis 26:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when he had been there a long time, that Abimelech king of the Philistines looked out at a window, and saw, and, behold, Isaac was sporting with Rebekah his wife."
-          },
+          "en": "And it came to pass, when he had been there a long time, that Abimelech king of the Philistines looked out at a window, and saw, and, behold, Isaac was sporting with Rebekah his wife.",
           "ref": "genesis 26:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abimelech called Isaac, and said: ‘Behold, of a surety she is thy wife; and how saidst thou: She is my sister?’ And Isaac said unto him: ‘Because I said: Lest I die because of her.’"
-          },
+          "en": "And Abimelech called Isaac, and said: ‘Behold, of a surety she is thy wife; and how saidst thou: She is my sister?’ And Isaac said unto him: ‘Because I said: Lest I die because of her.’",
           "ref": "genesis 26:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abimelech said: ‘What is this thou hast done unto us? one of the people might easily have lain with thy wife, and thou wouldest have brought guiltiness upon us.’"
-          },
+          "en": "And Abimelech said: ‘What is this thou hast done unto us? one of the people might easily have lain with thy wife, and thou wouldest have brought guiltiness upon us.’",
           "ref": "genesis 26:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abimelech charged all the people, saying: ‘He that toucheth this man or his wife shall surely be put to death.’"
-          },
+          "en": "And Abimelech charged all the people, saying: ‘He that toucheth this man or his wife shall surely be put to death.’",
           "ref": "genesis 26:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac sowed in that land, and found in the same year a hundred-fold; and the LORD blessed him."
-          },
+          "en": "And Isaac sowed in that land, and found in the same year a hundred-fold; and the LORD blessed him.",
           "ref": "genesis 26:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And the man waxed great, and grew more and more until he became very great."
-          },
+          "en": "And the man waxed great, and grew more and more until he became very great.",
           "ref": "genesis 26:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And he had possessions of flocks, and possessions of herds, and a great household; and the Philistines envied him."
-          },
+          "en": "And he had possessions of flocks, and possessions of herds, and a great household; and the Philistines envied him.",
           "ref": "genesis 26:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "Now all the wells which his father’s servants had digged in the days of Abraham his father, the Philistines had stopped them, and filled them with earth."
-          },
+          "en": "Now all the wells which his father’s servants had digged in the days of Abraham his father, the Philistines had stopped them, and filled them with earth.",
           "ref": "genesis 26:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And Abimelech said unto Isaac: ‘Go from us; for thou art much mightier than we.’"
-          },
+          "en": "And Abimelech said unto Isaac: ‘Go from us; for thou art much mightier than we.’",
           "ref": "genesis 26:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac departed thence, and encamped in the valley of Gerar, and dwelt there."
-          },
+          "en": "And Isaac departed thence, and encamped in the valley of Gerar, and dwelt there.",
           "ref": "genesis 26:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac digged again the wells of water, which they had digged in the days of Abraham his father; for the Philistines had stopped them after the death of Abraham; and he called their names after the names by which his father had called them."
-          },
+          "en": "And Isaac digged again the wells of water, which they had digged in the days of Abraham his father; for the Philistines had stopped them after the death of Abraham; and he called their names after the names by which his father had called them.",
           "ref": "genesis 26:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac’s servants digged in the valley, and found there a well of living water."
-          },
+          "en": "And Isaac’s servants digged in the valley, and found there a well of living water.",
           "ref": "genesis 26:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And the herdmen of Gerar strove with Isaac’s herdmen, saying: ‘The water is ours.’ And he called the name of the well Esek; because they contended with him."
-          },
+          "en": "And the herdmen of Gerar strove with Isaac’s herdmen, saying: ‘The water is ours.’ And he called the name of the well Esek; because they contended with him.",
           "ref": "genesis 26:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And they digged another well, and they strove for that also. And he called the name of it Sitnah."
-          },
+          "en": "And they digged another well, and they strove for that also. And he called the name of it Sitnah.",
           "ref": "genesis 26:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And he removed from thence, and digged another well; and for that they strove not. And he called the name of it Rehoboth; and he said: ‘For now the LORD hath made room for us, and we shall be fruitful in the land.’"
-          },
+          "en": "And he removed from thence, and digged another well; and for that they strove not. And he called the name of it Rehoboth; and he said: ‘For now the LORD hath made room for us, and we shall be fruitful in the land.’",
           "ref": "genesis 26:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And he went up from thence to Beer-sheba."
-          },
+          "en": "And he went up from thence to Beer-sheba.",
           "ref": "genesis 26:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD appeared unto him the same night, and said: ‘I am the God of Abraham thy father. Fear not, for I am with thee, and will bless thee, and multiply thy seed for My servant Abraham’s sake.’"
-          },
+          "en": "And the LORD appeared unto him the same night, and said: ‘I am the God of Abraham thy father. Fear not, for I am with thee, and will bless thee, and multiply thy seed for My servant Abraham’s sake.’",
           "ref": "genesis 26:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And he builded an altar there, and called upon the name of the LORD, and pitched his tent there; and there Isaac’s servants digged a well."
-          },
+          "en": "And he builded an altar there, and called upon the name of the LORD, and pitched his tent there; and there Isaac’s servants digged a well.",
           "ref": "genesis 26:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Abimelech went to him from Gerar, and Ahuzzath his friend, and Phicol the captain of his host."
-          },
+          "en": "Then Abimelech went to him from Gerar, and Ahuzzath his friend, and Phicol the captain of his host.",
           "ref": "genesis 26:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac said unto them: ‘Wherefore are ye come unto me, seeing ye hate me, and have sent me away from you?’"
-          },
+          "en": "And Isaac said unto them: ‘Wherefore are ye come unto me, seeing ye hate me, and have sent me away from you?’",
           "ref": "genesis 26:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said: ‘We saw plainly that the LORD was with thee; and we said: Let there now be an oath betwixt us, even betwixt us and thee, and let us make a covenant with thee;"
-          },
+          "en": "And they said: ‘We saw plainly that the LORD was with thee; and we said: Let there now be an oath betwixt us, even betwixt us and thee, and let us make a covenant with thee;",
           "ref": "genesis 26:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "that thou wilt do us no hurt, as we have not touched thee, and as we have done unto thee nothing but good, and have sent thee away in peace; thou art now the blessed of the LORD.’"
-          },
+          "en": "that thou wilt do us no hurt, as we have not touched thee, and as we have done unto thee nothing but good, and have sent thee away in peace; thou art now the blessed of the LORD.’",
           "ref": "genesis 26:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made them a feast, and they did eat and drink."
-          },
+          "en": "And he made them a feast, and they did eat and drink.",
           "ref": "genesis 26:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And they rose up betimes in the morning, and swore one to another; and Isaac sent them away, and they departed from him in peace."
-          },
+          "en": "And they rose up betimes in the morning, and swore one to another; and Isaac sent them away, and they departed from him in peace.",
           "ref": "genesis 26:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass the same day, that Isaac’s servants came, and told him concerning the well which they had digged, and said unto him: ‘We have found water.’"
-          },
+          "en": "And it came to pass the same day, that Isaac’s servants came, and told him concerning the well which they had digged, and said unto him: ‘We have found water.’",
           "ref": "genesis 26:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And he called it Shibah. Therefore the name of the city is Beer-sheba unto this day."
-          },
+          "en": "And he called it Shibah. Therefore the name of the city is Beer-sheba unto this day.",
           "ref": "genesis 26:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Esau was forty years old, he took to wife Judith the daughter of Beeri the Hittite, and Basemath the daughter of Elon the Hittite."
-          },
+          "en": "And when Esau was forty years old, he took to wife Judith the daughter of Beeri the Hittite, and Basemath the daughter of Elon the Hittite.",
           "ref": "genesis 26:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And they were a bitterness of spirit unto Isaac and to Rebekah."
-          },
+          "en": "And they were a bitterness of spirit unto Isaac and to Rebekah.",
           "ref": "genesis 26:35"
         }
       ]
@@ -5961,370 +3777,232 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, that when Isaac was old, and his eyes were dim, so that he could not see, he called Esau his elder son, and said unto him: ‘My son’; and he said unto him: ‘Here am I.’"
-          },
+          "en": "And it came to pass, that when Isaac was old, and his eyes were dim, so that he could not see, he called Esau his elder son, and said unto him: ‘My son’; and he said unto him: ‘Here am I.’",
           "ref": "genesis 27:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Behold now, I am old, I know not the day of my death."
-          },
+          "en": "And he said: ‘Behold now, I am old, I know not the day of my death.",
           "ref": "genesis 27:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "Now therefore take, I pray thee, thy weapons, thy quiver and thy bow, and go out to the field, and take me venison;"
-          },
+          "en": "Now therefore take, I pray thee, thy weapons, thy quiver and thy bow, and go out to the field, and take me venison;",
           "ref": "genesis 27:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "and make me savoury food, such as I love, and bring it to me, that I may eat; that my soul may bless thee before I die.’"
-          },
+          "en": "and make me savoury food, such as I love, and bring it to me, that I may eat; that my soul may bless thee before I die.’",
           "ref": "genesis 27:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And Rebekah heard when Isaac spoke to Esau his son. And Esau went to the field to hunt for venison, and to bring it."
-          },
+          "en": "And Rebekah heard when Isaac spoke to Esau his son. And Esau went to the field to hunt for venison, and to bring it.",
           "ref": "genesis 27:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Rebekah spoke unto Jacob her son, saying: ‘Behold, I heard thy father speak unto Esau thy brother, saying:"
-          },
+          "en": "And Rebekah spoke unto Jacob her son, saying: ‘Behold, I heard thy father speak unto Esau thy brother, saying:",
           "ref": "genesis 27:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "Bring me venison, and make me savoury food, that I may eat, and bless thee before the LORD before my death."
-          },
+          "en": "Bring me venison, and make me savoury food, that I may eat, and bless thee before the LORD before my death.",
           "ref": "genesis 27:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "Now therefore, my son, hearken to my voice according to that which I command thee."
-          },
+          "en": "Now therefore, my son, hearken to my voice according to that which I command thee.",
           "ref": "genesis 27:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "Go now to the flock, and fetch me from thence two good kids of the goats; and I will make them savoury food for thy father, such as he loveth;"
-          },
+          "en": "Go now to the flock, and fetch me from thence two good kids of the goats; and I will make them savoury food for thy father, such as he loveth;",
           "ref": "genesis 27:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "and thou shalt bring it to thy father, that he may eat, so that he may bless thee before his death.’"
-          },
+          "en": "and thou shalt bring it to thy father, that he may eat, so that he may bless thee before his death.’",
           "ref": "genesis 27:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob said to Rebekah his mother: ‘Behold, Esau my brother is a hairy man, and I am a smooth man."
-          },
+          "en": "And Jacob said to Rebekah his mother: ‘Behold, Esau my brother is a hairy man, and I am a smooth man.",
           "ref": "genesis 27:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "My father peradventure will feel me, and I shall seem to him as a mocker; and I shall bring a curse upon me, and not a blessing.’"
-          },
+          "en": "My father peradventure will feel me, and I shall seem to him as a mocker; and I shall bring a curse upon me, and not a blessing.’",
           "ref": "genesis 27:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And his mother said unto him: ‘Upon me be thy curse, my son; only hearken to my voice, and go fetch me them.’"
-          },
+          "en": "And his mother said unto him: ‘Upon me be thy curse, my son; only hearken to my voice, and go fetch me them.’",
           "ref": "genesis 27:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And he went, and fetched, and brought them to his mother; and his mother made savoury food, such as his father loved."
-          },
+          "en": "And he went, and fetched, and brought them to his mother; and his mother made savoury food, such as his father loved.",
           "ref": "genesis 27:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And Rebekah took the choicest garments of Esau her elder son, which were with her in the house, and put them upon Jacob her younger son."
-          },
+          "en": "And Rebekah took the choicest garments of Esau her elder son, which were with her in the house, and put them upon Jacob her younger son.",
           "ref": "genesis 27:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And she put the skins of the kids of the goats upon his hands, and upon the smooth of his neck."
-          },
+          "en": "And she put the skins of the kids of the goats upon his hands, and upon the smooth of his neck.",
           "ref": "genesis 27:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And she gave the savoury food and the bread, which she had prepared, into the hand of her son Jacob."
-          },
+          "en": "And she gave the savoury food and the bread, which she had prepared, into the hand of her son Jacob.",
           "ref": "genesis 27:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And he came unto his father, and said: ‘My father’; and he said: ‘Here am I; who art thou, my son?’"
-          },
+          "en": "And he came unto his father, and said: ‘My father’; and he said: ‘Here am I; who art thou, my son?’",
           "ref": "genesis 27:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob said unto his father: ‘I am Esau thy first-born; I have done according as thou badest me. Arise, I pray thee, sit and eat of my venison, that thy soul may bless me.’"
-          },
+          "en": "And Jacob said unto his father: ‘I am Esau thy first-born; I have done according as thou badest me. Arise, I pray thee, sit and eat of my venison, that thy soul may bless me.’",
           "ref": "genesis 27:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac said unto his son: ‘How is it that thou hast found it so quickly, my son?’ And he said: ‘Because the LORD thy God sent me good speed.’"
-          },
+          "en": "And Isaac said unto his son: ‘How is it that thou hast found it so quickly, my son?’ And he said: ‘Because the LORD thy God sent me good speed.’",
           "ref": "genesis 27:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac said unto Jacob: ‘Come near, I pray thee, that I may feel thee, my son, whether thou be my very son Esau or not.’"
-          },
+          "en": "And Isaac said unto Jacob: ‘Come near, I pray thee, that I may feel thee, my son, whether thou be my very son Esau or not.’",
           "ref": "genesis 27:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob went near unto Isaac his father; and he felt him, and said: ‘The voice is the voice of Jacob, but the hands are the hands of Esau.’"
-          },
+          "en": "And Jacob went near unto Isaac his father; and he felt him, and said: ‘The voice is the voice of Jacob, but the hands are the hands of Esau.’",
           "ref": "genesis 27:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And he discerned him not, because his hands were hairy, as his brother Esau’s hands; so he blessed him."
-          },
+          "en": "And he discerned him not, because his hands were hairy, as his brother Esau’s hands; so he blessed him.",
           "ref": "genesis 27:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Art thou my very son Esau?’ And he said: ‘I am.’"
-          },
+          "en": "And he said: ‘Art thou my very son Esau?’ And he said: ‘I am.’",
           "ref": "genesis 27:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Bring it near to me, and I will eat of my son’s venison, that my soul may bless thee.’ And he brought it near to him, and he did eat; and he brought him wine, and he drank."
-          },
+          "en": "And he said: ‘Bring it near to me, and I will eat of my son’s venison, that my soul may bless thee.’ And he brought it near to him, and he did eat; and he brought him wine, and he drank.",
           "ref": "genesis 27:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And his father Isaac said unto him: ‘Come near now, and kiss me, my son.’"
-          },
+          "en": "And his father Isaac said unto him: ‘Come near now, and kiss me, my son.’",
           "ref": "genesis 27:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And he came near, and kissed him. And he smelled the smell of his raiment, and blessed him, and said: See, the smell of my son Is as the smell of a field which the LORD hath blessed."
-          },
+          "en": "And he came near, and kissed him. And he smelled the smell of his raiment, and blessed him, and said: See, the smell of my son Is as the smell of a field which the LORD hath blessed.",
           "ref": "genesis 27:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "So God give thee of the dew of heaven, And of the fat places of the earth, And plenty of corn and wine."
-          },
+          "en": "So God give thee of the dew of heaven, And of the fat places of the earth, And plenty of corn and wine.",
           "ref": "genesis 27:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "Let peoples serve thee, And nations bow down to thee. Be lord over thy brethren, And let thy mother’s sons bow down to thee. Cursed be every one that curseth thee, And blessed be every one that blesseth thee."
-          },
+          "en": "Let peoples serve thee, And nations bow down to thee. Be lord over thy brethren, And let thy mother’s sons bow down to thee. Cursed be every one that curseth thee, And blessed be every one that blesseth thee.",
           "ref": "genesis 27:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, as soon as Isaac had made an end of blessing Jacob, and Jacob was yet scarce gone out from the presence of Isaac his father, that Esau his brother came in from his hunting."
-          },
+          "en": "And it came to pass, as soon as Isaac had made an end of blessing Jacob, and Jacob was yet scarce gone out from the presence of Isaac his father, that Esau his brother came in from his hunting.",
           "ref": "genesis 27:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And he also made savoury food, and brought it unto his father; and he said unto his father: ‘Let my father arise, and eat of his son’s venison, that thy soul may bless me.’"
-          },
+          "en": "And he also made savoury food, and brought it unto his father; and he said unto his father: ‘Let my father arise, and eat of his son’s venison, that thy soul may bless me.’",
           "ref": "genesis 27:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac his father said unto him: ‘Who art thou?’ And he said: ‘I am thy son, thy first-born, Esau.’"
-          },
+          "en": "And Isaac his father said unto him: ‘Who art thou?’ And he said: ‘I am thy son, thy first-born, Esau.’",
           "ref": "genesis 27:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac trembled very exceedingly, and said: ‘Who then is he that hath taken venison, and brought it me, and I have eaten of all before thou camest, and have blessed him? yea, and he shall be blessed.’"
-          },
+          "en": "And Isaac trembled very exceedingly, and said: ‘Who then is he that hath taken venison, and brought it me, and I have eaten of all before thou camest, and have blessed him? yea, and he shall be blessed.’",
           "ref": "genesis 27:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "When Esau heard the words of his father, he cried with an exceeding great and bitter cry, and said unto his father: ‘Bless me, even me also, O my father.’"
-          },
+          "en": "When Esau heard the words of his father, he cried with an exceeding great and bitter cry, and said unto his father: ‘Bless me, even me also, O my father.’",
           "ref": "genesis 27:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Thy brother came with guile, and hath taken away thy blessing.’"
-          },
+          "en": "And he said: ‘Thy brother came with guile, and hath taken away thy blessing.’",
           "ref": "genesis 27:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Is not he rightly named Jacob? for he hath supplanted me these two times: he took away my birthright; and, behold, now he hath taken away my blessing.’ And he said: ‘Hast thou not reserved a blessing for me?’"
-          },
+          "en": "And he said: ‘Is not he rightly named Jacob? for he hath supplanted me these two times: he took away my birthright; and, behold, now he hath taken away my blessing.’ And he said: ‘Hast thou not reserved a blessing for me?’",
           "ref": "genesis 27:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac answered and said unto Esau: ‘Behold, I have made him thy lord, and all his brethren have I given to him for servants; and with corn and wine have I sustained him; and what then shall I do for thee, my son?’"
-          },
+          "en": "And Isaac answered and said unto Esau: ‘Behold, I have made him thy lord, and all his brethren have I given to him for servants; and with corn and wine have I sustained him; and what then shall I do for thee, my son?’",
           "ref": "genesis 27:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": null,
-            "jps1917": "And Esau said unto his father: ‘Hast thou but one blessing, my father? bless me, even me also, O my father.’ And Esau lifted up his voice, and wept."
-          },
+          "en": "And Esau said unto his father: ‘Hast thou but one blessing, my father? bless me, even me also, O my father.’ And Esau lifted up his voice, and wept.",
           "ref": "genesis 27:38"
         },
         {
           "n": 39,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac his father answered and said unto him: Behold, of the fat places of the earth shall be thy dwelling, And of the dew of heaven from above;"
-          },
+          "en": "And Isaac his father answered and said unto him: Behold, of the fat places of the earth shall be thy dwelling, And of the dew of heaven from above;",
           "ref": "genesis 27:39"
         },
         {
           "n": 40,
-          "en": {
-            "sct": null,
-            "jps1917": "And by thy sword shalt thou live, And thou shalt serve thy brother; And it shall come to pass when thou shalt break loose, That thou shalt shake his yoke from off thy neck."
-          },
+          "en": "And by thy sword shalt thou live, And thou shalt serve thy brother; And it shall come to pass when thou shalt break loose, That thou shalt shake his yoke from off thy neck.",
           "ref": "genesis 27:40"
         },
         {
           "n": 41,
-          "en": {
-            "sct": null,
-            "jps1917": "And Esau hated Jacob because of the blessing wherewith his father blessed him. And Esau said in his heart: ‘Let the days of mourning for my father be at hand; then will I slay my brother Jacob.’"
-          },
+          "en": "And Esau hated Jacob because of the blessing wherewith his father blessed him. And Esau said in his heart: ‘Let the days of mourning for my father be at hand; then will I slay my brother Jacob.’",
           "ref": "genesis 27:41"
         },
         {
           "n": 42,
-          "en": {
-            "sct": null,
-            "jps1917": "And the words of Esau her elder son were told to Rebekah; and she sent and called Jacob her younger son, and said unto him: ‘Behold, thy brother Esau, as touching thee, doth comfort himself, purposing to kill thee."
-          },
+          "en": "And the words of Esau her elder son were told to Rebekah; and she sent and called Jacob her younger son, and said unto him: ‘Behold, thy brother Esau, as touching thee, doth comfort himself, purposing to kill thee.",
           "ref": "genesis 27:42"
         },
         {
           "n": 43,
-          "en": {
-            "sct": null,
-            "jps1917": "Now therefore, my son, hearken to my voice; and arise, flee thou to Laban my brother to Haran;"
-          },
+          "en": "Now therefore, my son, hearken to my voice; and arise, flee thou to Laban my brother to Haran;",
           "ref": "genesis 27:43"
         },
         {
           "n": 44,
-          "en": {
-            "sct": null,
-            "jps1917": "and tarry with him a few days, until thy brother’s fury turn away;"
-          },
+          "en": "and tarry with him a few days, until thy brother’s fury turn away;",
           "ref": "genesis 27:44"
         },
         {
           "n": 45,
-          "en": {
-            "sct": null,
-            "jps1917": "until thy brother’s anger turn away from thee, and he forget that which thou hast done to him; then I will send, and fetch thee from thence; why should I be bereaved of you both in one day?’"
-          },
+          "en": "until thy brother’s anger turn away from thee, and he forget that which thou hast done to him; then I will send, and fetch thee from thence; why should I be bereaved of you both in one day?’",
           "ref": "genesis 27:45"
         },
         {
           "n": 46,
-          "en": {
-            "sct": null,
-            "jps1917": "And Rebekah said to Isaac: ‘I am weary of my life because of the daughters of Heth. If Jacob take a wife of the daughters of Heth, such as these, of the daughters of the land, what good shall my life do me?’"
-          },
+          "en": "And Rebekah said to Isaac: ‘I am weary of my life because of the daughters of Heth. If Jacob take a wife of the daughters of Heth, such as these, of the daughters of the land, what good shall my life do me?’",
           "ref": "genesis 27:46"
         }
       ]
@@ -6334,178 +4012,112 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac called Jacob, and blessed him, and charged him, and said unto him: ‘Thou shalt not take a wife of the daughters of Canaan."
-          },
+          "en": "And Isaac called Jacob, and blessed him, and charged him, and said unto him: ‘Thou shalt not take a wife of the daughters of Canaan.",
           "ref": "genesis 28:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "Arise, go to Paddan-aram, to the house of Bethuel thy mother’s father; and take thee a wife from thence of the daughters of Laban thy mother’s brother."
-          },
+          "en": "Arise, go to Paddan-aram, to the house of Bethuel thy mother’s father; and take thee a wife from thence of the daughters of Laban thy mother’s brother.",
           "ref": "genesis 28:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And God Almighty bless thee, and make thee fruitful, and multiply thee, that thou mayest be a congregation of peoples;"
-          },
+          "en": "And God Almighty bless thee, and make thee fruitful, and multiply thee, that thou mayest be a congregation of peoples;",
           "ref": "genesis 28:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "and give thee the blessing of Abraham, to thee, and to thy seed with thee; that thou mayest inherit the land of thy sojournings, which God gave unto Abraham.’"
-          },
+          "en": "and give thee the blessing of Abraham, to thee, and to thy seed with thee; that thou mayest inherit the land of thy sojournings, which God gave unto Abraham.’",
           "ref": "genesis 28:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac sent away Jacob; and he went to Paddan-aram unto Laban, son of Bethuel the Aramean, the brother of Rebekah, Jacob’s and Esau’s mother."
-          },
+          "en": "And Isaac sent away Jacob; and he went to Paddan-aram unto Laban, son of Bethuel the Aramean, the brother of Rebekah, Jacob’s and Esau’s mother.",
           "ref": "genesis 28:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "Now Esau saw that Isaac had blessed Jacob and sent him away to Paddan-aram, to take him a wife from thence; and that as he blessed him he gave him a charge, saying: ‘Thou shalt not take a wife of the daughters of Canaan’;"
-          },
+          "en": "Now Esau saw that Isaac had blessed Jacob and sent him away to Paddan-aram, to take him a wife from thence; and that as he blessed him he gave him a charge, saying: ‘Thou shalt not take a wife of the daughters of Canaan’;",
           "ref": "genesis 28:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "and that Jacob hearkened to his father and his mother, and was gone to Paddan-aram;"
-          },
+          "en": "and that Jacob hearkened to his father and his mother, and was gone to Paddan-aram;",
           "ref": "genesis 28:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "and Esau saw that the daughters of Canaan pleased not Isaac his father; ."
-          },
+          "en": "and Esau saw that the daughters of Canaan pleased not Isaac his father; .",
           "ref": "genesis 28:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "so Esau went unto Ishmael, and took unto the wives that he had Mahalath the daughter of Ishmael Abraham’s son, the sister of Nebaioth, to be his wife."
-          },
+          "en": "so Esau went unto Ishmael, and took unto the wives that he had Mahalath the daughter of Ishmael Abraham’s son, the sister of Nebaioth, to be his wife.",
           "ref": "genesis 28:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": "Y se marchó Yaakov de Beer Shava en dirección a Jarán.",
-            "jps1917": "And Jacob went out from Beer-sheba, and went toward Haran."
-          },
+          "en": "And Jacob went out from Beer-sheba, and went toward Haran.",
           "ref": "genesis 28:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And he lighted upon the place, and tarried there all night, because the sun was set; and he took one of the stones of the place, and put it under his head, and lay down in that place to sleep."
-          },
+          "en": "And he lighted upon the place, and tarried there all night, because the sun was set; and he took one of the stones of the place, and put it under his head, and lay down in that place to sleep.",
           "ref": "genesis 28:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And he dreamed, and behold a ladder set up on the earth, and the top of it reached to heaven; and behold the angels of God ascending and descending on it."
-          },
+          "en": "And he dreamed, and behold a ladder set up on the earth, and the top of it reached to heaven; and behold the angels of God ascending and descending on it.",
           "ref": "genesis 28:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And, behold, the LORD stood beside him, and said: ‘I am the LORD, the God of Abraham thy father, and the God of Isaac. The land whereon thou liest, to thee will I give it, and to thy seed."
-          },
+          "en": "And, behold, the LORD stood beside him, and said: ‘I am the LORD, the God of Abraham thy father, and the God of Isaac. The land whereon thou liest, to thee will I give it, and to thy seed.",
           "ref": "genesis 28:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And thy seed shall be as the dust of the earth, and thou shalt spread abroad to the west, and to the east, and to the north, and to the south. And in thee and in thy seed shall all the families of the earth be blessed."
-          },
+          "en": "And thy seed shall be as the dust of the earth, and thou shalt spread abroad to the west, and to the east, and to the north, and to the south. And in thee and in thy seed shall all the families of the earth be blessed.",
           "ref": "genesis 28:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And, behold, I am with thee, and will keep thee whithersoever thou goest, and will bring thee back into this land; for I will not leave thee, until I have done that which I have spoken to thee of.’"
-          },
+          "en": "And, behold, I am with thee, and will keep thee whithersoever thou goest, and will bring thee back into this land; for I will not leave thee, until I have done that which I have spoken to thee of.’",
           "ref": "genesis 28:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob awaked out of his sleep, and he said: ‘Surely the LORD is in this place; and I knew it not.’"
-          },
+          "en": "And Jacob awaked out of his sleep, and he said: ‘Surely the LORD is in this place; and I knew it not.’",
           "ref": "genesis 28:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And he was afraid, and said: ‘How full of awe is this place! this is none other than the house of God, and this is the gate of heaven.’"
-          },
+          "en": "And he was afraid, and said: ‘How full of awe is this place! this is none other than the house of God, and this is the gate of heaven.’",
           "ref": "genesis 28:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob rose up early in the morning, and took the stone that he had put under his head, and set it up for a pillar, and poured oil upon the top of it."
-          },
+          "en": "And Jacob rose up early in the morning, and took the stone that he had put under his head, and set it up for a pillar, and poured oil upon the top of it.",
           "ref": "genesis 28:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And he called the name of that place Beth-el, but the name of the city was Luz at the first."
-          },
+          "en": "And he called the name of that place Beth-el, but the name of the city was Luz at the first.",
           "ref": "genesis 28:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob vowed a vow, saying: ‘If God will be with me, and will keep me in this way that I go, and will give me bread to eat, and raiment to put on,"
-          },
+          "en": "And Jacob vowed a vow, saying: ‘If God will be with me, and will keep me in this way that I go, and will give me bread to eat, and raiment to put on,",
           "ref": "genesis 28:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "so that I come back to my father’s house in peace, then shall the LORD be my God,"
-          },
+          "en": "so that I come back to my father’s house in peace, then shall the LORD be my God,",
           "ref": "genesis 28:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "and this stone, which I have set up for a pillar, shall be God’s house; and of all that Thou shalt give me I will surely give the tenth unto Thee.’"
-          },
+          "en": "and this stone, which I have set up for a pillar, shall be God’s house; and of all that Thou shalt give me I will surely give the tenth unto Thee.’",
           "ref": "genesis 28:22"
         }
       ]
@@ -6515,282 +4127,177 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Jacob went on his journey, and came to the land of the children of the east."
-          },
+          "en": "Then Jacob went on his journey, and came to the land of the children of the east.",
           "ref": "genesis 29:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And he looked, and behold a well in the field, and, lo, three flocks of sheep lying there by it.—For out of that well they watered the flocks. And the stone upon the well’s mouth was great."
-          },
+          "en": "And he looked, and behold a well in the field, and, lo, three flocks of sheep lying there by it.—For out of that well they watered the flocks. And the stone upon the well’s mouth was great.",
           "ref": "genesis 29:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And thither were all the flocks gathered; and they rolled the stone from the well’s mouth, and watered the sheep, and put the stone back upon the well’s mouth in its place.—"
-          },
+          "en": "And thither were all the flocks gathered; and they rolled the stone from the well’s mouth, and watered the sheep, and put the stone back upon the well’s mouth in its place.—",
           "ref": "genesis 29:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob said unto them: ‘My brethren, whence are ye?’ And they said: ‘Of Haran are we.’"
-          },
+          "en": "And Jacob said unto them: ‘My brethren, whence are ye?’ And they said: ‘Of Haran are we.’",
           "ref": "genesis 29:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto them: ‘Know ye Laban the son of Nahor?’ And they said: ‘We know him.’"
-          },
+          "en": "And he said unto them: ‘Know ye Laban the son of Nahor?’ And they said: ‘We know him.’",
           "ref": "genesis 29:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto them: ‘Is it well with him?’ And they said: ‘It is well; and, behold, Rachel his daughter cometh with the sheep.’"
-          },
+          "en": "And he said unto them: ‘Is it well with him?’ And they said: ‘It is well; and, behold, Rachel his daughter cometh with the sheep.’",
           "ref": "genesis 29:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Lo, it is yet high day, neither is it time that the cattle should be gathered together; water ye the sheep, and go and feed them.’"
-          },
+          "en": "And he said: ‘Lo, it is yet high day, neither is it time that the cattle should be gathered together; water ye the sheep, and go and feed them.’",
           "ref": "genesis 29:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said: ‘We cannot, until all the flocks be gathered together, and they roll the stone from the well’s mouth; then we water the sheep.’"
-          },
+          "en": "And they said: ‘We cannot, until all the flocks be gathered together, and they roll the stone from the well’s mouth; then we water the sheep.’",
           "ref": "genesis 29:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "While he was yet speaking with them, Rachel came with her father’s sheep; for she tended them."
-          },
+          "en": "While he was yet speaking with them, Rachel came with her father’s sheep; for she tended them.",
           "ref": "genesis 29:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when Jacob saw Rachel the daughter of Laban his mother’s brother, and the sheep of Laban his mother’s brother, that Jacob went near, and rolled the stone from the well’s mouth, and watered the flock of Laban his mother’s brother."
-          },
+          "en": "And it came to pass, when Jacob saw Rachel the daughter of Laban his mother’s brother, and the sheep of Laban his mother’s brother, that Jacob went near, and rolled the stone from the well’s mouth, and watered the flock of Laban his mother’s brother.",
           "ref": "genesis 29:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob kissed Rachel, and lifted up his voice, and wept."
-          },
+          "en": "And Jacob kissed Rachel, and lifted up his voice, and wept.",
           "ref": "genesis 29:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob told Rachel that he was her father’s brother, and that he was Rebekah’s son; and she ran and told her father."
-          },
+          "en": "And Jacob told Rachel that he was her father’s brother, and that he was Rebekah’s son; and she ran and told her father.",
           "ref": "genesis 29:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when Laban heard the tidings of Jacob his sister’s son, that he ran to meet him, and embraced him, and kissed him, and brought him to his house. And he told Laban all these things."
-          },
+          "en": "And it came to pass, when Laban heard the tidings of Jacob his sister’s son, that he ran to meet him, and embraced him, and kissed him, and brought him to his house. And he told Laban all these things.",
           "ref": "genesis 29:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And Laban said to him: ‘Surely thou art my bone and my flesh.’ And he abode with him the space of a month."
-          },
+          "en": "And Laban said to him: ‘Surely thou art my bone and my flesh.’ And he abode with him the space of a month.",
           "ref": "genesis 29:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And Laban said unto Jacob: ‘Because thou art my brother, shouldest thou therefore serve me for nought? tell me, what shall thy wages be?’"
-          },
+          "en": "And Laban said unto Jacob: ‘Because thou art my brother, shouldest thou therefore serve me for nought? tell me, what shall thy wages be?’",
           "ref": "genesis 29:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "Now Laban had two daughters: the name of the elder was Leah, and the name of the younger was Rachel."
-          },
+          "en": "Now Laban had two daughters: the name of the elder was Leah, and the name of the younger was Rachel.",
           "ref": "genesis 29:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And Leah’s eyes were weak; but Rachel was of beautiful form and fair to look upon."
-          },
+          "en": "And Leah’s eyes were weak; but Rachel was of beautiful form and fair to look upon.",
           "ref": "genesis 29:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob loved Rachel; and he said: ‘I will serve thee seven years for Rachel thy younger daughter.’"
-          },
+          "en": "And Jacob loved Rachel; and he said: ‘I will serve thee seven years for Rachel thy younger daughter.’",
           "ref": "genesis 29:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And Laban said: ‘It is better that I give her to thee, than that I should give her to another man; abide with me.’"
-          },
+          "en": "And Laban said: ‘It is better that I give her to thee, than that I should give her to another man; abide with me.’",
           "ref": "genesis 29:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob served seven years for Rachel; and they seemed unto him but a few days, for the love he had to her."
-          },
+          "en": "And Jacob served seven years for Rachel; and they seemed unto him but a few days, for the love he had to her.",
           "ref": "genesis 29:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob said unto Laban: ‘Give me my wife, for my days are filled, that I may go in unto her.’"
-          },
+          "en": "And Jacob said unto Laban: ‘Give me my wife, for my days are filled, that I may go in unto her.’",
           "ref": "genesis 29:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And Laban gathered together all the men of the place, and made a feast."
-          },
+          "en": "And Laban gathered together all the men of the place, and made a feast.",
           "ref": "genesis 29:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass in the evening, that he took Leah his daughter, and brought her to him; and he went in unto her."
-          },
+          "en": "And it came to pass in the evening, that he took Leah his daughter, and brought her to him; and he went in unto her.",
           "ref": "genesis 29:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And Laban gave Zilpah his handmaid unto his daughter Leah for a handmaid."
-          },
+          "en": "And Laban gave Zilpah his handmaid unto his daughter Leah for a handmaid.",
           "ref": "genesis 29:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass in the morning that, behold, it was Leah; and he said to Laban: ‘What is this thou hast done unto me? did not I serve with thee for Rachel? wherefore then hast thou beguiled me?’"
-          },
+          "en": "And it came to pass in the morning that, behold, it was Leah; and he said to Laban: ‘What is this thou hast done unto me? did not I serve with thee for Rachel? wherefore then hast thou beguiled me?’",
           "ref": "genesis 29:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And Laban said: ‘It is not so done in our place, to give the younger before the first-born."
-          },
+          "en": "And Laban said: ‘It is not so done in our place, to give the younger before the first-born.",
           "ref": "genesis 29:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "Fulfil the week of this one, and we will give thee the other also for the service which thou shalt serve with me yet seven other years.’"
-          },
+          "en": "Fulfil the week of this one, and we will give thee the other also for the service which thou shalt serve with me yet seven other years.’",
           "ref": "genesis 29:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob did so, and fulfilled her week; and he gave him Rachel his daughter to wife."
-          },
+          "en": "And Jacob did so, and fulfilled her week; and he gave him Rachel his daughter to wife.",
           "ref": "genesis 29:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And Laban gave to Rachel his daughter Bilhah his handmaid to be her handmaid."
-          },
+          "en": "And Laban gave to Rachel his daughter Bilhah his handmaid to be her handmaid.",
           "ref": "genesis 29:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And he went in also unto Rachel, and he loved Rachel more than Leah, and served with him yet seven other years."
-          },
+          "en": "And he went in also unto Rachel, and he loved Rachel more than Leah, and served with him yet seven other years.",
           "ref": "genesis 29:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD saw that Leah was hated, and he opened her womb; but Rachel was barren."
-          },
+          "en": "And the LORD saw that Leah was hated, and he opened her womb; but Rachel was barren.",
           "ref": "genesis 29:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And Leah conceived, and bore a son, and she called his name Reuben; for she said: ‘Because the LORD hath looked upon my affliction; for now my husband will love me.’"
-          },
+          "en": "And Leah conceived, and bore a son, and she called his name Reuben; for she said: ‘Because the LORD hath looked upon my affliction; for now my husband will love me.’",
           "ref": "genesis 29:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And she conceived again, and bore a son; and said: ‘Because the LORD hath heard that I am hated, He hath therefore given me this son also.’ And she called his name Simeon."
-          },
+          "en": "And she conceived again, and bore a son; and said: ‘Because the LORD hath heard that I am hated, He hath therefore given me this son also.’ And she called his name Simeon.",
           "ref": "genesis 29:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And she conceived again, and bore a son; and said: ‘Now this time will my husband be joined unto me, because I have borne him three sons.’ Therefore was his name called Levi."
-          },
+          "en": "And she conceived again, and bore a son; and said: ‘Now this time will my husband be joined unto me, because I have borne him three sons.’ Therefore was his name called Levi.",
           "ref": "genesis 29:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And she conceived again, and bore a son; and she said: ‘This time will I praise the LORD.’ Therefore she called his name Judah; and she left off bearing."
-          },
+          "en": "And she conceived again, and bore a son; and she said: ‘This time will I praise the LORD.’ Therefore she called his name Judah; and she left off bearing.",
           "ref": "genesis 29:35"
         }
       ]
@@ -6800,346 +4307,217 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Rachel saw that she bore Jacob no children, Rachel envied her sister; and she said unto Jacob: ‘Give me children, or else I die.’"
-          },
+          "en": "And when Rachel saw that she bore Jacob no children, Rachel envied her sister; and she said unto Jacob: ‘Give me children, or else I die.’",
           "ref": "genesis 30:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob’s anger was kindled against Rachel; and he said: ‘Am I in God’s stead, who hath withheld from thee the fruit of the womb?’"
-          },
+          "en": "And Jacob’s anger was kindled against Rachel; and he said: ‘Am I in God’s stead, who hath withheld from thee the fruit of the womb?’",
           "ref": "genesis 30:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And she said: ‘Behold my maid Bilhah, go in unto her; that she may bear upon my knees, and I also may be builded up through her.’"
-          },
+          "en": "And she said: ‘Behold my maid Bilhah, go in unto her; that she may bear upon my knees, and I also may be builded up through her.’",
           "ref": "genesis 30:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And she gave him Bilhah her handmaid to wife; and Jacob went in unto her."
-          },
+          "en": "And she gave him Bilhah her handmaid to wife; and Jacob went in unto her.",
           "ref": "genesis 30:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And Bilhah conceived, and bore Jacob a son."
-          },
+          "en": "And Bilhah conceived, and bore Jacob a son.",
           "ref": "genesis 30:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Rachel said: ‘God hath judged me, and hath also heard my voice, and hath given me a son.’ Therefore called she his name Dan."
-          },
+          "en": "And Rachel said: ‘God hath judged me, and hath also heard my voice, and hath given me a son.’ Therefore called she his name Dan.",
           "ref": "genesis 30:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Bilhah Rachel’s handmaid conceived again, and bore Jacob a second son."
-          },
+          "en": "And Bilhah Rachel’s handmaid conceived again, and bore Jacob a second son.",
           "ref": "genesis 30:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Rachel said: ‘With mighty wrestlings have I wrestled with my sister, and have prevailed.’ And she called his name Naphtali."
-          },
+          "en": "And Rachel said: ‘With mighty wrestlings have I wrestled with my sister, and have prevailed.’ And she called his name Naphtali.",
           "ref": "genesis 30:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "When Leah saw that she had left off bearing, she took Zilpah her handmaid, and gave her to Jacob to wife."
-          },
+          "en": "When Leah saw that she had left off bearing, she took Zilpah her handmaid, and gave her to Jacob to wife.",
           "ref": "genesis 30:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And Zilpah Leah’s handmaid bore Jacob a son."
-          },
+          "en": "And Zilpah Leah’s handmaid bore Jacob a son.",
           "ref": "genesis 30:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And Leah said: ‘Fortune is come! ’ And she called his name Gad."
-          },
+          "en": "And Leah said: ‘Fortune is come! ’ And she called his name Gad.",
           "ref": "genesis 30:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And Zilpah Leah’s handmaid bore Jacob a second son."
-          },
+          "en": "And Zilpah Leah’s handmaid bore Jacob a second son.",
           "ref": "genesis 30:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And Leah said: ‘Happy am I! for the daughters will call me happy.’ And she called his name Asher."
-          },
+          "en": "And Leah said: ‘Happy am I! for the daughters will call me happy.’ And she called his name Asher.",
           "ref": "genesis 30:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And Reuben went in the days of wheat harvest, and found mandrakes in the field, and brought them unto his mother Leah. Then Rachel said to Leah: ‘Give me, I pray thee, of thy son’s mandrakes.’"
-          },
+          "en": "And Reuben went in the days of wheat harvest, and found mandrakes in the field, and brought them unto his mother Leah. Then Rachel said to Leah: ‘Give me, I pray thee, of thy son’s mandrakes.’",
           "ref": "genesis 30:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And she said unto her: ‘Is it a small matter that thou hast taken away my husband? and wouldest thou take away my son’s mandrakes also?’ And Rachel said: ‘Therefore he shall lie with thee to-night for thy son’s mandrakes.’"
-          },
+          "en": "And she said unto her: ‘Is it a small matter that thou hast taken away my husband? and wouldest thou take away my son’s mandrakes also?’ And Rachel said: ‘Therefore he shall lie with thee to-night for thy son’s mandrakes.’",
           "ref": "genesis 30:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob came from the field in the evening, and Leah went out to meet him, and said: ‘Thou must come in unto me; for I have surely hired thee with my son’s mandrakes.’ And he lay with her that night."
-          },
+          "en": "And Jacob came from the field in the evening, and Leah went out to meet him, and said: ‘Thou must come in unto me; for I have surely hired thee with my son’s mandrakes.’ And he lay with her that night.",
           "ref": "genesis 30:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And God hearkened unto Leah, and she conceived, and bore Jacob a fifth son."
-          },
+          "en": "And God hearkened unto Leah, and she conceived, and bore Jacob a fifth son.",
           "ref": "genesis 30:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Leah said: ‘God hath given me my hire, because I gave my handmaid to my husband. And she called his name Issachar."
-          },
+          "en": "And Leah said: ‘God hath given me my hire, because I gave my handmaid to my husband. And she called his name Issachar.",
           "ref": "genesis 30:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And Leah conceived again, and bore a sixth son to Jacob."
-          },
+          "en": "And Leah conceived again, and bore a sixth son to Jacob.",
           "ref": "genesis 30:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Leah said: ‘God hath endowed me with a good dowry; now will my husband dwell with me, because I have borne him six sons.’ And she called his name Zebulun."
-          },
+          "en": "And Leah said: ‘God hath endowed me with a good dowry; now will my husband dwell with me, because I have borne him six sons.’ And she called his name Zebulun.",
           "ref": "genesis 30:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And afterwards she bore a daughter, and called her name Dinah."
-          },
+          "en": "And afterwards she bore a daughter, and called her name Dinah.",
           "ref": "genesis 30:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And God remembered Rachel, and God hearkened to her, and opened her womb."
-          },
+          "en": "And God remembered Rachel, and God hearkened to her, and opened her womb.",
           "ref": "genesis 30:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And she conceived, and bore a son, and said: ‘God hath taken away my reproach.’"
-          },
+          "en": "And she conceived, and bore a son, and said: ‘God hath taken away my reproach.’",
           "ref": "genesis 30:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And she called his name Joseph, saying: ‘The LORD add to me another son.’"
-          },
+          "en": "And she called his name Joseph, saying: ‘The LORD add to me another son.’",
           "ref": "genesis 30:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when Rachel had borne Joseph, that Jacob said unto Laban: ‘Send me away, that I may go unto mine own place, and to my country."
-          },
+          "en": "And it came to pass, when Rachel had borne Joseph, that Jacob said unto Laban: ‘Send me away, that I may go unto mine own place, and to my country.",
           "ref": "genesis 30:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "Give me my wives and my children for whom I have served thee, and let me go; for thou knowest my service wherewith I have served thee.’"
-          },
+          "en": "Give me my wives and my children for whom I have served thee, and let me go; for thou knowest my service wherewith I have served thee.’",
           "ref": "genesis 30:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And Laban said unto him: ‘If now I have found favour in thine eyes—I have observed the signs, and the LORD hath blessed me for thy sake.’"
-          },
+          "en": "And Laban said unto him: ‘If now I have found favour in thine eyes—I have observed the signs, and the LORD hath blessed me for thy sake.’",
           "ref": "genesis 30:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Appoint me thy wages, and I will give it.’"
-          },
+          "en": "And he said: ‘Appoint me thy wages, and I will give it.’",
           "ref": "genesis 30:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto him: ‘Thou knowest how I have served thee, and how thy cattle have fared with me."
-          },
+          "en": "And he said unto him: ‘Thou knowest how I have served thee, and how thy cattle have fared with me.",
           "ref": "genesis 30:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "For it was little which thou hadst before I came, and it hath increased abundantly; and the LORD hath blessed thee whithersoever I turned. And now when shall I provide for mine own house also?’"
-          },
+          "en": "For it was little which thou hadst before I came, and it hath increased abundantly; and the LORD hath blessed thee whithersoever I turned. And now when shall I provide for mine own house also?’",
           "ref": "genesis 30:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘What shall I give thee?’ And Jacob said: ‘Thou shalt not give me aught; if thou wilt do this thing for me, I will again feed thy flock and keep it."
-          },
+          "en": "And he said: ‘What shall I give thee?’ And Jacob said: ‘Thou shalt not give me aught; if thou wilt do this thing for me, I will again feed thy flock and keep it.",
           "ref": "genesis 30:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "I will pass through all thy flock to-day, removing from thence every speckled and spotted one, and every dark one among the sheep, and the spotted and speckled among the goats; and of such shall be my hire."
-          },
+          "en": "I will pass through all thy flock to-day, removing from thence every speckled and spotted one, and every dark one among the sheep, and the spotted and speckled among the goats; and of such shall be my hire.",
           "ref": "genesis 30:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "So shall my righteousness witness against me hereafter, when thou shalt come to look over my hire that is before thee: every one that is not speckled and spotted among the goats, and dark among the sheep, that if found with me shall be counted stolen.’"
-          },
+          "en": "So shall my righteousness witness against me hereafter, when thou shalt come to look over my hire that is before thee: every one that is not speckled and spotted among the goats, and dark among the sheep, that if found with me shall be counted stolen.’",
           "ref": "genesis 30:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And Laban said: ‘Behold, would it might be according to thy word.’"
-          },
+          "en": "And Laban said: ‘Behold, would it might be according to thy word.’",
           "ref": "genesis 30:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And he removed that day the he-goats that were streaked and spotted, and all the she-goats that were speckled and spotted, every one that had white in it, and all the dark ones among the sheep, and gave them into the hand of his sons."
-          },
+          "en": "And he removed that day the he-goats that were streaked and spotted, and all the she-goats that were speckled and spotted, every one that had white in it, and all the dark ones among the sheep, and gave them into the hand of his sons.",
           "ref": "genesis 30:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "And he set three days’journey betwixt himself and Jacob. And Jacob fed the rest of Laban’s flocks."
-          },
+          "en": "And he set three days’journey betwixt himself and Jacob. And Jacob fed the rest of Laban’s flocks.",
           "ref": "genesis 30:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob took him rods of fresh poplar, and of the almond and of the plane-tree; and peeled white streaks in them, making the white appear which was in the rods."
-          },
+          "en": "And Jacob took him rods of fresh poplar, and of the almond and of the plane-tree; and peeled white streaks in them, making the white appear which was in the rods.",
           "ref": "genesis 30:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": null,
-            "jps1917": "And he set the rods which he had peeled over against the flocks in the gutters in the watering-troughs where the flocks came to drink; and they conceived when they came to drink."
-          },
+          "en": "And he set the rods which he had peeled over against the flocks in the gutters in the watering-troughs where the flocks came to drink; and they conceived when they came to drink.",
           "ref": "genesis 30:38"
         },
         {
           "n": 39,
-          "en": {
-            "sct": null,
-            "jps1917": "And the flocks conceived at the sight of the rods, and the flocks brought forth streaked, speckled, and spotted."
-          },
+          "en": "And the flocks conceived at the sight of the rods, and the flocks brought forth streaked, speckled, and spotted.",
           "ref": "genesis 30:39"
         },
         {
           "n": 40,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob separated the lambs—he also set the faces of the flocks toward the streaked and all the dark in the flock of Laban— and put his own droves apart, and put them not unto Laban’s flock."
-          },
+          "en": "And Jacob separated the lambs—he also set the faces of the flocks toward the streaked and all the dark in the flock of Laban— and put his own droves apart, and put them not unto Laban’s flock.",
           "ref": "genesis 30:40"
         },
         {
           "n": 41,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, whensoever the stronger of the flock did conceive, that Jacob laid the rods before the eyes of the flock in the gutters, that they might conceive among the rods;"
-          },
+          "en": "And it came to pass, whensoever the stronger of the flock did conceive, that Jacob laid the rods before the eyes of the flock in the gutters, that they might conceive among the rods;",
           "ref": "genesis 30:41"
         },
         {
           "n": 42,
-          "en": {
-            "sct": null,
-            "jps1917": "but when the flock were feeble, he put them not in; so the feebler were Laban’s, and the stronger Jacob’s."
-          },
+          "en": "but when the flock were feeble, he put them not in; so the feebler were Laban’s, and the stronger Jacob’s.",
           "ref": "genesis 30:42"
         },
         {
           "n": 43,
-          "en": {
-            "sct": null,
-            "jps1917": "And the man increased exceedingly, and had large flocks, and maid-servants and men-servants, and camels and asses."
-          },
+          "en": "And the man increased exceedingly, and had large flocks, and maid-servants and men-servants, and camels and asses.",
           "ref": "genesis 30:43"
         }
       ]
@@ -7149,434 +4527,272 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": "And he heard the words of Laban’s sons, saying: ‘Jacob hath taken away all that was our father’s; and of that which was our father’s hath he gotten all this wealth.’",
-            "jps1917": "And he heard the words of Laban’s sons, saying: ‘Jacob hath taken away all that was our father’s; and of that which was our father’s hath he gotten all this wealth.’"
-          },
+          "en": "And he heard the words of Laban’s sons, saying: ‘Jacob hath taken away all that was our father’s; and of that which was our father’s hath he gotten all this wealth.’",
           "ref": "genesis 31:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": "And Jacob beheld the countenance of Laban, and, behold, it was not toward him as beforetime.",
-            "jps1917": "And Jacob beheld the countenance of Laban, and, behold, it was not toward him as beforetime."
-          },
+          "en": "And Jacob beheld the countenance of Laban, and, behold, it was not toward him as beforetime.",
           "ref": "genesis 31:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": "And the LORD said unto Jacob: ‘Return unto the land of thy fathers, and to thy kindred; and I will be with thee.’",
-            "jps1917": "And the LORD said unto Jacob: ‘Return unto the land of thy fathers, and to thy kindred; and I will be with thee.’"
-          },
+          "en": "And the LORD said unto Jacob: ‘Return unto the land of thy fathers, and to thy kindred; and I will be with thee.’",
           "ref": "genesis 31:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": "And Jacob sent and called Rachel and Leah to the field unto his flock,",
-            "jps1917": "And Jacob sent and called Rachel and Leah to the field unto his flock,"
-          },
+          "en": "And Jacob sent and called Rachel and Leah to the field unto his flock,",
           "ref": "genesis 31:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": "and said unto them: ‘I see your father’s countenance, that it is not toward me as beforetime; but the God of my father hath been with me.",
-            "jps1917": "and said unto them: ‘I see your father’s countenance, that it is not toward me as beforetime; but the God of my father hath been with me."
-          },
+          "en": "and said unto them: ‘I see your father’s countenance, that it is not toward me as beforetime; but the God of my father hath been with me.",
           "ref": "genesis 31:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": "And ye know that with all my power I have served your father.",
-            "jps1917": "And ye know that with all my power I have served your father."
-          },
+          "en": "And ye know that with all my power I have served your father.",
           "ref": "genesis 31:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": "And your father hath mocked me, and changed my wages ten times; but God suffered him not to hurt me.",
-            "jps1917": "And your father hath mocked me, and changed my wages ten times; but God suffered him not to hurt me."
-          },
+          "en": "And your father hath mocked me, and changed my wages ten times; but God suffered him not to hurt me.",
           "ref": "genesis 31:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": "If he said thus: The speckled shall be thy wages; then all the flock bore speckled; and if he said thus: The streaked shall be thy wages; then bore all the flock streaked.",
-            "jps1917": "If he said thus: The speckled shall be thy wages; then all the flock bore speckled; and if he said thus: The streaked shall be thy wages; then bore all the flock streaked."
-          },
+          "en": "If he said thus: The speckled shall be thy wages; then all the flock bore speckled; and if he said thus: The streaked shall be thy wages; then bore all the flock streaked.",
           "ref": "genesis 31:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": "Thus God hath taken away the cattle of your father, and given them to me.",
-            "jps1917": "Thus God hath taken away the cattle of your father, and given them to me."
-          },
+          "en": "Thus God hath taken away the cattle of your father, and given them to me.",
           "ref": "genesis 31:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": "And it came to pass at the time that the flock conceived, that I lifted up mine eyes, and saw in a dream, and, behold, the he-goats which leaped upon the flock were streaked, speckled, and grizzled.",
-            "jps1917": "And it came to pass at the time that the flock conceived, that I lifted up mine eyes, and saw in a dream, and, behold, the he-goats which leaped upon the flock were streaked, speckled, and grizzled."
-          },
+          "en": "And it came to pass at the time that the flock conceived, that I lifted up mine eyes, and saw in a dream, and, behold, the he-goats which leaped upon the flock were streaked, speckled, and grizzled.",
           "ref": "genesis 31:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": "And the angel of God said unto me in the dream: Jacob; and I said: Here am I.",
-            "jps1917": "And the angel of God said unto me in the dream: Jacob; and I said: Here am I."
-          },
+          "en": "And the angel of God said unto me in the dream: Jacob; and I said: Here am I.",
           "ref": "genesis 31:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": "And he said: Lift up now thine eyes, and see, all the he-goats which leap upon the flock are streaked, speckled, and grizzled; for I have seen all that Laban doeth unto thee.",
-            "jps1917": "And he said: Lift up now thine eyes, and see, all the he-goats which leap upon the flock are streaked, speckled, and grizzled; for I have seen all that Laban doeth unto thee."
-          },
+          "en": "And he said: Lift up now thine eyes, and see, all the he-goats which leap upon the flock are streaked, speckled, and grizzled; for I have seen all that Laban doeth unto thee.",
           "ref": "genesis 31:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": "I am the God of Beth-el, where thou didst anoint a pillar, where thou didst vow a vow unto Me. Now arise, get thee out from this land, and return unto the land of thy nativity.’",
-            "jps1917": "I am the God of Beth-el, where thou didst anoint a pillar, where thou didst vow a vow unto Me. Now arise, get thee out from this land, and return unto the land of thy nativity.’"
-          },
+          "en": "I am the God of Beth-el, where thou didst anoint a pillar, where thou didst vow a vow unto Me. Now arise, get thee out from this land, and return unto the land of thy nativity.’",
           "ref": "genesis 31:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": "And Rachel and Leah answered and said unto him: ‘Is there yet any portion or inheritance for us in our father’s house?",
-            "jps1917": "And Rachel and Leah answered and said unto him: ‘Is there yet any portion or inheritance for us in our father’s house?"
-          },
+          "en": "And Rachel and Leah answered and said unto him: ‘Is there yet any portion or inheritance for us in our father’s house?",
           "ref": "genesis 31:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": "Are we not accounted by him strangers? for he hath sold us, and hath also quite devoured our price.",
-            "jps1917": "Are we not accounted by him strangers? for he hath sold us, and hath also quite devoured our price."
-          },
+          "en": "Are we not accounted by him strangers? for he hath sold us, and hath also quite devoured our price.",
           "ref": "genesis 31:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": "For all the riches which God hath taken away from our father, that is ours and our children’s. Now then, whatsoever God hath said unto thee, do.’",
-            "jps1917": "For all the riches which God hath taken away from our father, that is ours and our children’s. Now then, whatsoever God hath said unto thee, do.’"
-          },
+          "en": "For all the riches which God hath taken away from our father, that is ours and our children’s. Now then, whatsoever God hath said unto thee, do.’",
           "ref": "genesis 31:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": "Then Jacob rose up, and set his sons and his wives upon the camels;",
-            "jps1917": "Then Jacob rose up, and set his sons and his wives upon the camels;"
-          },
+          "en": "Then Jacob rose up, and set his sons and his wives upon the camels;",
           "ref": "genesis 31:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": "and he carried away all his cattle, and all his substance which he had gathered, the cattle of his getting, which he had gathered in Paddan-aram, to go to Isaac his father unto the land of Canaan.",
-            "jps1917": "and he carried away all his cattle, and all his substance which he had gathered, the cattle of his getting, which he had gathered in Paddan-aram, to go to Isaac his father unto the land of Canaan."
-          },
+          "en": "and he carried away all his cattle, and all his substance which he had gathered, the cattle of his getting, which he had gathered in Paddan-aram, to go to Isaac his father unto the land of Canaan.",
           "ref": "genesis 31:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": "Now Laban was gone to shear his sheep. And Rachel stole the teraphim that were her father’s.",
-            "jps1917": "Now Laban was gone to shear his sheep. And Rachel stole the teraphim that were her father’s."
-          },
+          "en": "Now Laban was gone to shear his sheep. And Rachel stole the teraphim that were her father’s.",
           "ref": "genesis 31:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": "And Jacob outwitted Laban the Aramean, in that he told him not that he fled.",
-            "jps1917": "And Jacob outwitted Laban the Aramean, in that he told him not that he fled."
-          },
+          "en": "And Jacob outwitted Laban the Aramean, in that he told him not that he fled.",
           "ref": "genesis 31:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": "So he fled with all that he had; and he rose up, and passed over athe River, and set his face toward the mountain of Gilead.",
-            "jps1917": "So he fled with all that he had; and he rose up, and passed over the River, and set his face toward the mountain of Gilead."
-          },
+          "en": "So he fled with all that he had; and he rose up, and passed over the River, and set his face toward the mountain of Gilead.",
           "ref": "genesis 31:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": "And it was told Laban on the third day that Jacob was fled.",
-            "jps1917": "And it was told Laban on the third day that Jacob was fled."
-          },
+          "en": "And it was told Laban on the third day that Jacob was fled.",
           "ref": "genesis 31:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": "And he took his brethren with him, and pursued after him seven days’journey; and he overtook him in the mountain of Gilead.",
-            "jps1917": "And he took his brethren with him, and pursued after him seven days’journey; and he overtook him in the mountain of Gilead."
-          },
+          "en": "And he took his brethren with him, and pursued after him seven days’journey; and he overtook him in the mountain of Gilead.",
           "ref": "genesis 31:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": "And God came to Laban the Aramean in a dream of the night, and said unto him: ‘Take heed to thyself that thou speak not to Jacob either good or bad.’",
-            "jps1917": "And God came to Laban the Aramean in a dream of the night, and said unto him: ‘Take heed to thyself that thou speak not to Jacob either good or bad.’"
-          },
+          "en": "And God came to Laban the Aramean in a dream of the night, and said unto him: ‘Take heed to thyself that thou speak not to Jacob either good or bad.’",
           "ref": "genesis 31:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": "And Laban came up with Jacob. Now Jacob had pitched his tent in the mountain; and Laban with his brethren pitched in the mountain of Gilead.",
-            "jps1917": "And Laban came up with Jacob. Now Jacob had pitched his tent in the mountain; and Laban with his brethren pitched in the mountain of Gilead."
-          },
+          "en": "And Laban came up with Jacob. Now Jacob had pitched his tent in the mountain; and Laban with his brethren pitched in the mountain of Gilead.",
           "ref": "genesis 31:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": "And Laban said to Jacob: ‘What hast thou done, that thou hast outwitted me, and carried away my daughters as though captives of the sword?",
-            "jps1917": "And Laban said to Jacob: ‘What hast thou done, that thou hast outwitted me, and carried away my daughters as though captives of the sword?"
-          },
+          "en": "And Laban said to Jacob: ‘What hast thou done, that thou hast outwitted me, and carried away my daughters as though captives of the sword?",
           "ref": "genesis 31:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": "Wherefore didst thou flee secretly, and outwit me; and didst not tell me, that I might have sent thee away with mirth and with songs, with tabret and with harp;",
-            "jps1917": "Wherefore didst thou flee secretly, and outwit me; and didst not tell me, that I might have sent thee away with mirth and with songs, with tabret and with harp;"
-          },
+          "en": "Wherefore didst thou flee secretly, and outwit me; and didst not tell me, that I might have sent thee away with mirth and with songs, with tabret and with harp;",
           "ref": "genesis 31:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": "and didst not suffer me to kiss my sons and my daughters? now hast thou done foolishly.",
-            "jps1917": "and didst not suffer me to kiss my sons and my daughters? now hast thou done foolishly."
-          },
+          "en": "and didst not suffer me to kiss my sons and my daughters? now hast thou done foolishly.",
           "ref": "genesis 31:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": "It is in the power of my hand to do you hurt; but the God of your father spoke unto me yesternight, saying: Take heed to thyself that thou speak not to Jacob either good or bad.",
-            "jps1917": "It is in the power of my hand to do you hurt; but the God of your father spoke unto me yesternight, saying: Take heed to thyself that thou speak not to Jacob either good or bad."
-          },
+          "en": "It is in the power of my hand to do you hurt; but the God of your father spoke unto me yesternight, saying: Take heed to thyself that thou speak not to Jacob either good or bad.",
           "ref": "genesis 31:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": "And now that thou art surely gone, because thou sore longest after thy father’s house, wherefore hast thou stolen my gods?’",
-            "jps1917": "And now that thou art surely gone, because thou sore longest after thy father’s house, wherefore hast thou stolen my gods?’"
-          },
+          "en": "And now that thou art surely gone, because thou sore longest after thy father’s house, wherefore hast thou stolen my gods?’",
           "ref": "genesis 31:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": "And Jacob answered and said to Laban: ‘Because I was afraid; for I said: Lest thou shouldest take thy daughters from me by force.",
-            "jps1917": "And Jacob answered and said to Laban: ‘Because I was afraid; for I said: Lest thou shouldest take thy daughters from me by force."
-          },
+          "en": "And Jacob answered and said to Laban: ‘Because I was afraid; for I said: Lest thou shouldest take thy daughters from me by force.",
           "ref": "genesis 31:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": "With whomsoever thou findest thy gods, he shall not live; before our brethren discern thou what is thine with me, and take it to thee.’—For Jacob knew not that Rachel had stolen them.—",
-            "jps1917": "With whomsoever thou findest thy gods, he shall not live; before our brethren discern thou what is thine with me, and take it to thee.’—For Jacob knew not that Rachel had stolen them.—"
-          },
+          "en": "With whomsoever thou findest thy gods, he shall not live; before our brethren discern thou what is thine with me, and take it to thee.’—For Jacob knew not that Rachel had stolen them.—",
           "ref": "genesis 31:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": "And Laban went into Jacob’s tent, and into Leah’s tent, and into the tent of the two maid-servants; but he found them not. And he went out of Leah’s tent, and entered into Rachel’s tent.",
-            "jps1917": "And Laban went into Jacob’s tent, and into Leah’s tent, and into the tent of the two maid-servants; but he found them not. And he went out of Leah’s tent, and entered into Rachel’s tent."
-          },
+          "en": "And Laban went into Jacob’s tent, and into Leah’s tent, and into the tent of the two maid-servants; but he found them not. And he went out of Leah’s tent, and entered into Rachel’s tent.",
           "ref": "genesis 31:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": "Now Rachel had taken the teraphim, and put them in the saddle of the camel, and sat upon them. And Laban felt about all the tent, but found them not.",
-            "jps1917": "Now Rachel had taken the teraphim, and put them in the saddle of the camel, and sat upon them. And Laban felt about all the tent, but found them not."
-          },
+          "en": "Now Rachel had taken the teraphim, and put them in the saddle of the camel, and sat upon them. And Laban felt about all the tent, but found them not.",
           "ref": "genesis 31:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": "And she said to her father: ‘Let not my lord be angry that I cannot rise up before thee; for the manner of women is upon me.’ And he searched, but found not the teraphim.",
-            "jps1917": "And she said to her father: ‘Let not my lord be angry that I cannot rise up before thee; for the manner of women is upon me.’ And he searched, but found not the teraphim."
-          },
+          "en": "And she said to her father: ‘Let not my lord be angry that I cannot rise up before thee; for the manner of women is upon me.’ And he searched, but found not the teraphim.",
           "ref": "genesis 31:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": "And Jacob was wroth, and strove with Laban. And Jacob answered and said to Laban: ‘What is my trespass? what is my sin, that thou hast hotly pursued after me?",
-            "jps1917": "And Jacob was wroth, and strove with Laban. And Jacob answered and said to Laban: ‘What is my trespass? what is my sin, that thou hast hotly pursued after me?"
-          },
+          "en": "And Jacob was wroth, and strove with Laban. And Jacob answered and said to Laban: ‘What is my trespass? what is my sin, that thou hast hotly pursued after me?",
           "ref": "genesis 31:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": "Whereas thou hast felt about all my stuff, what hast thou found of all thy household stuff? Set it here before my brethren and thy brethren, that they may judge betwixt us two.",
-            "jps1917": "Whereas thou hast felt about all my stuff, what hast thou found of all thy household stuff? Set it here before my brethren and thy brethren, that they may judge betwixt us two."
-          },
+          "en": "Whereas thou hast felt about all my stuff, what hast thou found of all thy household stuff? Set it here before my brethren and thy brethren, that they may judge betwixt us two.",
           "ref": "genesis 31:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": "These twenty years have I been with thee; thy ewes and thy she-goats have not cast their young, and the rams of thy flocks have I not eaten.",
-            "jps1917": "These twenty years have I been with thee; thy ewes and thy she-goats have not cast their young, and the rams of thy flocks have I not eaten."
-          },
+          "en": "These twenty years have I been with thee; thy ewes and thy she-goats have not cast their young, and the rams of thy flocks have I not eaten.",
           "ref": "genesis 31:38"
         },
         {
           "n": 39,
-          "en": {
-            "sct": "That which was torn of beasts I brought not unto thee; I bore the loss of it; of my hand didst thou require it, whether stolen by day or stolen by night.",
-            "jps1917": "That which was torn of beasts I brought not unto thee; I bore the loss of it; of my hand didst thou require it, whether stolen by day or stolen by night."
-          },
+          "en": "That which was torn of beasts I brought not unto thee; I bore the loss of it; of my hand didst thou require it, whether stolen by day or stolen by night.",
           "ref": "genesis 31:39"
         },
         {
           "n": 40,
-          "en": {
-            "sct": "Thus I was: in the day the drought consumed me, and the frost by night; and my sleep fled from mine eyes.",
-            "jps1917": "Thus I was: in the day the drought consumed me, and the frost by night; and my sleep fled from mine eyes."
-          },
+          "en": "Thus I was: in the day the drought consumed me, and the frost by night; and my sleep fled from mine eyes.",
           "ref": "genesis 31:40"
         },
         {
           "n": 41,
-          "en": {
-            "sct": "These twenty years have I been in thy house: I served thee fourteen years for thy two daughters, and six years for thy flock; and thou hast changed my wages ten times.",
-            "jps1917": "These twenty years have I been in thy house: I served thee fourteen years for thy two daughters, and six years for thy flock; and thou hast changed my wages ten times."
-          },
+          "en": "These twenty years have I been in thy house: I served thee fourteen years for thy two daughters, and six years for thy flock; and thou hast changed my wages ten times.",
           "ref": "genesis 31:41"
         },
         {
           "n": 42,
-          "en": {
-            "sct": "Except the God of my father, the God of Abraham, and the Fear of Isaac, had been on my side, surely now hadst thou sent me away empty. God hath seen mine affliction and the labour of my hands, and gave judgment yesternight.’",
-            "jps1917": "Except the God of my father, the God of Abraham, and the Fear of Isaac, had been on my side, surely now hadst thou sent me away empty. God hath seen mine affliction and the labour of my hands, and gave judgment yesternight.’"
-          },
+          "en": "Except the God of my father, the God of Abraham, and the Fear of Isaac, had been on my side, surely now hadst thou sent me away empty. God hath seen mine affliction and the labour of my hands, and gave judgment yesternight.’",
           "ref": "genesis 31:42"
         },
         {
           "n": 43,
-          "en": {
-            "sct": "And Laban answered and said unto Jacob: ‘The daughters are my daughters, and the children are my children, and the flocks are my flocks, and all that thou seest is mine; and what can I do this day for these my daughters, or for their children whom they have borne?",
-            "jps1917": "And Laban answered and said unto Jacob: ‘The daughters are my daughters, and the children are my children, and the flocks are my flocks, and all that thou seest is mine; and what can I do this day for these my daughters, or for their children whom they have borne?"
-          },
+          "en": "And Laban answered and said unto Jacob: ‘The daughters are my daughters, and the children are my children, and the flocks are my flocks, and all that thou seest is mine; and what can I do this day for these my daughters, or for their children whom they have borne?",
           "ref": "genesis 31:43"
         },
         {
           "n": 44,
-          "en": {
-            "sct": "And now come, let us make a covenant, I and thou; and let it be for a witness between me and thee.’",
-            "jps1917": "And now come, let us make a covenant, I and thou; and let it be for a witness between me and thee.’"
-          },
+          "en": "And now come, let us make a covenant, I and thou; and let it be for a witness between me and thee.’",
           "ref": "genesis 31:44"
         },
         {
           "n": 45,
-          "en": {
-            "sct": "And Jacob took a stone, and set it up for a pillar.",
-            "jps1917": "And Jacob took a stone, and set it up for a pillar."
-          },
+          "en": "And Jacob took a stone, and set it up for a pillar.",
           "ref": "genesis 31:45"
         },
         {
           "n": 46,
-          "en": {
-            "sct": "And Jacob said unto his brethren: ‘Gather stones’; and they took stones, and made a heap. And they did eat there by the heap.",
-            "jps1917": "And Jacob said unto his brethren: ‘Gather stones’; and they took stones, and made a heap. And they did eat there by the heap."
-          },
+          "en": "And Jacob said unto his brethren: ‘Gather stones’; and they took stones, and made a heap. And they did eat there by the heap.",
           "ref": "genesis 31:46"
         },
         {
           "n": 47,
-          "en": {
-            "sct": "And Laban called it Jegar-sahadutha; but Jacob called it Galeed.",
-            "jps1917": "And Laban called it Jegar-sahadutha; but Jacob called it Galeed."
-          },
+          "en": "And Laban called it Jegar-sahadutha; but Jacob called it Galeed.",
           "ref": "genesis 31:47"
         },
         {
           "n": 48,
-          "en": {
-            "sct": "And Laban said: ‘This heap is witness between me and thee this day.’ Therefore was the name of it called Galeed;",
-            "jps1917": "And Laban said: ‘This heap is witness between me and thee this day.’ Therefore was the name of it called Galeed;"
-          },
+          "en": "And Laban said: ‘This heap is witness between me and thee this day.’ Therefore was the name of it called Galeed;",
           "ref": "genesis 31:48"
         },
         {
           "n": 49,
-          "en": {
-            "sct": "and Mizpah, for he said: ‘The LORD watch between me and thee, when we are absent one from another.",
-            "jps1917": "and Mizpah, for he said: ‘The LORD watch between me and thee, when we are absent one from another."
-          },
+          "en": "and Mizpah, for he said: ‘The LORD watch between me and thee, when we are absent one from another.",
           "ref": "genesis 31:49"
         },
         {
           "n": 50,
-          "en": {
-            "sct": "If thou shalt afflict my daughters, and if thou shalt take wives beside my daughters, no man being with us; see, God is witness betwixt me and thee.’",
-            "jps1917": "If thou shalt afflict my daughters, and if thou shalt take wives beside my daughters, no man being with us; see, God is witness betwixt me and thee.’"
-          },
+          "en": "If thou shalt afflict my daughters, and if thou shalt take wives beside my daughters, no man being with us; see, God is witness betwixt me and thee.’",
           "ref": "genesis 31:50"
         },
         {
           "n": 51,
-          "en": {
-            "sct": "And Laban said to Jacob: ‘Behold this heap, and behold the pillar, which I have set up betwixt me and thee.",
-            "jps1917": "And Laban said to Jacob: ‘Behold this heap, and behold the pillar, which I have set up betwixt me and thee."
-          },
+          "en": "And Laban said to Jacob: ‘Behold this heap, and behold the pillar, which I have set up betwixt me and thee.",
           "ref": "genesis 31:51"
         },
         {
           "n": 52,
-          "en": {
-            "sct": "This heap be witness, and the pillar be witness, that I will not pass over this heap to thee, and that thou shalt not pass over this heap and this pillar unto me, for harm.",
-            "jps1917": "This heap be witness, and the pillar be witness, that I will not pass over this heap to thee, and that thou shalt not pass over this heap and this pillar unto me, for harm."
-          },
+          "en": "This heap be witness, and the pillar be witness, that I will not pass over this heap to thee, and that thou shalt not pass over this heap and this pillar unto me, for harm.",
           "ref": "genesis 31:52"
         },
         {
           "n": 53,
-          "en": {
-            "sct": "The God of Abraham, and the God of Nahor, the God of their father, judge betwixt us.’ And Jacob swore by the Fear of his father Isaac.",
-            "jps1917": "The God of Abraham, and the God of Nahor, the God of their father, judge betwixt us.’ And Jacob swore by the Fear of his father Isaac."
-          },
+          "en": "The God of Abraham, and the God of Nahor, the God of their father, judge betwixt us.’ And Jacob swore by the Fear of his father Isaac.",
           "ref": "genesis 31:53"
         },
         {
           "n": 54,
-          "en": {
-            "sct": "And Jacob offered a sacrifice in the mountain, and called his brethren to eat bread; and they did eat bread, and tarried all night in the mountain.",
-            "jps1917": "And Jacob offered a sacrifice in the mountain, and called his brethren to eat bread; and they did eat bread, and tarried all night in the mountain."
-          },
+          "en": "And Jacob offered a sacrifice in the mountain, and called his brethren to eat bread; and they did eat bread, and tarried all night in the mountain.",
           "ref": "genesis 31:54"
         }
       ]
@@ -7586,266 +4802,167 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And Laban arose early in the morning, kissed his sons and daughters, and blessed them; and then Laban went and returned to his place."
-          },
+          "en": "And Laban arose early in the morning, kissed his sons and daughters, and blessed them; and then Laban went and returned to his place.",
           "ref": "genesis 32:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob went on his way, and the angels of God met him."
-          },
+          "en": "And Jacob went on his way, and the angels of God met him.",
           "ref": "genesis 32:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob said when he saw them: ‘This is God’s camp.’ And he called the name of that place Mahanaim."
-          },
+          "en": "And Jacob said when he saw them: ‘This is God’s camp.’ And he called the name of that place Mahanaim.",
           "ref": "genesis 32:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob sent messengers before him to Esau his brother unto the land of Seir, the field of Edom."
-          },
+          "en": "And Jacob sent messengers before him to Esau his brother unto the land of Seir, the field of Edom.",
           "ref": "genesis 32:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And he commanded them, saying: ‘Thus shall ye say unto my lord Esau: Thus saith thy servant Jacob: I have sojourned with Laban, and stayed until now."
-          },
+          "en": "And he commanded them, saying: ‘Thus shall ye say unto my lord Esau: Thus saith thy servant Jacob: I have sojourned with Laban, and stayed until now.",
           "ref": "genesis 32:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And I have oxen, and asses and flocks, and men-servants and maid-servants; and I have sent to tell my lord, that I may find favour in thy sight.’"
-          },
+          "en": "And I have oxen, and asses and flocks, and men-servants and maid-servants; and I have sent to tell my lord, that I may find favour in thy sight.’",
           "ref": "genesis 32:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And the messengers returned to Jacob, saying: ‘We came to thy brother Esau, and moreover he cometh to meet thee, and four hundred men with him.’"
-          },
+          "en": "And the messengers returned to Jacob, saying: ‘We came to thy brother Esau, and moreover he cometh to meet thee, and four hundred men with him.’",
           "ref": "genesis 32:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Jacob was greatly afraid and was distressed. And he divided the people that was with him, and the flocks, and the herds, and the camels, into two camps."
-          },
+          "en": "Then Jacob was greatly afraid and was distressed. And he divided the people that was with him, and the flocks, and the herds, and the camels, into two camps.",
           "ref": "genesis 32:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘If Esau come to the one camp, and smite it, then the camp which is left shall escape.’"
-          },
+          "en": "And he said: ‘If Esau come to the one camp, and smite it, then the camp which is left shall escape.’",
           "ref": "genesis 32:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob said: ‘O God of my father Abraham, and God of my father Isaac, O LORD, who saidst unto me: Return unto thy country, and to thy kindred, and I will do thee good;"
-          },
+          "en": "And Jacob said: ‘O God of my father Abraham, and God of my father Isaac, O LORD, who saidst unto me: Return unto thy country, and to thy kindred, and I will do thee good;",
           "ref": "genesis 32:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "I am not worthy of all the mercies, and of all the truth, which Thou hast shown unto Thy servant; for with my staff I passed over this Jordan; and now I am become two camps."
-          },
+          "en": "I am not worthy of all the mercies, and of all the truth, which Thou hast shown unto Thy servant; for with my staff I passed over this Jordan; and now I am become two camps.",
           "ref": "genesis 32:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "Deliver me, I pray Thee, from the hand of my brother, from the hand of Esau; for I fear him, lest he come and smite me, the mother with the children."
-          },
+          "en": "Deliver me, I pray Thee, from the hand of my brother, from the hand of Esau; for I fear him, lest he come and smite me, the mother with the children.",
           "ref": "genesis 32:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And Thou saidst: I will surely do thee good, and make thy seed as the sand of the sea, which cannot be numbered for multitude.’"
-          },
+          "en": "And Thou saidst: I will surely do thee good, and make thy seed as the sand of the sea, which cannot be numbered for multitude.’",
           "ref": "genesis 32:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And he lodged there that night; and took of that which he had with him a present for Esau his brother:"
-          },
+          "en": "And he lodged there that night; and took of that which he had with him a present for Esau his brother:",
           "ref": "genesis 32:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "two hundred she-goats and twenty he-goats, two hundred ewes and twenty rams,"
-          },
+          "en": "two hundred she-goats and twenty he-goats, two hundred ewes and twenty rams,",
           "ref": "genesis 32:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "thirty milch camels and their colts, forty kine and ten bulls, twenty she-asses and ten foals."
-          },
+          "en": "thirty milch camels and their colts, forty kine and ten bulls, twenty she-asses and ten foals.",
           "ref": "genesis 32:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And he delivered them into the hand of his servants, every drove by itself; and said unto his servants: ‘Pass over before me, and put a space betwixt drove and drove.’"
-          },
+          "en": "And he delivered them into the hand of his servants, every drove by itself; and said unto his servants: ‘Pass over before me, and put a space betwixt drove and drove.’",
           "ref": "genesis 32:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And he commanded the foremost, saying: ‘When Esau my brother meeteth thee, and asketh thee, saying: Whose art thou? and whither goest thou? and whose are these before thee?"
-          },
+          "en": "And he commanded the foremost, saying: ‘When Esau my brother meeteth thee, and asketh thee, saying: Whose art thou? and whither goest thou? and whose are these before thee?",
           "ref": "genesis 32:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "then thou shalt say: They are thy servant Jacob’s; it is a present sent unto my lord, even unto Esau; and, behold, he also is behind us.’"
-          },
+          "en": "then thou shalt say: They are thy servant Jacob’s; it is a present sent unto my lord, even unto Esau; and, behold, he also is behind us.’",
           "ref": "genesis 32:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And he commanded also the second, and the third, and all that followed the droves, saying: ‘In this manner shall ye speak unto Esau, when ye find him;"
-          },
+          "en": "And he commanded also the second, and the third, and all that followed the droves, saying: ‘In this manner shall ye speak unto Esau, when ye find him;",
           "ref": "genesis 32:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "and ye shall say: Moreover, behold, thy servant Jacob is behind us.’ For he said: ‘I will appease him with the present that goeth before me, and afterward I will see his face; peradventure he will accept me.’"
-          },
+          "en": "and ye shall say: Moreover, behold, thy servant Jacob is behind us.’ For he said: ‘I will appease him with the present that goeth before me, and afterward I will see his face; peradventure he will accept me.’",
           "ref": "genesis 32:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "So the present passed over before him; and he himself lodged that night in the camp."
-          },
+          "en": "So the present passed over before him; and he himself lodged that night in the camp.",
           "ref": "genesis 32:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And he rose up that night, and took his two wives, and his two handmaids, and his eleven children, and passed over the ford of the Jabbok."
-          },
+          "en": "And he rose up that night, and took his two wives, and his two handmaids, and his eleven children, and passed over the ford of the Jabbok.",
           "ref": "genesis 32:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And he took them, and sent them over the stream, and sent over that which he had."
-          },
+          "en": "And he took them, and sent them over the stream, and sent over that which he had.",
           "ref": "genesis 32:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob was left alone; and there wrestled a man with him until the breaking of the day."
-          },
+          "en": "And Jacob was left alone; and there wrestled a man with him until the breaking of the day.",
           "ref": "genesis 32:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And when he saw that he prevailed not against him, he touched the hollow of his thigh; and the hollow of Jacob’s thigh was strained, as he wrestled with him."
-          },
+          "en": "And when he saw that he prevailed not against him, he touched the hollow of his thigh; and the hollow of Jacob’s thigh was strained, as he wrestled with him.",
           "ref": "genesis 32:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Let me go, for the day breaketh.’ And he said: ‘I will not let thee go, except thou bless me.’"
-          },
+          "en": "And he said: ‘Let me go, for the day breaketh.’ And he said: ‘I will not let thee go, except thou bless me.’",
           "ref": "genesis 32:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto him: ‘What is thy name?’ And he said: ‘Jacob.’"
-          },
+          "en": "And he said unto him: ‘What is thy name?’ And he said: ‘Jacob.’",
           "ref": "genesis 32:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Thy name shall be called no more Jacob, but Israel; for thou hast striven with God and with men, and hast prevailed.’"
-          },
+          "en": "And he said: ‘Thy name shall be called no more Jacob, but Israel; for thou hast striven with God and with men, and hast prevailed.’",
           "ref": "genesis 32:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": "Jacob returned the question: \"If you would,\" he said, \"tell me what your name is.\" \"Why do you ask my name?\" replied (the stranger). He then blessed (Jacob).",
-            "jps1917": "And Jacob asked him, and said: ‘Tell me, I pray thee, thy name.’ And he said: ‘Wherefore is it that thou dost ask after my name?’ And he blessed him there."
-          },
+          "en": "And Jacob asked him, and said: ‘Tell me, I pray thee, thy name.’ And he said: ‘Wherefore is it that thou dost ask after my name?’ And he blessed him there.",
           "ref": "genesis 32:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob called the name of the place Peniel: ‘for I have seen God face to face, and my life is preserved.’"
-          },
+          "en": "And Jacob called the name of the place Peniel: ‘for I have seen God face to face, and my life is preserved.’",
           "ref": "genesis 32:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sun rose upon him as he passed over Peniel, and he limped upon his thigh."
-          },
+          "en": "And the sun rose upon him as he passed over Peniel, and he limped upon his thigh.",
           "ref": "genesis 32:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "Therefore the children of Israel eat not the sinew of the thigh-vein which is upon the hollow of the thigh, unto this day; because he touched the hollow of Jacob’s thigh, even in the sinew of the thigh-vein."
-          },
+          "en": "Therefore the children of Israel eat not the sinew of the thigh-vein which is upon the hollow of the thigh, unto this day; because he touched the hollow of Jacob’s thigh, even in the sinew of the thigh-vein.",
           "ref": "genesis 32:33"
         }
       ]
@@ -7855,162 +4972,102 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob lifted up his eyes and looked, and, behold, Esau came, and with him four hundred men. And he divided the children unto Leah, and unto Rachel, and unto the two handmaids."
-          },
+          "en": "And Jacob lifted up his eyes and looked, and, behold, Esau came, and with him four hundred men. And he divided the children unto Leah, and unto Rachel, and unto the two handmaids.",
           "ref": "genesis 33:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And he put the handmaids and their children foremost, and Leah and her children after, and Rachel and Joseph hindermost."
-          },
+          "en": "And he put the handmaids and their children foremost, and Leah and her children after, and Rachel and Joseph hindermost.",
           "ref": "genesis 33:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And he himself passed over before them, and bowed himself to the ground seven times, until he came near to his brother."
-          },
+          "en": "And he himself passed over before them, and bowed himself to the ground seven times, until he came near to his brother.",
           "ref": "genesis 33:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And Esau ran to meet him, and embraced him, and fell on his neck, and kissed him; and they wept."
-          },
+          "en": "And Esau ran to meet him, and embraced him, and fell on his neck, and kissed him; and they wept.",
           "ref": "genesis 33:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And he lifted up his eyes, and saw the women and the children; and said: ‘Who are these with thee?’ And he said: ‘The children whom God hath graciously given thy servant.’"
-          },
+          "en": "And he lifted up his eyes, and saw the women and the children; and said: ‘Who are these with thee?’ And he said: ‘The children whom God hath graciously given thy servant.’",
           "ref": "genesis 33:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "Then the handmaids came near, they and their children, and they bowed down."
-          },
+          "en": "Then the handmaids came near, they and their children, and they bowed down.",
           "ref": "genesis 33:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Leah also and her children came near, and bowed down; and after came Joseph near and Rachel, and they bowed down."
-          },
+          "en": "And Leah also and her children came near, and bowed down; and after came Joseph near and Rachel, and they bowed down.",
           "ref": "genesis 33:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘What meanest thou by all this camp which I met?’ And he said: ‘To find favour in the sight of my lord.’"
-          },
+          "en": "And he said: ‘What meanest thou by all this camp which I met?’ And he said: ‘To find favour in the sight of my lord.’",
           "ref": "genesis 33:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And Esau said: ‘I have enough; my brother, let that which thou hast be thine.’"
-          },
+          "en": "And Esau said: ‘I have enough; my brother, let that which thou hast be thine.’",
           "ref": "genesis 33:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob said: ‘Nay, I pray thee, if now I have found favour in thy sight, then receive my present at my hand; forasmuch as I have seen thy face, as one seeth the face of God, and thou wast pleased with me."
-          },
+          "en": "And Jacob said: ‘Nay, I pray thee, if now I have found favour in thy sight, then receive my present at my hand; forasmuch as I have seen thy face, as one seeth the face of God, and thou wast pleased with me.",
           "ref": "genesis 33:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "Take, I pray thee, my gift that is brought to thee; because God hath dealt graciously with me, and because I have enough.’ And he urged him, and he took it."
-          },
+          "en": "Take, I pray thee, my gift that is brought to thee; because God hath dealt graciously with me, and because I have enough.’ And he urged him, and he took it.",
           "ref": "genesis 33:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Let us take our journey, and let us go, and I will go before thee.’"
-          },
+          "en": "And he said: ‘Let us take our journey, and let us go, and I will go before thee.’",
           "ref": "genesis 33:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto him: ‘My lord knoweth that the children are tender, and that the flocks and herds giving suck are a care to me; and if they overdrive them one day, all the flocks will die."
-          },
+          "en": "And he said unto him: ‘My lord knoweth that the children are tender, and that the flocks and herds giving suck are a care to me; and if they overdrive them one day, all the flocks will die.",
           "ref": "genesis 33:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "Let my lord, I pray thee, pass over before his servant; and I will journey on gently, according to the pace of the cattle that are before me and according to the pace of the children, until I come unto my lord unto Seir.’"
-          },
+          "en": "Let my lord, I pray thee, pass over before his servant; and I will journey on gently, according to the pace of the cattle that are before me and according to the pace of the children, until I come unto my lord unto Seir.’",
           "ref": "genesis 33:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And Esau said: ‘Let me now leave with thee some of the folk that are with me.’ And he said: ‘What needeth it? let me find favour in the sight of my lord.’"
-          },
+          "en": "And Esau said: ‘Let me now leave with thee some of the folk that are with me.’ And he said: ‘What needeth it? let me find favour in the sight of my lord.’",
           "ref": "genesis 33:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "So Esau returned that day on his way unto Seir."
-          },
+          "en": "So Esau returned that day on his way unto Seir.",
           "ref": "genesis 33:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob journeyed to Succoth, and built him a house, and made booths for his cattle. Therefore the name of the place is called Succoth."
-          },
+          "en": "And Jacob journeyed to Succoth, and built him a house, and made booths for his cattle. Therefore the name of the place is called Succoth.",
           "ref": "genesis 33:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob came in peace to the city of Shechem, which is in the land of Canaan, when he came from Paddan-aram; and encamped before the city."
-          },
+          "en": "And Jacob came in peace to the city of Shechem, which is in the land of Canaan, when he came from Paddan-aram; and encamped before the city.",
           "ref": "genesis 33:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And he bought the parcel of ground, where he had spread his tent, at the hand of the children of Hamor, Shechem’s father, for a hundred pieces of money."
-          },
+          "en": "And he bought the parcel of ground, where he had spread his tent, at the hand of the children of Hamor, Shechem’s father, for a hundred pieces of money.",
           "ref": "genesis 33:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And he erected there an altar, and called it El-elohe-Israel."
-          },
+          "en": "And he erected there an altar, and called it El-elohe-Israel.",
           "ref": "genesis 33:20"
         }
       ]
@@ -8020,250 +5077,157 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And Dinah the daughter of Leah, whom she had borne unto Jacob, went out to see the daughters of the land."
-          },
+          "en": "And Dinah the daughter of Leah, whom she had borne unto Jacob, went out to see the daughters of the land.",
           "ref": "genesis 34:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Shechem the son of Hamor the Hivite, the prince of the land, saw her; and he took her, and lay with her, and humbled her."
-          },
+          "en": "And Shechem the son of Hamor the Hivite, the prince of the land, saw her; and he took her, and lay with her, and humbled her.",
           "ref": "genesis 34:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And his soul did cleave unto Dinah the daughter of Jacob, and he loved the damsel, and spoke comfortingly unto the damsel."
-          },
+          "en": "And his soul did cleave unto Dinah the daughter of Jacob, and he loved the damsel, and spoke comfortingly unto the damsel.",
           "ref": "genesis 34:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And Shechem spoke unto his father Hamor, saying: ‘Get me this damsel to wife.’"
-          },
+          "en": "And Shechem spoke unto his father Hamor, saying: ‘Get me this damsel to wife.’",
           "ref": "genesis 34:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "Now Jacob heard that he had defiled Dinah his daughter; and his sons were with his cattle in the field; and Jacob held his peace until they came."
-          },
+          "en": "Now Jacob heard that he had defiled Dinah his daughter; and his sons were with his cattle in the field; and Jacob held his peace until they came.",
           "ref": "genesis 34:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Hamor the father of Shechem went out unto Jacob to speak with him."
-          },
+          "en": "And Hamor the father of Shechem went out unto Jacob to speak with him.",
           "ref": "genesis 34:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Jacob came in from the field when they heard it; and the men were grieved, and they were very wroth, because he had wrought a vile deed in Israel in lying with Jacob’s daughter; which thing ought not to be done."
-          },
+          "en": "And the sons of Jacob came in from the field when they heard it; and the men were grieved, and they were very wroth, because he had wrought a vile deed in Israel in lying with Jacob’s daughter; which thing ought not to be done.",
           "ref": "genesis 34:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Hamor spoke with them, saying ‘The soul of my son Shechem longeth for your daughter. I pray you give her unto him to wife."
-          },
+          "en": "And Hamor spoke with them, saying ‘The soul of my son Shechem longeth for your daughter. I pray you give her unto him to wife.",
           "ref": "genesis 34:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And make ye marriages with us; give your daughters unto us, and take our daughters unto you."
-          },
+          "en": "And make ye marriages with us; give your daughters unto us, and take our daughters unto you.",
           "ref": "genesis 34:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And ye shall dwell with us; and the land shall be before you; dwell and trade ye therein, and get you possessions therein.’"
-          },
+          "en": "And ye shall dwell with us; and the land shall be before you; dwell and trade ye therein, and get you possessions therein.’",
           "ref": "genesis 34:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And Shechem said unto her father and unto her brethren: ‘Let me find favour in your eyes, and what ye shall say unto me I will give."
-          },
+          "en": "And Shechem said unto her father and unto her brethren: ‘Let me find favour in your eyes, and what ye shall say unto me I will give.",
           "ref": "genesis 34:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "Ask me never so much dowry and gift, and I will give according as ye shall say unto me; but give me the damsel to wife.’"
-          },
+          "en": "Ask me never so much dowry and gift, and I will give according as ye shall say unto me; but give me the damsel to wife.’",
           "ref": "genesis 34:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Jacob answered Shechem and Hamor his father with guile, and spoke, because he had defiled Dinah their sister,"
-          },
+          "en": "And the sons of Jacob answered Shechem and Hamor his father with guile, and spoke, because he had defiled Dinah their sister,",
           "ref": "genesis 34:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "and said unto them: ‘We cannot do this thing, to give our sister to one that is uncircumcised; for that were a reproach unto us."
-          },
+          "en": "and said unto them: ‘We cannot do this thing, to give our sister to one that is uncircumcised; for that were a reproach unto us.",
           "ref": "genesis 34:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "Only on this condition will we consent unto you: if ye will be as we are, that every male of you be circumcised;"
-          },
+          "en": "Only on this condition will we consent unto you: if ye will be as we are, that every male of you be circumcised;",
           "ref": "genesis 34:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "then will we give our daughters unto you, and we will take your daughters to us, and we will dwell with you, and we will become one people."
-          },
+          "en": "then will we give our daughters unto you, and we will take your daughters to us, and we will dwell with you, and we will become one people.",
           "ref": "genesis 34:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "But if ye will not hearken unto us, to be circumcised; then will we take our daughter, and we will be gone.’"
-          },
+          "en": "But if ye will not hearken unto us, to be circumcised; then will we take our daughter, and we will be gone.’",
           "ref": "genesis 34:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And their words pleased Hamor, and Shechem Hamor’s son."
-          },
+          "en": "And their words pleased Hamor, and Shechem Hamor’s son.",
           "ref": "genesis 34:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And the young man deferred not to do the thing, because he had delight in Jacob’s daughter. And he was honoured above all the house of his father."
-          },
+          "en": "And the young man deferred not to do the thing, because he had delight in Jacob’s daughter. And he was honoured above all the house of his father.",
           "ref": "genesis 34:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Hamor and Shechem his son came unto the gate of their city, and spoke with the men of their city, saying:"
-          },
+          "en": "And Hamor and Shechem his son came unto the gate of their city, and spoke with the men of their city, saying:",
           "ref": "genesis 34:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "’These men are peaceable with us; therefore let them dwell in the land, and trade therein; for, behold, the land is large enough for them; let us take their daughters to us for wives, and let us give them our daughters."
-          },
+          "en": "’These men are peaceable with us; therefore let them dwell in the land, and trade therein; for, behold, the land is large enough for them; let us take their daughters to us for wives, and let us give them our daughters.",
           "ref": "genesis 34:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "Only on this condition will the men consent unto us to dwell with us, to become one people, if every male among us be circumcised, as they are circumcised."
-          },
+          "en": "Only on this condition will the men consent unto us to dwell with us, to become one people, if every male among us be circumcised, as they are circumcised.",
           "ref": "genesis 34:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "Shall not their cattle and their substance and all their beasts be ours? only let us consent unto them, and they will dwell with us.’"
-          },
+          "en": "Shall not their cattle and their substance and all their beasts be ours? only let us consent unto them, and they will dwell with us.’",
           "ref": "genesis 34:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And unto Hamor and unto Shechem his son hearkened all that went out of the gate of his city; and every male was circumcised, all that went out of the gate of his city."
-          },
+          "en": "And unto Hamor and unto Shechem his son hearkened all that went out of the gate of his city; and every male was circumcised, all that went out of the gate of his city.",
           "ref": "genesis 34:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass on the third day, when they were in pain, that two of the sons of Jacob, Simeon and Levi, Dinah’s brethren, took each man his sword, and came upon the city unawares, and slew all the males."
-          },
+          "en": "And it came to pass on the third day, when they were in pain, that two of the sons of Jacob, Simeon and Levi, Dinah’s brethren, took each man his sword, and came upon the city unawares, and slew all the males.",
           "ref": "genesis 34:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And they slew Hamor and Shechem his son with the edge of the sword, and took Dinah out of Shechem’s house, and went forth. ."
-          },
+          "en": "And they slew Hamor and Shechem his son with the edge of the sword, and took Dinah out of Shechem’s house, and went forth. .",
           "ref": "genesis 34:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "The sons of Jacob came upon the slain, and spoiled the city, because they had defiled their sister."
-          },
+          "en": "The sons of Jacob came upon the slain, and spoiled the city, because they had defiled their sister.",
           "ref": "genesis 34:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "They took their flocks and their herds and their asses, and that which was in the city and that which was in the field;"
-          },
+          "en": "They took their flocks and their herds and their asses, and that which was in the city and that which was in the field;",
           "ref": "genesis 34:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "and all their wealth, and all their little ones and their wives, took they captive and spoiled, even all that was in the house."
-          },
+          "en": "and all their wealth, and all their little ones and their wives, took they captive and spoiled, even all that was in the house.",
           "ref": "genesis 34:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob said to Simeon and Levi: ‘Ye have troubled me, to make me odious unto the inhabitants of the land, even unto the Canaanites and the Perizzites; and, I being few in number, they will gather themselves together against me and smite me; and I shall be destroyed, I and my house.’"
-          },
+          "en": "And Jacob said to Simeon and Levi: ‘Ye have troubled me, to make me odious unto the inhabitants of the land, even unto the Canaanites and the Perizzites; and, I being few in number, they will gather themselves together against me and smite me; and I shall be destroyed, I and my house.’",
           "ref": "genesis 34:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said: ‘Should one deal with our sister as with a harlot?’"
-          },
+          "en": "And they said: ‘Should one deal with our sister as with a harlot?’",
           "ref": "genesis 34:31"
         }
       ]
@@ -8273,234 +5237,147 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said unto Jacob: ‘Arise, go up to Beth-el, and dwell there; and make there an altar unto God, who appeared unto thee when thou didst flee from the face of Esau thy brother.’"
-          },
+          "en": "And God said unto Jacob: ‘Arise, go up to Beth-el, and dwell there; and make there an altar unto God, who appeared unto thee when thou didst flee from the face of Esau thy brother.’",
           "ref": "genesis 35:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Jacob said unto his household, and to all that were with him: ‘Put away the strange gods that are among you, and purify yourselves, and change your garments;"
-          },
+          "en": "Then Jacob said unto his household, and to all that were with him: ‘Put away the strange gods that are among you, and purify yourselves, and change your garments;",
           "ref": "genesis 35:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "and let us arise, and go up to Beth-el; and I will make there an altar unto God, who answered me in the day of my distress, and was with me in the way which I went.’"
-          },
+          "en": "and let us arise, and go up to Beth-el; and I will make there an altar unto God, who answered me in the day of my distress, and was with me in the way which I went.’",
           "ref": "genesis 35:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And they gave unto Jacob all the foreign gods which were in their hand, and the rings which were in their ears; and Jacob hid them under the terebinth which was by Shechem."
-          },
+          "en": "And they gave unto Jacob all the foreign gods which were in their hand, and the rings which were in their ears; and Jacob hid them under the terebinth which was by Shechem.",
           "ref": "genesis 35:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And they journeyed; and a terror of God was upon the cities that were round about them, and they did not pursue after the sons of Jacob."
-          },
+          "en": "And they journeyed; and a terror of God was upon the cities that were round about them, and they did not pursue after the sons of Jacob.",
           "ref": "genesis 35:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "So Jacob came to Luz, which is in the land of Canaan—the same is Beth-el—he and all the people that were with him."
-          },
+          "en": "So Jacob came to Luz, which is in the land of Canaan—the same is Beth-el—he and all the people that were with him.",
           "ref": "genesis 35:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And he built there an altar, and called the place El-beth-el, because there God was revealed unto him, when he fled from the face of his brother."
-          },
+          "en": "And he built there an altar, and called the place El-beth-el, because there God was revealed unto him, when he fled from the face of his brother.",
           "ref": "genesis 35:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Deborah Rebekah’s nurse died, and she was buried below Beth-el under the oak; and the name of it was called Allon-bacuth."
-          },
+          "en": "And Deborah Rebekah’s nurse died, and she was buried below Beth-el under the oak; and the name of it was called Allon-bacuth.",
           "ref": "genesis 35:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And God appeared unto Jacob again, when he came from Paddan-aram, and blessed him."
-          },
+          "en": "And God appeared unto Jacob again, when he came from Paddan-aram, and blessed him.",
           "ref": "genesis 35:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said unto him: ‘Thy name is Jacob: thy name shall not be called any more Jacob, but Israel shall be thy name’; and He called his name Israel."
-          },
+          "en": "And God said unto him: ‘Thy name is Jacob: thy name shall not be called any more Jacob, but Israel shall be thy name’; and He called his name Israel.",
           "ref": "genesis 35:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And God said unto him: ‘I am God Almighty. Be fruitful and multiply; a nation and a company of nations shall be of thee, and kings shall come out of thy loins;"
-          },
+          "en": "And God said unto him: ‘I am God Almighty. Be fruitful and multiply; a nation and a company of nations shall be of thee, and kings shall come out of thy loins;",
           "ref": "genesis 35:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "and the land which I gave unto Abraham and Isaac, to thee I will give it, and to thy seed after thee will I give the land.’"
-          },
+          "en": "and the land which I gave unto Abraham and Isaac, to thee I will give it, and to thy seed after thee will I give the land.’",
           "ref": "genesis 35:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And God went up from him in the place where He spoke with him."
-          },
+          "en": "And God went up from him in the place where He spoke with him.",
           "ref": "genesis 35:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob set up a pillar in the place where He spoke with him, a pillar of stone, and he poured out a drink-offering thereon, and poured oil thereon."
-          },
+          "en": "And Jacob set up a pillar in the place where He spoke with him, a pillar of stone, and he poured out a drink-offering thereon, and poured oil thereon.",
           "ref": "genesis 35:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob called the name of the place where God spoke with him, Beth-el."
-          },
+          "en": "And Jacob called the name of the place where God spoke with him, Beth-el.",
           "ref": "genesis 35:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And they journeyed from Beth-el; and there was still some way to come to Ephrath; and Rachel travailed, and she had hard labour."
-          },
+          "en": "And they journeyed from Beth-el; and there was still some way to come to Ephrath; and Rachel travailed, and she had hard labour.",
           "ref": "genesis 35:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when she was in hard labour, that the mid-wife said unto her: ‘Fear not; for this also is a son for thee.’"
-          },
+          "en": "And it came to pass, when she was in hard labour, that the mid-wife said unto her: ‘Fear not; for this also is a son for thee.’",
           "ref": "genesis 35:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, as her soul was in departing—for she died—that she called his name Ben-oni; but his father called him Benjamin."
-          },
+          "en": "And it came to pass, as her soul was in departing—for she died—that she called his name Ben-oni; but his father called him Benjamin.",
           "ref": "genesis 35:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And Rachel died, and was buried in the way to Ephrath—the same is Beth-lehem."
-          },
+          "en": "And Rachel died, and was buried in the way to Ephrath—the same is Beth-lehem.",
           "ref": "genesis 35:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob set up a pillar upon her grave; the same is the pillar of Rachel’s grave unto this day."
-          },
+          "en": "And Jacob set up a pillar upon her grave; the same is the pillar of Rachel’s grave unto this day.",
           "ref": "genesis 35:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And Israel journeyed, and spread his tent beyond Migdal-eder."
-          },
+          "en": "And Israel journeyed, and spread his tent beyond Migdal-eder.",
           "ref": "genesis 35:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, while Israel dwelt in that land, that Reuben went and lay with Bilhah his father’s concubine; and Israel heard of it. Now the sons of Jacob were twelve:"
-          },
+          "en": "And it came to pass, while Israel dwelt in that land, that Reuben went and lay with Bilhah his father’s concubine; and Israel heard of it. Now the sons of Jacob were twelve:",
           "ref": "genesis 35:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "the sons of Leah: Reuben, Jacob’s first-born, and Simeon, and Levi, and Judah, and Issachar, and Zebulun;"
-          },
+          "en": "the sons of Leah: Reuben, Jacob’s first-born, and Simeon, and Levi, and Judah, and Issachar, and Zebulun;",
           "ref": "genesis 35:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "the sons of Rachel: Joseph and Benjamin;"
-          },
+          "en": "the sons of Rachel: Joseph and Benjamin;",
           "ref": "genesis 35:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "and the sons of Bilhah, Rachel’s handmaid: Dan and Naphtali;"
-          },
+          "en": "and the sons of Bilhah, Rachel’s handmaid: Dan and Naphtali;",
           "ref": "genesis 35:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "and the sons of Zilpah, Leah’s handmaid: Gad and Asher. These are the sons of Jacob, that were born to him in Paddan-aram."
-          },
+          "en": "and the sons of Zilpah, Leah’s handmaid: Gad and Asher. These are the sons of Jacob, that were born to him in Paddan-aram.",
           "ref": "genesis 35:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob came unto Isaac his father to Mamre, to Kiriatharba—the same is Hebron—where Abraham and Isaac sojourned."
-          },
+          "en": "And Jacob came unto Isaac his father to Mamre, to Kiriatharba—the same is Hebron—where Abraham and Isaac sojourned.",
           "ref": "genesis 35:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And the days of Isaac were a hundred and fourscore years."
-          },
+          "en": "And the days of Isaac were a hundred and fourscore years.",
           "ref": "genesis 35:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And Isaac expired, and died, and was gathered unto his people, old and full of days; and Esau and Jacob his sons buried him."
-          },
+          "en": "And Isaac expired, and died, and was gathered unto his people, old and full of days; and Esau and Jacob his sons buried him.",
           "ref": "genesis 35:29"
         }
       ]
@@ -8510,346 +5387,217 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "Now these are the generations of Esau—the same is Edom."
-          },
+          "en": "Now these are the generations of Esau—the same is Edom.",
           "ref": "genesis 36:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "Esau took his wives of the daughters of Canaan; Adah the daughter of Elon the Hittite, and Oholibamah the daughter of Anah, the daughter of Zibeon the Hivite,"
-          },
+          "en": "Esau took his wives of the daughters of Canaan; Adah the daughter of Elon the Hittite, and Oholibamah the daughter of Anah, the daughter of Zibeon the Hivite,",
           "ref": "genesis 36:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "and Basemath Ishmael’s daughter, sister of Nebaioth."
-          },
+          "en": "and Basemath Ishmael’s daughter, sister of Nebaioth.",
           "ref": "genesis 36:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And Adah bore to Esau Eliphaz; and Basemath bore Reuel;"
-          },
+          "en": "And Adah bore to Esau Eliphaz; and Basemath bore Reuel;",
           "ref": "genesis 36:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "and Oholibamah bore Jeush, and Jalam, and Korah. These are the sons of Esau, that were born unto him in the land of Canaan."
-          },
+          "en": "and Oholibamah bore Jeush, and Jalam, and Korah. These are the sons of Esau, that were born unto him in the land of Canaan.",
           "ref": "genesis 36:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Esau took his wives, and his sons, and his daughters, and all the souls of his house, and his cattle, and all his beasts, and all his possessions, which he had gathered in the land of Canaan; and went into a land away from his brother Jacob."
-          },
+          "en": "And Esau took his wives, and his sons, and his daughters, and all the souls of his house, and his cattle, and all his beasts, and all his possessions, which he had gathered in the land of Canaan; and went into a land away from his brother Jacob.",
           "ref": "genesis 36:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "For their substance was too great for them to dwell together; and the land of their sojournings could not bear them because of their cattle."
-          },
+          "en": "For their substance was too great for them to dwell together; and the land of their sojournings could not bear them because of their cattle.",
           "ref": "genesis 36:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Esau dwelt in the mountain-land of Seir—Esau is Edom."
-          },
+          "en": "And Esau dwelt in the mountain-land of Seir—Esau is Edom.",
           "ref": "genesis 36:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the generations of Esau the father of a the Edomites in the mountain-land of Seir."
-          },
+          "en": "And these are the generations of Esau the father of a the Edomites in the mountain-land of Seir.",
           "ref": "genesis 36:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the names of Esau’s sons: Eliphaz the son of Adah the wife of Esau, Reuel the son of Basemath the wife of Esau."
-          },
+          "en": "These are the names of Esau’s sons: Eliphaz the son of Adah the wife of Esau, Reuel the son of Basemath the wife of Esau.",
           "ref": "genesis 36:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Eliphaz were Teman, Omar, Zepho, and Gatam, and Kenaz."
-          },
+          "en": "And the sons of Eliphaz were Teman, Omar, Zepho, and Gatam, and Kenaz.",
           "ref": "genesis 36:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And Timna was concubine to Eliphaz Esau’s son; and she bore to Eliphaz Amalek. These are the sons of Adah Esau’s wife."
-          },
+          "en": "And Timna was concubine to Eliphaz Esau’s son; and she bore to Eliphaz Amalek. These are the sons of Adah Esau’s wife.",
           "ref": "genesis 36:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the sons of Reuel: Nahath, and Zerah, Shammah, and Mizzah. These were the sons of Basemath Esau’s wife."
-          },
+          "en": "And these are the sons of Reuel: Nahath, and Zerah, Shammah, and Mizzah. These were the sons of Basemath Esau’s wife.",
           "ref": "genesis 36:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And these were the sons of Oholibamah the daughter of Anah, the daughter of Zibeon, Esau’s wife; and she bore to Esau Jeush, and Jalam, and Korah."
-          },
+          "en": "And these were the sons of Oholibamah the daughter of Anah, the daughter of Zibeon, Esau’s wife; and she bore to Esau Jeush, and Jalam, and Korah.",
           "ref": "genesis 36:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the chiefs of the sons of Esau: the sons of Eliphaz the first-born of Esau: the chief of Teman, the chief of Omar, the chief of Zepho, the chief of Kenaz,"
-          },
+          "en": "These are the chiefs of the sons of Esau: the sons of Eliphaz the first-born of Esau: the chief of Teman, the chief of Omar, the chief of Zepho, the chief of Kenaz,",
           "ref": "genesis 36:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "the chief of Korah, the chief of Gatam, the chief of Amalek. These are the chiefs that came of Eliphaz in the land of Edom. These are the sons of Adah."
-          },
+          "en": "the chief of Korah, the chief of Gatam, the chief of Amalek. These are the chiefs that came of Eliphaz in the land of Edom. These are the sons of Adah.",
           "ref": "genesis 36:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the sons of Reuel Esau’s son: the chief of Nahath, the chief of Zerah, the chief of Shammah, the chief of Mizzah. These are the chiefs that came of Reuel in the land of Edom. These are the sons of Basemath Esau’s wife."
-          },
+          "en": "And these are the sons of Reuel Esau’s son: the chief of Nahath, the chief of Zerah, the chief of Shammah, the chief of Mizzah. These are the chiefs that came of Reuel in the land of Edom. These are the sons of Basemath Esau’s wife.",
           "ref": "genesis 36:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the sons of Oholibamah Esau’s wife: the chief of Jeush, the chief of Jalam, the chief of Korah. These are the chiefs that came of Oholibamah the daughter of Anah, Esau’s wife."
-          },
+          "en": "And these are the sons of Oholibamah Esau’s wife: the chief of Jeush, the chief of Jalam, the chief of Korah. These are the chiefs that came of Oholibamah the daughter of Anah, Esau’s wife.",
           "ref": "genesis 36:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the sons of Esau, and these are their chiefs; the same is Edom."
-          },
+          "en": "These are the sons of Esau, and these are their chiefs; the same is Edom.",
           "ref": "genesis 36:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the sons of Seir the Horite, the inhabitants of the land: Lotan and Shobal and Zibeon and Anah,"
-          },
+          "en": "These are the sons of Seir the Horite, the inhabitants of the land: Lotan and Shobal and Zibeon and Anah,",
           "ref": "genesis 36:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "and Dishon and Ezer and Dishan. These are the chiefs that came of the Horites, the children of Seir in the land of Edom."
-          },
+          "en": "and Dishon and Ezer and Dishan. These are the chiefs that came of the Horites, the children of Seir in the land of Edom.",
           "ref": "genesis 36:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And the children of Lotan were Hori and Hemam; and Lotan’s sister was Timna."
-          },
+          "en": "And the children of Lotan were Hori and Hemam; and Lotan’s sister was Timna.",
           "ref": "genesis 36:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the children of Shobal: Alvan and Manahath and Ebal, Shepho and Onam."
-          },
+          "en": "And these are the children of Shobal: Alvan and Manahath and Ebal, Shepho and Onam.",
           "ref": "genesis 36:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the children of Zibeon: Aiah and Anah—this is Anah who found the hot springs in the wilderness, as he fed the asses of Zibeon his father."
-          },
+          "en": "And these are the children of Zibeon: Aiah and Anah—this is Anah who found the hot springs in the wilderness, as he fed the asses of Zibeon his father.",
           "ref": "genesis 36:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the children of Anah: Dishon and Oholibamah the daughter of Anah."
-          },
+          "en": "And these are the children of Anah: Dishon and Oholibamah the daughter of Anah.",
           "ref": "genesis 36:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the children of Dishon: Hemdan and Eshban and Ithran and Cheran."
-          },
+          "en": "And these are the children of Dishon: Hemdan and Eshban and Ithran and Cheran.",
           "ref": "genesis 36:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the children of Ezer: Bilhan and Zaavan and Akan."
-          },
+          "en": "These are the children of Ezer: Bilhan and Zaavan and Akan.",
           "ref": "genesis 36:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the children of Dishan: Uz and Aran."
-          },
+          "en": "These are the children of Dishan: Uz and Aran.",
           "ref": "genesis 36:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the chiefs that came of the Horites: the chief of Lotan, the chief of Shobal, the chief of Zibeon, the chief of Anah,"
-          },
+          "en": "These are the chiefs that came of the Horites: the chief of Lotan, the chief of Shobal, the chief of Zibeon, the chief of Anah,",
           "ref": "genesis 36:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "the chief of Dishon, the chief of Ezer, the chief of Dishan. These are the chiefs that came of the Horites, according to their chiefs in the land of Seir."
-          },
+          "en": "the chief of Dishon, the chief of Ezer, the chief of Dishan. These are the chiefs that came of the Horites, according to their chiefs in the land of Seir.",
           "ref": "genesis 36:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the kings that reigned in the land of Edom, before there reigned any king over the children of Israel."
-          },
+          "en": "And these are the kings that reigned in the land of Edom, before there reigned any king over the children of Israel.",
           "ref": "genesis 36:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And Bela the son of Beor reigned in Edom; and the name of his city was Dinhabah."
-          },
+          "en": "And Bela the son of Beor reigned in Edom; and the name of his city was Dinhabah.",
           "ref": "genesis 36:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And Bela died, and Jobab the son of Zerah of Bozrah reigned in his stead."
-          },
+          "en": "And Bela died, and Jobab the son of Zerah of Bozrah reigned in his stead.",
           "ref": "genesis 36:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jobab died, and Husham of the land of the Temanites reigned in his stead."
-          },
+          "en": "And Jobab died, and Husham of the land of the Temanites reigned in his stead.",
           "ref": "genesis 36:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And Husham died, and Hadad the son of Bedad, who smote Midian in the field of Moab, reigned in his stead; and the name of his city was Avith."
-          },
+          "en": "And Husham died, and Hadad the son of Bedad, who smote Midian in the field of Moab, reigned in his stead; and the name of his city was Avith.",
           "ref": "genesis 36:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "And Hadad died, and Samlah of Masrekah reigned in his stead."
-          },
+          "en": "And Hadad died, and Samlah of Masrekah reigned in his stead.",
           "ref": "genesis 36:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": null,
-            "jps1917": "And Samlah died, and Shaul of Rehoboth by the River reigned in his stead."
-          },
+          "en": "And Samlah died, and Shaul of Rehoboth by the River reigned in his stead.",
           "ref": "genesis 36:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": null,
-            "jps1917": "And Shaul died, and Baal-hanan the son of Achbor reigned in his stead."
-          },
+          "en": "And Shaul died, and Baal-hanan the son of Achbor reigned in his stead.",
           "ref": "genesis 36:38"
         },
         {
           "n": 39,
-          "en": {
-            "sct": null,
-            "jps1917": "And Baal-hanan the son of Achbor died, and Hadar reigned in his stead; and the name of the city was Pau; and his wife’s name was Mehetabel, the daughter of Matred, the daughter of Me-zahab."
-          },
+          "en": "And Baal-hanan the son of Achbor died, and Hadar reigned in his stead; and the name of the city was Pau; and his wife’s name was Mehetabel, the daughter of Matred, the daughter of Me-zahab.",
           "ref": "genesis 36:39"
         },
         {
           "n": 40,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the names of the chiefs that came of Esau, according to their families, after their places, by their names: the chief of Timna, the chief of Alvah, the chief of Jetheth;"
-          },
+          "en": "And these are the names of the chiefs that came of Esau, according to their families, after their places, by their names: the chief of Timna, the chief of Alvah, the chief of Jetheth;",
           "ref": "genesis 36:40"
         },
         {
           "n": 41,
-          "en": {
-            "sct": null,
-            "jps1917": "the chief of Oholibamah, the chief of Elah, the chief of Pinon;"
-          },
+          "en": "the chief of Oholibamah, the chief of Elah, the chief of Pinon;",
           "ref": "genesis 36:41"
         },
         {
           "n": 42,
-          "en": {
-            "sct": null,
-            "jps1917": "the chief of Kenaz, the chief of Teman, the chief of Mibzar;"
-          },
+          "en": "the chief of Kenaz, the chief of Teman, the chief of Mibzar;",
           "ref": "genesis 36:42"
         },
         {
           "n": 43,
-          "en": {
-            "sct": null,
-            "jps1917": "the chief of Magdiel, the chief of Iram. These are the chiefs of Edom, according to their habitations in the land of their possession. This is Esau the father of the Edomites."
-          },
+          "en": "the chief of Magdiel, the chief of Iram. These are the chiefs of Edom, according to their habitations in the land of their possession. This is Esau the father of the Edomites.",
           "ref": "genesis 36:43"
         }
       ]
@@ -8859,290 +5607,182 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": "Now Jacob was settled in the land where his father had sojourned, the land of Canaan.",
-            "jps1917": "And Jacob dwelt in the land of his father’s sojournings, in the land of Canaan."
-          },
+          "en": "And Jacob dwelt in the land of his father’s sojournings, in the land of Canaan.",
           "ref": "genesis 37:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": "This, then, is the line of Jacob: At seventeen years of age, Joseph tended the flocks with his brothers, as a helper to the sons of his father’s wives Bilhah and Zilpah. And Joseph brought bad reports of them to their father.",
-            "jps1917": "These are the generations of Jacob. Joseph, being seventeen years old, was feeding the flock with his brethren, being still a lad even with the sons of Bilhah, and with the sons of Zilpah, his father’s wives; and Joseph brought evil report of them unto their father."
-          },
+          "en": "These are the generations of Jacob. Joseph, being seventeen years old, was feeding the flock with his brethren, being still a lad even with the sons of Bilhah, and with the sons of Zilpah, his father’s wives; and Joseph brought evil report of them unto their father.",
           "ref": "genesis 37:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": "Now Israel loved Joseph best of all his sons—he was his “child of old age”; and he had made him an ornamented tunic.",
-            "jps1917": "Now Israel loved Joseph more than all his children, because he was the son of his old age; and he made him a coat of many colours."
-          },
+          "en": "Now Israel loved Joseph more than all his children, because he was the son of his old age; and he made him a coat of many colours.",
           "ref": "genesis 37:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": "And when his brothers saw that their father loved him more than any of his brothers, they hated him so that they could not speak a friendly word to him.",
-            "jps1917": "And when his brethren saw that their father loved him more than all his brethren, they hated him, and could not speak peaceably unto him."
-          },
+          "en": "And when his brethren saw that their father loved him more than all his brethren, they hated him, and could not speak peaceably unto him.",
           "ref": "genesis 37:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": "Once Joseph had a dream which he told to his brothers; and they hated him even more.",
-            "jps1917": "And Joseph dreamed a dream, and he told it to his brethren; and they hated him yet the more."
-          },
+          "en": "And Joseph dreamed a dream, and he told it to his brethren; and they hated him yet the more.",
           "ref": "genesis 37:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": "He said to them, “Hear this dream which I have dreamed:",
-            "jps1917": "And he said unto them: ‘Hear, I pray you, this dream which I have dreamed:"
-          },
+          "en": "And he said unto them: ‘Hear, I pray you, this dream which I have dreamed:",
           "ref": "genesis 37:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": "There we were binding sheaves in the field, when suddenly my sheaf stood up and remained upright; then your sheaves gathered around and bowed low to my sheaf.”",
-            "jps1917": "for, behold, we were binding sheaves in the field, and, lo, my sheaf arose, and also stood upright; and, behold, your sheaves came round about, and bowed down to my sheaf.’"
-          },
+          "en": "for, behold, we were binding sheaves in the field, and, lo, my sheaf arose, and also stood upright; and, behold, your sheaves came round about, and bowed down to my sheaf.’",
           "ref": "genesis 37:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": "His brothers answered, “Do you mean to reign over us? Do you mean to rule over us?” And they hated him even more for his talk about his dreams.",
-            "jps1917": "And his brethren said to him: ‘Shalt thou indeed reign over us? or shalt thou indeed have dominion over us?’ And they hated him yet the more for his dreams, and for his words."
-          },
+          "en": "And his brethren said to him: ‘Shalt thou indeed reign over us? or shalt thou indeed have dominion over us?’ And they hated him yet the more for his dreams, and for his words.",
           "ref": "genesis 37:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": "He dreamed another dream and told it to his brothers, saying, “Look, I have had another dream: And this time, the sun, the moon, and eleven stars were bowing down to me.”",
-            "jps1917": "And he dreamed yet another dream, and told it to his brethren, and said: ‘Behold, I have dreamed yet a dream: and, behold, the sun and the moon and eleven stars bowed down to me.’"
-          },
+          "en": "And he dreamed yet another dream, and told it to his brethren, and said: ‘Behold, I have dreamed yet a dream: and, behold, the sun and the moon and eleven stars bowed down to me.’",
           "ref": "genesis 37:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": "And when he told it to his father and brothers, his father berated him. “What,” he said to him, “is this dream you have dreamed? Are we to come, I and your mother and your brothers, and bow low to you to the ground?”",
-            "jps1917": "And he told it to his father, and to his brethren; and his father rebuked him, and said unto him: ‘What is this dream that thou hast dreamed? Shall I and thy mother and thy brethren indeed come to bow down to thee to the earth?’"
-          },
+          "en": "And he told it to his father, and to his brethren; and his father rebuked him, and said unto him: ‘What is this dream that thou hast dreamed? Shall I and thy mother and thy brethren indeed come to bow down to thee to the earth?’",
           "ref": "genesis 37:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": "So his brothers were wrought up at him, and his father kept the matter in mind.",
-            "jps1917": "And his brethren envied him; but his father kept the saying in mind. ."
-          },
+          "en": "And his brethren envied him; but his father kept the saying in mind. .",
           "ref": "genesis 37:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": "One time, when his brothers had gone to pasture their father’s flock at Shechem,",
-            "jps1917": "And his brethren went to feed their father’s flock in Shechem."
-          },
+          "en": "And his brethren went to feed their father’s flock in Shechem.",
           "ref": "genesis 37:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": "Israel said to Joseph, “Your brothers are pasturing at Shechem. Come, I will send you to them.” He answered, “I am ready.”",
-            "jps1917": "And Israel said unto Joseph: ‘Do not thy brethren feed the flock in Shechem? come, and I will send thee unto them.’ And he said to him: ‘Here am I.’"
-          },
+          "en": "And Israel said unto Joseph: ‘Do not thy brethren feed the flock in Shechem? come, and I will send thee unto them.’ And he said to him: ‘Here am I.’",
           "ref": "genesis 37:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": "And he said to him, “Go and see how your brothers are and how the flocks are faring, and bring me back word.” So he sent him from the valley of Hebron. When he reached Shechem,",
-            "jps1917": "And he said to him: ‘Go now, see whether it is well with thy brethren, and well with the flock; and bring me back word.’ So he sent him out of the vale of Hebron, and he came to Shechem."
-          },
+          "en": "And he said to him: ‘Go now, see whether it is well with thy brethren, and well with the flock; and bring me back word.’ So he sent him out of the vale of Hebron, and he came to Shechem.",
           "ref": "genesis 37:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": "a man came upon him wandering in the fields. The man asked him, “What are you looking for?”",
-            "jps1917": "And a certain man found him, and, behold, he was wandering in the field. And the man asked him, saying: ‘What seekest thou?’"
-          },
+          "en": "And a certain man found him, and, behold, he was wandering in the field. And the man asked him, saying: ‘What seekest thou?’",
           "ref": "genesis 37:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": "He answered, “I am looking for my brothers. Could you tell me where they are pasturing?”",
-            "jps1917": "And he said: ‘I seek my brethren. Tell me, I pray thee, where they are feeding the flock.’"
-          },
+          "en": "And he said: ‘I seek my brethren. Tell me, I pray thee, where they are feeding the flock.’",
           "ref": "genesis 37:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": "The man said, “They have gone from here, for I heard them say: Let us go to Dothan.” So Joseph followed his brothers and found them at Dothan.",
-            "jps1917": "And the man said: ‘They are departed hence; for I heard them say: Let us go to Dothan.’ And Joseph went after his brethren, and found them in Dothan."
-          },
+          "en": "And the man said: ‘They are departed hence; for I heard them say: Let us go to Dothan.’ And Joseph went after his brethren, and found them in Dothan.",
           "ref": "genesis 37:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": "They saw him from afar, and before he came close to them they conspired to kill him.",
-            "jps1917": "And they saw him afar off, and before he came near unto them, they conspired against him to slay him."
-          },
+          "en": "And they saw him afar off, and before he came near unto them, they conspired against him to slay him.",
           "ref": "genesis 37:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": "They said to one another, “Here comes that dreamer!",
-            "jps1917": "And they said one to another: ‘Behold, this dreamer cometh."
-          },
+          "en": "And they said one to another: ‘Behold, this dreamer cometh.",
           "ref": "genesis 37:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": "Come now, let us kill him and throw him into one of the pits; and we can say, ‘A savage beast devoured him.’ We shall see what comes of his dreams!”",
-            "jps1917": "Come now therefore, and let us slay him, and cast him into one of the pits, and we will say: An evil beast hath devoured him; and we shall see what will become of his dreams.’"
-          },
+          "en": "Come now therefore, and let us slay him, and cast him into one of the pits, and we will say: An evil beast hath devoured him; and we shall see what will become of his dreams.’",
           "ref": "genesis 37:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": "But when Reuben heard it, he tried to save him from them. He said, “Let us not take his life.”",
-            "jps1917": "And Reuben heard it, and delivered him out of their hand; and said: ‘Let us not take his life.’"
-          },
+          "en": "And Reuben heard it, and delivered him out of their hand; and said: ‘Let us not take his life.’",
           "ref": "genesis 37:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": "And Reuben went on, “Shed no blood! Cast him into that pit out in the wilderness, but do not touch him yourselves”—intending to save him from them and restore him to his father.",
-            "jps1917": "And Reuben said unto them: ‘Shed no blood; cast him into this pit that is in the wilderness, but lay no hand upon him’—that he might deliver him out of their hand, to restore him to his father."
-          },
+          "en": "And Reuben said unto them: ‘Shed no blood; cast him into this pit that is in the wilderness, but lay no hand upon him’—that he might deliver him out of their hand, to restore him to his father.",
           "ref": "genesis 37:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": "When Joseph came up to his brothers, they stripped Joseph of his tunic, the ornamented tunic that he was wearing,",
-            "jps1917": "And it came to pass, when Joseph was come unto his brethren, that they stripped Joseph of his coat, the coat of many colours that was on him;"
-          },
+          "en": "And it came to pass, when Joseph was come unto his brethren, that they stripped Joseph of his coat, the coat of many colours that was on him;",
           "ref": "genesis 37:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": "and took him and cast him into the pit. The pit was empty; there was no water in it.",
-            "jps1917": "and they took him, and cast him into the pit—and the pit was empty, there was no water in it."
-          },
+          "en": "and they took him, and cast him into the pit—and the pit was empty, there was no water in it.",
           "ref": "genesis 37:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": "Then they sat down to a meal. Looking up, they saw a caravan of Ishmaelites coming from Gilead, their camels bearing gum, balm, and ladanum to be taken to Egypt.",
-            "jps1917": "And they sat down to eat bread; and they lifted up their eyes and looked, and, behold, a caravan of Ishmaelites came from Gilead, with their camels bearing spicery and balm and ladanum, going to carry it down to Egypt."
-          },
+          "en": "And they sat down to eat bread; and they lifted up their eyes and looked, and, behold, a caravan of Ishmaelites came from Gilead, with their camels bearing spicery and balm and ladanum, going to carry it down to Egypt.",
           "ref": "genesis 37:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": "Then Judah said to his brothers, “What do we gain by killing our brother and covering up his blood?",
-            "jps1917": "And Judah said unto his brethren: ‘What profit is it if we slay our brother and conceal his blood?"
-          },
+          "en": "And Judah said unto his brethren: ‘What profit is it if we slay our brother and conceal his blood?",
           "ref": "genesis 37:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": "Come, let us sell him to the Ishmaelites, but let us not do away with him ourselves. After all, he is our brother, our own flesh.” His brothers agreed.",
-            "jps1917": "Come, and let us sell him to the Ishmaelites, and let not our hand be upon him; for he is our brother, our flesh.’ And his brethren hearkened unto him."
-          },
+          "en": "Come, and let us sell him to the Ishmaelites, and let not our hand be upon him; for he is our brother, our flesh.’ And his brethren hearkened unto him.",
           "ref": "genesis 37:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": "When Midianite traders passed by, they pulled Joseph up out of the pit. They sold Joseph for twenty pieces of silver to the Ishmaelites, who brought Joseph to Egypt.",
-            "jps1917": "And there passed by Midianites, merchantmen; and they drew and lifted up Joseph out of the pit, and sold Joseph to the Ishmaelites for twenty shekels of silver. And they brought Joseph into Egypt."
-          },
+          "en": "And there passed by Midianites, merchantmen; and they drew and lifted up Joseph out of the pit, and sold Joseph to the Ishmaelites for twenty shekels of silver. And they brought Joseph into Egypt.",
           "ref": "genesis 37:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": "When Reuben returned to the pit and saw that Joseph was not in the pit, he rent his clothes.",
-            "jps1917": "And Reuben returned unto the pit; and, behold, Joseph was not in the pit; and he rent his clothes."
-          },
+          "en": "And Reuben returned unto the pit; and, behold, Joseph was not in the pit; and he rent his clothes.",
           "ref": "genesis 37:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": "Returning to his brothers, he said, “The boy is gone! Now, what am I to do?”",
-            "jps1917": "And he returned unto his brethren, and said: ‘The child is not; and as for me, whither shall I go?’"
-          },
+          "en": "And he returned unto his brethren, and said: ‘The child is not; and as for me, whither shall I go?’",
           "ref": "genesis 37:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": "Then they took Joseph’s tunic, slaughtered a kid, and dipped the tunic in the blood.",
-            "jps1917": "And they took Joseph’s coat, and killed a he-goat, and dipped the coat in the blood;"
-          },
+          "en": "And they took Joseph’s coat, and killed a he-goat, and dipped the coat in the blood;",
           "ref": "genesis 37:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": "They had the ornamented tunic taken to their father, and they said, “We found this. Please examine it; is it your son’s tunic or not?”",
-            "jps1917": "and they sent the coat of many colours, and they brought it to their father; and said: ‘This have we found. Know now whether it is thy son’s coat or not.’"
-          },
+          "en": "and they sent the coat of many colours, and they brought it to their father; and said: ‘This have we found. Know now whether it is thy son’s coat or not.’",
           "ref": "genesis 37:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": "He recognized it, and said, “My son’s tunic! A savage beast devoured him! Joseph was torn by a beast!”",
-            "jps1917": "And he knew it, and said: ‘It is my son’s coat; an evil beast hath devoured him; Joseph is without doubt torn in pieces.’"
-          },
+          "en": "And he knew it, and said: ‘It is my son’s coat; an evil beast hath devoured him; Joseph is without doubt torn in pieces.’",
           "ref": "genesis 37:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": "Jacob rent his clothes, put sackcloth on his loins, and observed mourning for his son many days.",
-            "jps1917": "And Jacob rent his garments, and put sackcloth upon his loins, and mourned for his son many days."
-          },
+          "en": "And Jacob rent his garments, and put sackcloth upon his loins, and mourned for his son many days.",
           "ref": "genesis 37:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": "All his sons and daughters sought to comfort him; but he refused to be comforted, saying, “No, I will go down mourning to my son in Sheol.” Thus his father bewailed him.",
-            "jps1917": "And all his sons and all his daughters rose up to comfort him; but he refused to be comforted; and he said: ‘Nay, but I will go down to the grave to my son mourning.’ And his father wept for him."
-          },
+          "en": "And all his sons and all his daughters rose up to comfort him; but he refused to be comforted; and he said: ‘Nay, but I will go down to the grave to my son mourning.’ And his father wept for him.",
           "ref": "genesis 37:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": "The Midianites, meanwhile, sold him in Egypt to Potiphar, a courtier of Pharaoh and his prefect.",
-            "jps1917": "And the Midianites sold him into Egypt unto Potiphar, an officer of Pharaoh’s, the captain of the guard."
-          },
+          "en": "And the Midianites sold him into Egypt unto Potiphar, an officer of Pharaoh’s, the captain of the guard.",
           "ref": "genesis 37:36"
         }
       ]
@@ -9152,242 +5792,152 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass at that time, that Judah went down from his brethren, and turned in to a certain Adullamite, whose name was Hirah."
-          },
+          "en": "And it came to pass at that time, that Judah went down from his brethren, and turned in to a certain Adullamite, whose name was Hirah.",
           "ref": "genesis 38:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Judah saw there a daughter of a certain Canaanite whose name was Shua; and he took her, and went in unto her."
-          },
+          "en": "And Judah saw there a daughter of a certain Canaanite whose name was Shua; and he took her, and went in unto her.",
           "ref": "genesis 38:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And she conceived, and bore a son; and he called his name Er."
-          },
+          "en": "And she conceived, and bore a son; and he called his name Er.",
           "ref": "genesis 38:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And she conceived again, and bore a son; and she called his name Onan."
-          },
+          "en": "And she conceived again, and bore a son; and she called his name Onan.",
           "ref": "genesis 38:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And she yet again bore a son, and called his name Shelah; and he was at Chezib, when she bore him."
-          },
+          "en": "And she yet again bore a son, and called his name Shelah; and he was at Chezib, when she bore him.",
           "ref": "genesis 38:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Judah took a wife for Er his first-born, and her name was Tamar."
-          },
+          "en": "And Judah took a wife for Er his first-born, and her name was Tamar.",
           "ref": "genesis 38:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Er, Judah’s first-born, was wicked in the sight of the LORD; and the LORD slew him."
-          },
+          "en": "And Er, Judah’s first-born, was wicked in the sight of the LORD; and the LORD slew him.",
           "ref": "genesis 38:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Judah said unto Onan: ‘Go in unto thy brother’s wife, and perform the duty of a husband’s brother unto her, and raise up seed to thy brother.’"
-          },
+          "en": "And Judah said unto Onan: ‘Go in unto thy brother’s wife, and perform the duty of a husband’s brother unto her, and raise up seed to thy brother.’",
           "ref": "genesis 38:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And Onan knew that the seed would not be his; and it came to pass when he went in unto his brother’s wife, that he spilled it on the ground, lest he should give seed to his brother."
-          },
+          "en": "And Onan knew that the seed would not be his; and it came to pass when he went in unto his brother’s wife, that he spilled it on the ground, lest he should give seed to his brother.",
           "ref": "genesis 38:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And the thing which he did was evil in the sight of the LORD; and He slew him also."
-          },
+          "en": "And the thing which he did was evil in the sight of the LORD; and He slew him also.",
           "ref": "genesis 38:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "Then said Judah to Tamar his daughter-in-law: ‘Remain a widow in thy father’s house, till Shelah my son be grown up’; for he said: ‘Lest he also die, like his brethren.’ And Tamar went and dwelt in her father’s house."
-          },
+          "en": "Then said Judah to Tamar his daughter-in-law: ‘Remain a widow in thy father’s house, till Shelah my son be grown up’; for he said: ‘Lest he also die, like his brethren.’ And Tamar went and dwelt in her father’s house.",
           "ref": "genesis 38:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And in process of time Shua’s daughter, the wife of Judah, died; and Judah was comforted, and went up unto his sheep-shearers to Timnah, he and his friend Hirah the Adullamite."
-          },
+          "en": "And in process of time Shua’s daughter, the wife of Judah, died; and Judah was comforted, and went up unto his sheep-shearers to Timnah, he and his friend Hirah the Adullamite.",
           "ref": "genesis 38:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And it was told Tamar, saying: ‘Behold, thy father-in-law goeth up to Timnah to shear his sheep.’"
-          },
+          "en": "And it was told Tamar, saying: ‘Behold, thy father-in-law goeth up to Timnah to shear his sheep.’",
           "ref": "genesis 38:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And she put off from her the garments of her widowhood, and covered herself with her veil, and wrapped herself, and sat in the entrance of Enaim, which is by the way to Timnah; for she saw that Shelah was grown up, and she was not given unto him to wife."
-          },
+          "en": "And she put off from her the garments of her widowhood, and covered herself with her veil, and wrapped herself, and sat in the entrance of Enaim, which is by the way to Timnah; for she saw that Shelah was grown up, and she was not given unto him to wife.",
           "ref": "genesis 38:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "When Judah saw her, he thought her to be a harlot; for she had covered her face."
-          },
+          "en": "When Judah saw her, he thought her to be a harlot; for she had covered her face.",
           "ref": "genesis 38:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And he turned unto her by the way, and said: ‘Come, I pray thee, let me come in unto thee’; for he knew not that she was his daughter-in-law. And she said: ‘What wilt thou give me, that thou mayest come in unto me?’"
-          },
+          "en": "And he turned unto her by the way, and said: ‘Come, I pray thee, let me come in unto thee’; for he knew not that she was his daughter-in-law. And she said: ‘What wilt thou give me, that thou mayest come in unto me?’",
           "ref": "genesis 38:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘I will send thee a kid of the goats from the flock.’ And she said: ‘Wilt thou give me a pledge, till thou send it?’"
-          },
+          "en": "And he said: ‘I will send thee a kid of the goats from the flock.’ And she said: ‘Wilt thou give me a pledge, till thou send it?’",
           "ref": "genesis 38:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘What pledge shall I give thee?’ And she said: ‘Thy signet and thy cord, and thy staff that is in thy hand.’ And he gave them to her, and came in unto her, and she conceived by him."
-          },
+          "en": "And he said: ‘What pledge shall I give thee?’ And she said: ‘Thy signet and thy cord, and thy staff that is in thy hand.’ And he gave them to her, and came in unto her, and she conceived by him.",
           "ref": "genesis 38:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And she arose, and went away, and put off her veil from her, and put on the garments of her widowhood."
-          },
+          "en": "And she arose, and went away, and put off her veil from her, and put on the garments of her widowhood.",
           "ref": "genesis 38:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Judah sent the kid of the goats by the hand of his friend the Adullamite, to receive the pledge from the woman’s hand; but he found her not."
-          },
+          "en": "And Judah sent the kid of the goats by the hand of his friend the Adullamite, to receive the pledge from the woman’s hand; but he found her not.",
           "ref": "genesis 38:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "Then he asked the men of her place, saying: ‘Where is the harlot, that was at Enaim by the wayside?’ And they said: ‘There hath been no harlot here.’"
-          },
+          "en": "Then he asked the men of her place, saying: ‘Where is the harlot, that was at Enaim by the wayside?’ And they said: ‘There hath been no harlot here.’",
           "ref": "genesis 38:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And he returned to Judah, and said: ‘I have not found her; and also the men of the place said: There hath been no harlot here.’"
-          },
+          "en": "And he returned to Judah, and said: ‘I have not found her; and also the men of the place said: There hath been no harlot here.’",
           "ref": "genesis 38:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And Judah said: ‘Let her take it, lest we be put to shame; behold, I sent this kid, and thou hast not found her.’"
-          },
+          "en": "And Judah said: ‘Let her take it, lest we be put to shame; behold, I sent this kid, and thou hast not found her.’",
           "ref": "genesis 38:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass about three months after, that it was told Judah, saying: ‘Tamar thy daughter-in-law hath played the harlot; and moreover, behold, she is with child by harlotry.’ And Judah said: ‘Bring her forth, and let her be burnt.’"
-          },
+          "en": "And it came to pass about three months after, that it was told Judah, saying: ‘Tamar thy daughter-in-law hath played the harlot; and moreover, behold, she is with child by harlotry.’ And Judah said: ‘Bring her forth, and let her be burnt.’",
           "ref": "genesis 38:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "When she was brought forth, she sent to her father-in-law, saying: ‘By the man, whose these are, am I with child’; and she said: ‘Discern, I pray thee, whose are these, the signet, and the cords, and the staff.’"
-          },
+          "en": "When she was brought forth, she sent to her father-in-law, saying: ‘By the man, whose these are, am I with child’; and she said: ‘Discern, I pray thee, whose are these, the signet, and the cords, and the staff.’",
           "ref": "genesis 38:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And Judah acknowledged them, and said: ‘She is more righteous than I; forasmuch as I gave her not to Shelah my son.’ And he knew her again no more."
-          },
+          "en": "And Judah acknowledged them, and said: ‘She is more righteous than I; forasmuch as I gave her not to Shelah my son.’ And he knew her again no more.",
           "ref": "genesis 38:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass in the time of her travail, that, behold, twins were in her womb."
-          },
+          "en": "And it came to pass in the time of her travail, that, behold, twins were in her womb.",
           "ref": "genesis 38:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when she travailed, that one put out a hand; and the midwife took and bound upon his hand a scarlet thread, saying: ‘This came out first.’"
-          },
+          "en": "And it came to pass, when she travailed, that one put out a hand; and the midwife took and bound upon his hand a scarlet thread, saying: ‘This came out first.’",
           "ref": "genesis 38:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, as he drew back his hand, that, behold his brother came out; and she said: ‘Wherefore hast thou made a breach for thyself?’ Therefore his name was called Perez."
-          },
+          "en": "And it came to pass, as he drew back his hand, that, behold his brother came out; and she said: ‘Wherefore hast thou made a breach for thyself?’ Therefore his name was called Perez.",
           "ref": "genesis 38:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And afterward came out his brother, that had the scarlet thread upon his hand; and his name was called Zerah."
-          },
+          "en": "And afterward came out his brother, that had the scarlet thread upon his hand; and his name was called Zerah.",
           "ref": "genesis 38:30"
         }
       ]
@@ -9397,186 +5947,117 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph was brought down to Egypt; and Potiphar, an officer of Pharaoh’s, the captain of the guard, an Egyptian, bought him of the hand of the Ishmaelites, that had brought him down thither."
-          },
+          "en": "And Joseph was brought down to Egypt; and Potiphar, an officer of Pharaoh’s, the captain of the guard, an Egyptian, bought him of the hand of the Ishmaelites, that had brought him down thither.",
           "ref": "genesis 39:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And the LORD was with Joseph, and he was a prosperous man; and he was in the house of his master the Egyptian."
-          },
+          "en": "And the LORD was with Joseph, and he was a prosperous man; and he was in the house of his master the Egyptian.",
           "ref": "genesis 39:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And his master saw that the LORD was with him, and that the LORD made all that he did to prosper in his hand."
-          },
+          "en": "And his master saw that the LORD was with him, and that the LORD made all that he did to prosper in his hand.",
           "ref": "genesis 39:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph found favour in his sight, and he ministered unto him. And he appointed him overseer over his house, and all that he had he put into his hand."
-          },
+          "en": "And Joseph found favour in his sight, and he ministered unto him. And he appointed him overseer over his house, and all that he had he put into his hand.",
           "ref": "genesis 39:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass from the time that he appointed him overseer in his house, and over all that he had, that the LORD blessed the Egyptian’s house for Joseph’s sake; and the blessing of the LORD was upon all that he had, in the house and in the field."
-          },
+          "en": "And it came to pass from the time that he appointed him overseer in his house, and over all that he had, that the LORD blessed the Egyptian’s house for Joseph’s sake; and the blessing of the LORD was upon all that he had, in the house and in the field.",
           "ref": "genesis 39:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And he left all that he had in Joseph’s hand; and, having him, he knew not aught save the bread which he did eat. And Joseph was of beautiful form, and fair to look upon."
-          },
+          "en": "And he left all that he had in Joseph’s hand; and, having him, he knew not aught save the bread which he did eat. And Joseph was of beautiful form, and fair to look upon.",
           "ref": "genesis 39:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass after these things, that his master’s wife cast her eyes upon Joseph; and she said: ‘Lie with me.’"
-          },
+          "en": "And it came to pass after these things, that his master’s wife cast her eyes upon Joseph; and she said: ‘Lie with me.’",
           "ref": "genesis 39:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "But he refused, and said unto his master’s wife: ‘Behold, my master, having me, knoweth not what is in the house, and he hath put all that he hath into my hand;"
-          },
+          "en": "But he refused, and said unto his master’s wife: ‘Behold, my master, having me, knoweth not what is in the house, and he hath put all that he hath into my hand;",
           "ref": "genesis 39:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "he is not greater in this house than I; neither hath he kept back any thing from me but thee, because thou art his wife. How then can I do this great wickedness, and sin against God?’"
-          },
+          "en": "he is not greater in this house than I; neither hath he kept back any thing from me but thee, because thou art his wife. How then can I do this great wickedness, and sin against God?’",
           "ref": "genesis 39:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, as she spoke to Joseph day by day, that he hearkened not unto her, to lie by her, or to be with her."
-          },
+          "en": "And it came to pass, as she spoke to Joseph day by day, that he hearkened not unto her, to lie by her, or to be with her.",
           "ref": "genesis 39:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass on a certain day, when he went into the house to do his work, and there was none of the men of the house there within,"
-          },
+          "en": "And it came to pass on a certain day, when he went into the house to do his work, and there was none of the men of the house there within,",
           "ref": "genesis 39:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "that she caught him by his garment, saying: ‘Lie with me.’ And he left his garment in her hand, and fled, and got him out."
-          },
+          "en": "that she caught him by his garment, saying: ‘Lie with me.’ And he left his garment in her hand, and fled, and got him out.",
           "ref": "genesis 39:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when she saw that he had left his garment in her hand, and was fled forth,"
-          },
+          "en": "And it came to pass, when she saw that he had left his garment in her hand, and was fled forth,",
           "ref": "genesis 39:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "that she called unto the men of her house, and spoke unto them, saying: ‘See, he hath brought in a Hebrew unto us to mock us; he came in unto me to lie with me, and I cried with a loud voice."
-          },
+          "en": "that she called unto the men of her house, and spoke unto them, saying: ‘See, he hath brought in a Hebrew unto us to mock us; he came in unto me to lie with me, and I cried with a loud voice.",
           "ref": "genesis 39:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when he heard that I lifted up my voice and cried, that he left his garment by me, and fled, and got him out.’"
-          },
+          "en": "And it came to pass, when he heard that I lifted up my voice and cried, that he left his garment by me, and fled, and got him out.’",
           "ref": "genesis 39:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And she laid up his garment by her, until his master came home."
-          },
+          "en": "And she laid up his garment by her, until his master came home.",
           "ref": "genesis 39:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And she spoke unto him according to these words, saying: ‘The Hebrew servant, whom thou hast brought unto us, came in unto me to mock me."
-          },
+          "en": "And she spoke unto him according to these words, saying: ‘The Hebrew servant, whom thou hast brought unto us, came in unto me to mock me.",
           "ref": "genesis 39:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, as I lifted up my voice and cried, that he left his garment by me, and fled out.’"
-          },
+          "en": "And it came to pass, as I lifted up my voice and cried, that he left his garment by me, and fled out.’",
           "ref": "genesis 39:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when his master heard the words of his wife, which she spoke unto him, saying: ‘After this manner did thy servant to me’; that his wrath was kindled."
-          },
+          "en": "And it came to pass, when his master heard the words of his wife, which she spoke unto him, saying: ‘After this manner did thy servant to me’; that his wrath was kindled.",
           "ref": "genesis 39:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph’s master took him, and put him into the prison, the place where the king’s prisoners were bound; and he was there in the prison."
-          },
+          "en": "And Joseph’s master took him, and put him into the prison, the place where the king’s prisoners were bound; and he was there in the prison.",
           "ref": "genesis 39:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "But the LORD was with Joseph, and showed kindness unto him, and gave him favour in the sight of the keeper of the prison."
-          },
+          "en": "But the LORD was with Joseph, and showed kindness unto him, and gave him favour in the sight of the keeper of the prison.",
           "ref": "genesis 39:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And the keeper of the prison committed to Joseph’s hand all the prisoners that were in the prison; and whatsoever they did there, he was the doer of it."
-          },
+          "en": "And the keeper of the prison committed to Joseph’s hand all the prisoners that were in the prison; and whatsoever they did there, he was the doer of it.",
           "ref": "genesis 39:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "The keeper of the prison looked not to any thing that was under his hand, because the LORD was with him; and that which he did, the LORD made it to prosper."
-          },
+          "en": "The keeper of the prison looked not to any thing that was under his hand, because the LORD was with him; and that which he did, the LORD made it to prosper.",
           "ref": "genesis 39:23"
         }
       ]
@@ -9586,186 +6067,117 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass after these things, that the butler of the king of Egypt and his baker offended their lord the king of Egypt."
-          },
+          "en": "And it came to pass after these things, that the butler of the king of Egypt and his baker offended their lord the king of Egypt.",
           "ref": "genesis 40:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh was wroth against his two officers, against the chief of the butlers, and against the chief of the bakers."
-          },
+          "en": "And Pharaoh was wroth against his two officers, against the chief of the butlers, and against the chief of the bakers.",
           "ref": "genesis 40:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And he put them in ward in the house of the captain of the guard, into the prison, the place where Joseph was bound."
-          },
+          "en": "And he put them in ward in the house of the captain of the guard, into the prison, the place where Joseph was bound.",
           "ref": "genesis 40:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And the captain of the guard charged Joseph to be with them, and he ministered unto them; and they continued a season in ward."
-          },
+          "en": "And the captain of the guard charged Joseph to be with them, and he ministered unto them; and they continued a season in ward.",
           "ref": "genesis 40:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And they dreamed a dream both of them, each man his dream, in one night, each man according to the interpretation of his dream, the butler and the baker of the king of Egypt, who were bound in the prison."
-          },
+          "en": "And they dreamed a dream both of them, each man his dream, in one night, each man according to the interpretation of his dream, the butler and the baker of the king of Egypt, who were bound in the prison.",
           "ref": "genesis 40:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph came in unto them in the morning, and saw them, and, behold, they were sad."
-          },
+          "en": "And Joseph came in unto them in the morning, and saw them, and, behold, they were sad.",
           "ref": "genesis 40:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And he asked Pharaoh’s officers that were with him in the ward of his master’s house, saying: ‘Wherefore look ye so sad to-day?’"
-          },
+          "en": "And he asked Pharaoh’s officers that were with him in the ward of his master’s house, saying: ‘Wherefore look ye so sad to-day?’",
           "ref": "genesis 40:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said unto him: ‘We have dreamed a dream, and there is none that can interpret it.’ And Joseph said unto them: ‘Do not interpretations belong to God? tell it me, I pray you.’"
-          },
+          "en": "And they said unto him: ‘We have dreamed a dream, and there is none that can interpret it.’ And Joseph said unto them: ‘Do not interpretations belong to God? tell it me, I pray you.’",
           "ref": "genesis 40:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And the chief butler told his dream to Joseph, and said to him: ‘In my dream, behold, a vine was before me;"
-          },
+          "en": "And the chief butler told his dream to Joseph, and said to him: ‘In my dream, behold, a vine was before me;",
           "ref": "genesis 40:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "and in the vine were three branches; and as it was budding, its blossoms shot forth, and the clusters thereof brought forth ripe grapes,"
-          },
+          "en": "and in the vine were three branches; and as it was budding, its blossoms shot forth, and the clusters thereof brought forth ripe grapes,",
           "ref": "genesis 40:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "and Pharaoh’s cup was in my hand; and I took the grapes, and pressed them into Pharaoh’s cup, and I gave the cup into Pharaoh’s hand.’"
-          },
+          "en": "and Pharaoh’s cup was in my hand; and I took the grapes, and pressed them into Pharaoh’s cup, and I gave the cup into Pharaoh’s hand.’",
           "ref": "genesis 40:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph said unto him: ‘This is the interpretation of it: the three branches are three days;"
-          },
+          "en": "And Joseph said unto him: ‘This is the interpretation of it: the three branches are three days;",
           "ref": "genesis 40:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "within yet three days shall Pharaoh lift up thy head, and restore thee unto thine office; and thou shalt give Pharaoh’s cup into his hand, after the former manner when thou wast his butler."
-          },
+          "en": "within yet three days shall Pharaoh lift up thy head, and restore thee unto thine office; and thou shalt give Pharaoh’s cup into his hand, after the former manner when thou wast his butler.",
           "ref": "genesis 40:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "But have me in thy remembrance when it shall be well with thee, and show kindness, I pray thee, unto me, and make mention of me unto Pharaoh, and bring me out of this house."
-          },
+          "en": "But have me in thy remembrance when it shall be well with thee, and show kindness, I pray thee, unto me, and make mention of me unto Pharaoh, and bring me out of this house.",
           "ref": "genesis 40:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "For indeed I was stolen away out of the land of the Hebrews; and here also have I done nothing that they should put me into the dungeon.’"
-          },
+          "en": "For indeed I was stolen away out of the land of the Hebrews; and here also have I done nothing that they should put me into the dungeon.’",
           "ref": "genesis 40:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "When the chief baker saw that the interpretation was good, he said unto Joseph: ‘I also saw in my dream, and, behold, three baskets of white bread were on my head;"
-          },
+          "en": "When the chief baker saw that the interpretation was good, he said unto Joseph: ‘I also saw in my dream, and, behold, three baskets of white bread were on my head;",
           "ref": "genesis 40:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "and in the uppermost basket there was of all manner of baked food for Pharaoh; and the birds did eat them out of the basket upon my head.’"
-          },
+          "en": "and in the uppermost basket there was of all manner of baked food for Pharaoh; and the birds did eat them out of the basket upon my head.’",
           "ref": "genesis 40:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph answered and said: ‘This is the interpretation thereof: the three baskets are three days;"
-          },
+          "en": "And Joseph answered and said: ‘This is the interpretation thereof: the three baskets are three days;",
           "ref": "genesis 40:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "within yet three days shall Pharaoh lift up thy head from off thee, and shall hang thee on a tree; and the birds shall eat thy flesh from off thee.’"
-          },
+          "en": "within yet three days shall Pharaoh lift up thy head from off thee, and shall hang thee on a tree; and the birds shall eat thy flesh from off thee.’",
           "ref": "genesis 40:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass the third day, which was Pharaoh’s birthday, that he made a feast unto all his servants; and he lifted up the head of the chief butler and the head of the chief baker among his servants."
-          },
+          "en": "And it came to pass the third day, which was Pharaoh’s birthday, that he made a feast unto all his servants; and he lifted up the head of the chief butler and the head of the chief baker among his servants.",
           "ref": "genesis 40:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And he restored the chief butler back unto his butlership; and he gave the cup into Pharaoh’s hand."
-          },
+          "en": "And he restored the chief butler back unto his butlership; and he gave the cup into Pharaoh’s hand.",
           "ref": "genesis 40:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "But he hanged the chief baker, as Joseph had interpreted to them."
-          },
+          "en": "But he hanged the chief baker, as Joseph had interpreted to them.",
           "ref": "genesis 40:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "Yet did not the chief butler remember Joseph, but forgot him."
-          },
+          "en": "Yet did not the chief butler remember Joseph, but forgot him.",
           "ref": "genesis 40:23"
         }
       ]
@@ -9775,458 +6187,287 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass at the end of two full years, that Pharaoh dreamed: and, behold, he stood by the river."
-          },
+          "en": "And it came to pass at the end of two full years, that Pharaoh dreamed: and, behold, he stood by the river.",
           "ref": "genesis 41:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And, behold, there came up out of the river seven kine, well-favoured and fat-fleshed; and they fed in the reed-grass."
-          },
+          "en": "And, behold, there came up out of the river seven kine, well-favoured and fat-fleshed; and they fed in the reed-grass.",
           "ref": "genesis 41:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And, behold, seven other kine came up after them out of the river, ill favoured and lean-fleshed; and stood by the other kine upon the brink of the river."
-          },
+          "en": "And, behold, seven other kine came up after them out of the river, ill favoured and lean-fleshed; and stood by the other kine upon the brink of the river.",
           "ref": "genesis 41:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And the ill-favoured and lean-fleshed kine did eat up the seven well-favoured and fat kine. So Pharaoh awoke."
-          },
+          "en": "And the ill-favoured and lean-fleshed kine did eat up the seven well-favoured and fat kine. So Pharaoh awoke.",
           "ref": "genesis 41:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And he slept and dreamed a second time: and, behold, seven ears of corn came up upon one stalk, rank and good."
-          },
+          "en": "And he slept and dreamed a second time: and, behold, seven ears of corn came up upon one stalk, rank and good.",
           "ref": "genesis 41:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And, behold, seven ears, thin and blasted with the east wind, sprung up after them."
-          },
+          "en": "And, behold, seven ears, thin and blasted with the east wind, sprung up after them.",
           "ref": "genesis 41:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And the thin ears swallowed up the seven rank and full ears. And Pharaoh awoke, and, behold, it was a dream."
-          },
+          "en": "And the thin ears swallowed up the seven rank and full ears. And Pharaoh awoke, and, behold, it was a dream.",
           "ref": "genesis 41:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass in the morning that his spirit was troubled; and he sent and called for all the magicians of Egypt, and all the wise men thereof; and Pharaoh told them his dream; but there was none that could interpret them unto Pharaoh."
-          },
+          "en": "And it came to pass in the morning that his spirit was troubled; and he sent and called for all the magicians of Egypt, and all the wise men thereof; and Pharaoh told them his dream; but there was none that could interpret them unto Pharaoh.",
           "ref": "genesis 41:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "Then spoke the chief butler unto Pharaoh, saying: ‘I make mention of my faults this day:"
-          },
+          "en": "Then spoke the chief butler unto Pharaoh, saying: ‘I make mention of my faults this day:",
           "ref": "genesis 41:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "Pharaoh was wroth with his servants, and put me in the ward of the house of the captain of the guard, me and the chief baker."
-          },
+          "en": "Pharaoh was wroth with his servants, and put me in the ward of the house of the captain of the guard, me and the chief baker.",
           "ref": "genesis 41:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And we dreamed a dream in one night, I and he; we dreamed each man according to the interpretation of his dream."
-          },
+          "en": "And we dreamed a dream in one night, I and he; we dreamed each man according to the interpretation of his dream.",
           "ref": "genesis 41:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And there was with us there a young man, a Hebrew, servant to the captain of the guard; and we told him, and he interpreted to us our dreams; to each man according to his dream he did interpret."
-          },
+          "en": "And there was with us there a young man, a Hebrew, servant to the captain of the guard; and we told him, and he interpreted to us our dreams; to each man according to his dream he did interpret.",
           "ref": "genesis 41:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, as he interpreted to us, so it was: I was restored unto mine office, and he was hanged.’"
-          },
+          "en": "And it came to pass, as he interpreted to us, so it was: I was restored unto mine office, and he was hanged.’",
           "ref": "genesis 41:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Pharaoh sent and called Joseph, and they brought him hastily out of the dungeon. And he shaved himself, and changed his raiment, and came in unto Pharaoh."
-          },
+          "en": "Then Pharaoh sent and called Joseph, and they brought him hastily out of the dungeon. And he shaved himself, and changed his raiment, and came in unto Pharaoh.",
           "ref": "genesis 41:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh said unto Joseph: ‘I have dreamed a dream, and there is none that can interpret it; and I have heard say of thee, that when thou hearest a dream thou canst interpret it.’"
-          },
+          "en": "And Pharaoh said unto Joseph: ‘I have dreamed a dream, and there is none that can interpret it; and I have heard say of thee, that when thou hearest a dream thou canst interpret it.’",
           "ref": "genesis 41:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph answered Pharaoh, saying: ‘It is not in me; God will give Pharaoh an answer of peace.’"
-          },
+          "en": "And Joseph answered Pharaoh, saying: ‘It is not in me; God will give Pharaoh an answer of peace.’",
           "ref": "genesis 41:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh spoke unto Joseph: ‘In my dream, behold, I stood upon the brink of the river."
-          },
+          "en": "And Pharaoh spoke unto Joseph: ‘In my dream, behold, I stood upon the brink of the river.",
           "ref": "genesis 41:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And, behold, there came up out of the river seven kine, fat-fleshed and well-favoured; and they fed in the reedgrass."
-          },
+          "en": "And, behold, there came up out of the river seven kine, fat-fleshed and well-favoured; and they fed in the reedgrass.",
           "ref": "genesis 41:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And, behold, seven other kine came up after them, poor and very ill-favoured and lean-fleshed, such as I never saw in all the land of Egypt for badness."
-          },
+          "en": "And, behold, seven other kine came up after them, poor and very ill-favoured and lean-fleshed, such as I never saw in all the land of Egypt for badness.",
           "ref": "genesis 41:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And the lean and ill-favoured kine did eat up the first seven fat kine."
-          },
+          "en": "And the lean and ill-favoured kine did eat up the first seven fat kine.",
           "ref": "genesis 41:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And when they had eaten them up, it could not be known that they had eaten them; but they were still ill-favoured as at the beginning. So I awoke."
-          },
+          "en": "And when they had eaten them up, it could not be known that they had eaten them; but they were still ill-favoured as at the beginning. So I awoke.",
           "ref": "genesis 41:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And I saw in my dream, and, behold, seven ears came up upon one stalk, full and good."
-          },
+          "en": "And I saw in my dream, and, behold, seven ears came up upon one stalk, full and good.",
           "ref": "genesis 41:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And, behold, seven ears, withered, thin, and blasted with the east wind, sprung up after them."
-          },
+          "en": "And, behold, seven ears, withered, thin, and blasted with the east wind, sprung up after them.",
           "ref": "genesis 41:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And the thin ears swallowed up the seven good ears. And I told it unto the magicians; but there was none that could declare it to me.’"
-          },
+          "en": "And the thin ears swallowed up the seven good ears. And I told it unto the magicians; but there was none that could declare it to me.’",
           "ref": "genesis 41:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph said unto Pharaoh: ‘The dream of Pharaoh is one; what God is about to do He hath declared unto Pharaoh."
-          },
+          "en": "And Joseph said unto Pharaoh: ‘The dream of Pharaoh is one; what God is about to do He hath declared unto Pharaoh.",
           "ref": "genesis 41:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "The seven good kine are seven years; and the seven good ears are seven years: the dream is one."
-          },
+          "en": "The seven good kine are seven years; and the seven good ears are seven years: the dream is one.",
           "ref": "genesis 41:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And the seven lean and ill-favoured kine that came up after them are seven years, and also the seven empty ears blasted with the east wind; they shall be seven years of famine."
-          },
+          "en": "And the seven lean and ill-favoured kine that came up after them are seven years, and also the seven empty ears blasted with the east wind; they shall be seven years of famine.",
           "ref": "genesis 41:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "That is the thing which I spoke unto Pharaoh: what God is about to do He hath shown unto Pharaoh."
-          },
+          "en": "That is the thing which I spoke unto Pharaoh: what God is about to do He hath shown unto Pharaoh.",
           "ref": "genesis 41:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "Behold, there come seven years of great plenty throughout all the land of Egypt."
-          },
+          "en": "Behold, there come seven years of great plenty throughout all the land of Egypt.",
           "ref": "genesis 41:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And there shall arise after them seven years of famine; and all the plenty shall be forgotten in the land of Egypt; and the famine shall consume the land;"
-          },
+          "en": "And there shall arise after them seven years of famine; and all the plenty shall be forgotten in the land of Egypt; and the famine shall consume the land;",
           "ref": "genesis 41:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "and the plenty shall not be known in the land by reason of that famine which followeth; for it shall be very grievous."
-          },
+          "en": "and the plenty shall not be known in the land by reason of that famine which followeth; for it shall be very grievous.",
           "ref": "genesis 41:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And for that the dream was doubled unto Pharaoh twice, it is because the thing is established by God, and God will shortly bring it to pass."
-          },
+          "en": "And for that the dream was doubled unto Pharaoh twice, it is because the thing is established by God, and God will shortly bring it to pass.",
           "ref": "genesis 41:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "Now therefore let Pharaoh look out a man discreet and wise, and set him over the land of Egypt."
-          },
+          "en": "Now therefore let Pharaoh look out a man discreet and wise, and set him over the land of Egypt.",
           "ref": "genesis 41:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "Let Pharaoh do this, and let him appoint overseers over the land, and take up the fifth part of the land of Egypt in the seven years of plenty."
-          },
+          "en": "Let Pharaoh do this, and let him appoint overseers over the land, and take up the fifth part of the land of Egypt in the seven years of plenty.",
           "ref": "genesis 41:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And let them gather all the food of these good years that come, and lay up corn under the hand of Pharaoh for food in the cities, and let them keep it."
-          },
+          "en": "And let them gather all the food of these good years that come, and lay up corn under the hand of Pharaoh for food in the cities, and let them keep it.",
           "ref": "genesis 41:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "And the food shall be for a store to the land against the seven years of famine, which shall be in the land of Egypt; that the land perish not through the famine.’"
-          },
+          "en": "And the food shall be for a store to the land against the seven years of famine, which shall be in the land of Egypt; that the land perish not through the famine.’",
           "ref": "genesis 41:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": null,
-            "jps1917": "And the thing was good in the eyes of Pharaoh, and in the eyes of all his servants."
-          },
+          "en": "And the thing was good in the eyes of Pharaoh, and in the eyes of all his servants.",
           "ref": "genesis 41:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh said unto his servants: ‘Can we find such a one as this, a man in whom the spirit of God is?’"
-          },
+          "en": "And Pharaoh said unto his servants: ‘Can we find such a one as this, a man in whom the spirit of God is?’",
           "ref": "genesis 41:38"
         },
         {
           "n": 39,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh said unto Joseph: ‘Forasmuch as God hath shown thee all this, there is none so discreet and wise as thou."
-          },
+          "en": "And Pharaoh said unto Joseph: ‘Forasmuch as God hath shown thee all this, there is none so discreet and wise as thou.",
           "ref": "genesis 41:39"
         },
         {
           "n": 40,
-          "en": {
-            "sct": null,
-            "jps1917": "Thou shalt be over my house, and according unto thy word shall all my people be ruled; only in the throne will I be greater than thou.’"
-          },
+          "en": "Thou shalt be over my house, and according unto thy word shall all my people be ruled; only in the throne will I be greater than thou.’",
           "ref": "genesis 41:40"
         },
         {
           "n": 41,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh said unto Joseph: ‘See, I have set thee over all the land of Egypt.’"
-          },
+          "en": "And Pharaoh said unto Joseph: ‘See, I have set thee over all the land of Egypt.’",
           "ref": "genesis 41:41"
         },
         {
           "n": 42,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh took off his signet ring from his hand, and put it upon Joseph’s hand, and arrayed him in vestures of fine linen, and put a gold chain about his neck."
-          },
+          "en": "And Pharaoh took off his signet ring from his hand, and put it upon Joseph’s hand, and arrayed him in vestures of fine linen, and put a gold chain about his neck.",
           "ref": "genesis 41:42"
         },
         {
           "n": 43,
-          "en": {
-            "sct": null,
-            "jps1917": "And he made him to ride in the second chariot which he had; and they cried before him: ‘Abrech’; and he set him over all the land of Egypt."
-          },
+          "en": "And he made him to ride in the second chariot which he had; and they cried before him: ‘Abrech’; and he set him over all the land of Egypt.",
           "ref": "genesis 41:43"
         },
         {
           "n": 44,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh said unto Joseph: ‘I am Pharaoh, and without thee shall no man lift up his hand or his foot in all the land of Egypt.’"
-          },
+          "en": "And Pharaoh said unto Joseph: ‘I am Pharaoh, and without thee shall no man lift up his hand or his foot in all the land of Egypt.’",
           "ref": "genesis 41:44"
         },
         {
           "n": 45,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh called Joseph’s name Zaphenath-paneah; and he gave him to wife Asenath the daughter of Poti-phera priest of On. And Joseph went out over the land of Egypt.—"
-          },
+          "en": "And Pharaoh called Joseph’s name Zaphenath-paneah; and he gave him to wife Asenath the daughter of Poti-phera priest of On. And Joseph went out over the land of Egypt.—",
           "ref": "genesis 41:45"
         },
         {
           "n": 46,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph was thirty years old when he stood before Pharaoh king of Egypt.—And Joseph went out from the presence of Pharaoh, and went throughout all the land of Egypt."
-          },
+          "en": "And Joseph was thirty years old when he stood before Pharaoh king of Egypt.—And Joseph went out from the presence of Pharaoh, and went throughout all the land of Egypt.",
           "ref": "genesis 41:46"
         },
         {
           "n": 47,
-          "en": {
-            "sct": null,
-            "jps1917": "And in the seven years of plenty the earth brought forth in heaps."
-          },
+          "en": "And in the seven years of plenty the earth brought forth in heaps.",
           "ref": "genesis 41:47"
         },
         {
           "n": 48,
-          "en": {
-            "sct": null,
-            "jps1917": "And he gathered up all the food of the seven years which were in the land of Egypt, and laid up the food in the cities; the food of the field, which was round about every city, laid he up in the same."
-          },
+          "en": "And he gathered up all the food of the seven years which were in the land of Egypt, and laid up the food in the cities; the food of the field, which was round about every city, laid he up in the same.",
           "ref": "genesis 41:48"
         },
         {
           "n": 49,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph laid up corn as the sand of the sea, very much, until they left off numbering; for it was without number."
-          },
+          "en": "And Joseph laid up corn as the sand of the sea, very much, until they left off numbering; for it was without number.",
           "ref": "genesis 41:49"
         },
         {
           "n": 50,
-          "en": {
-            "sct": null,
-            "jps1917": "And unto Joseph were born two sons before the year of famine came, whom Asenath the daughter of Poti-phera priest of On bore unto him."
-          },
+          "en": "And unto Joseph were born two sons before the year of famine came, whom Asenath the daughter of Poti-phera priest of On bore unto him.",
           "ref": "genesis 41:50"
         },
         {
           "n": 51,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph called the name of the first-born Manasseh: ‘for God hath made me forget all my toil, and all my father’s house.’"
-          },
+          "en": "And Joseph called the name of the first-born Manasseh: ‘for God hath made me forget all my toil, and all my father’s house.’",
           "ref": "genesis 41:51"
         },
         {
           "n": 52,
-          "en": {
-            "sct": null,
-            "jps1917": "And the name of the second called he Ephraim: ‘for God hath made me fruitful in the land of my affliction.’"
-          },
+          "en": "And the name of the second called he Ephraim: ‘for God hath made me fruitful in the land of my affliction.’",
           "ref": "genesis 41:52"
         },
         {
           "n": 53,
-          "en": {
-            "sct": null,
-            "jps1917": "And the seven years of plenty, that was in the land of Egypt, came to an end."
-          },
+          "en": "And the seven years of plenty, that was in the land of Egypt, came to an end.",
           "ref": "genesis 41:53"
         },
         {
           "n": 54,
-          "en": {
-            "sct": null,
-            "jps1917": "And the seven years of famine began to come, according as Joseph had said; and there was famine in all lands; but in all the land of Egypt there was bread."
-          },
+          "en": "And the seven years of famine began to come, according as Joseph had said; and there was famine in all lands; but in all the land of Egypt there was bread.",
           "ref": "genesis 41:54"
         },
         {
           "n": 55,
-          "en": {
-            "sct": null,
-            "jps1917": "And when all the land of Egypt was famished, the people cried to Pharaoh for bread; and Pharaoh said unto all the Egyptians: ‘Go unto Joseph; what he saith to you, do.’"
-          },
+          "en": "And when all the land of Egypt was famished, the people cried to Pharaoh for bread; and Pharaoh said unto all the Egyptians: ‘Go unto Joseph; what he saith to you, do.’",
           "ref": "genesis 41:55"
         },
         {
           "n": 56,
-          "en": {
-            "sct": null,
-            "jps1917": "And the famine was over all the face of the earth; and Joseph opened all the storehouses, and sold unto the Egyptians; and the famine was sore in the land of Egypt."
-          },
+          "en": "And the famine was over all the face of the earth; and Joseph opened all the storehouses, and sold unto the Egyptians; and the famine was sore in the land of Egypt.",
           "ref": "genesis 41:56"
         },
         {
           "n": 57,
-          "en": {
-            "sct": null,
-            "jps1917": "And all countries came into Egypt to Joseph to buy corn; because the famine was sore in all the earth."
-          },
+          "en": "And all countries came into Egypt to Joseph to buy corn; because the famine was sore in all the earth.",
           "ref": "genesis 41:57"
         }
       ]
@@ -10236,306 +6477,192 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "Now Jacob saw that there was corn in Egypt, and Jacob said unto his sons: ‘Why do ye look one upon another?’"
-          },
+          "en": "Now Jacob saw that there was corn in Egypt, and Jacob said unto his sons: ‘Why do ye look one upon another?’",
           "ref": "genesis 42:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Behold, I have heard that there is corn in Egypt. Get you down thither, and buy for us from thence; that we may live, and not die.’"
-          },
+          "en": "And he said: ‘Behold, I have heard that there is corn in Egypt. Get you down thither, and buy for us from thence; that we may live, and not die.’",
           "ref": "genesis 42:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph’s ten brethren went down to buy corn from Egypt."
-          },
+          "en": "And Joseph’s ten brethren went down to buy corn from Egypt.",
           "ref": "genesis 42:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "But Benjamin, Joseph’s brother, Jacob sent not with his brethren; for he said: ‘Lest peradventure harm befall him.’"
-          },
+          "en": "But Benjamin, Joseph’s brother, Jacob sent not with his brethren; for he said: ‘Lest peradventure harm befall him.’",
           "ref": "genesis 42:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Israel came to buy among those that came; for the famine was in the land of Caanan."
-          },
+          "en": "And the sons of Israel came to buy among those that came; for the famine was in the land of Caanan.",
           "ref": "genesis 42:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph was the governor over the land; he it was that sold to all the people of the land. And Joseph’s brethren came, and bowed down to him with their faces to the earth."
-          },
+          "en": "And Joseph was the governor over the land; he it was that sold to all the people of the land. And Joseph’s brethren came, and bowed down to him with their faces to the earth.",
           "ref": "genesis 42:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph saw his brethren, and he knew them, but made himself strange unto them, and spoke roughly with them; and he said unto them: ‘Whence come ye?’ And they said: ‘From the land of Canaan to buy food.’"
-          },
+          "en": "And Joseph saw his brethren, and he knew them, but made himself strange unto them, and spoke roughly with them; and he said unto them: ‘Whence come ye?’ And they said: ‘From the land of Canaan to buy food.’",
           "ref": "genesis 42:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph knew his brethren, but they knew him not."
-          },
+          "en": "And Joseph knew his brethren, but they knew him not.",
           "ref": "genesis 42:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph remembered the dreams which he dreamed of them, and said unto them: ‘Ye are spies; to see the nakedness of the land ye are come.’"
-          },
+          "en": "And Joseph remembered the dreams which he dreamed of them, and said unto them: ‘Ye are spies; to see the nakedness of the land ye are come.’",
           "ref": "genesis 42:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said unto him: ‘Nay, my lord, but to buy food are thy servants come."
-          },
+          "en": "And they said unto him: ‘Nay, my lord, but to buy food are thy servants come.",
           "ref": "genesis 42:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "We are all one man’s sons; we are upright men, thy servants are no spies.’"
-          },
+          "en": "We are all one man’s sons; we are upright men, thy servants are no spies.’",
           "ref": "genesis 42:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto them: ‘Nay, but to see the nakedness of the land ye are come.’"
-          },
+          "en": "And he said unto them: ‘Nay, but to see the nakedness of the land ye are come.’",
           "ref": "genesis 42:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said: ‘We thy servants are twelve brethren, the sons of one man in the land of Canaan; and, behold, the youngest is this day with our father, and one is not.’"
-          },
+          "en": "And they said: ‘We thy servants are twelve brethren, the sons of one man in the land of Canaan; and, behold, the youngest is this day with our father, and one is not.’",
           "ref": "genesis 42:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph said unto them: ‘That is it that I spoke unto you, saying: Ye are spies."
-          },
+          "en": "And Joseph said unto them: ‘That is it that I spoke unto you, saying: Ye are spies.",
           "ref": "genesis 42:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "Hereby ye shall be proved, as Pharaoh liveth, ye shall not go forth hence, except your youngest brother come hither."
-          },
+          "en": "Hereby ye shall be proved, as Pharaoh liveth, ye shall not go forth hence, except your youngest brother come hither.",
           "ref": "genesis 42:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "Send one of you, and let him fetch your brother, and ye shall be bound, that your words may be proved, whether there be truth in you; or else, as Pharaoh liveth, surely ye are spies.’"
-          },
+          "en": "Send one of you, and let him fetch your brother, and ye shall be bound, that your words may be proved, whether there be truth in you; or else, as Pharaoh liveth, surely ye are spies.’",
           "ref": "genesis 42:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And he put them all together into ward three days."
-          },
+          "en": "And he put them all together into ward three days.",
           "ref": "genesis 42:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph said unto them the third day.’ This do, and live; for I fear God:"
-          },
+          "en": "And Joseph said unto them the third day.’ This do, and live; for I fear God:",
           "ref": "genesis 42:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "if ye be upright men, let one of your brethren be bound in your prison-house; but go ye, carry corn for the famine of your houses;"
-          },
+          "en": "if ye be upright men, let one of your brethren be bound in your prison-house; but go ye, carry corn for the famine of your houses;",
           "ref": "genesis 42:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "and bring your youngest brother unto me; so shall your words be verified, and ye shall not die.’ And they did so."
-          },
+          "en": "and bring your youngest brother unto me; so shall your words be verified, and ye shall not die.’ And they did so.",
           "ref": "genesis 42:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said one to another: ‘We are verily guilty concerning our brother, in that we saw the distress of his soul, when he besought us, and we would not hear; therefore is this distress come upon us.’"
-          },
+          "en": "And they said one to another: ‘We are verily guilty concerning our brother, in that we saw the distress of his soul, when he besought us, and we would not hear; therefore is this distress come upon us.’",
           "ref": "genesis 42:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And Reuben answered them, saying: ‘Spoke I not unto you, saying: Do not sin against the child; and ye would not hear? therefore also, behold, his blood is required.’"
-          },
+          "en": "And Reuben answered them, saying: ‘Spoke I not unto you, saying: Do not sin against the child; and ye would not hear? therefore also, behold, his blood is required.’",
           "ref": "genesis 42:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And they knew not that Joseph understood them; for the interpreter was between them."
-          },
+          "en": "And they knew not that Joseph understood them; for the interpreter was between them.",
           "ref": "genesis 42:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And he turned himself about from them, and wept; and he returned to them, and spoke to them, and took Simeon from among them, and bound him before their eyes."
-          },
+          "en": "And he turned himself about from them, and wept; and he returned to them, and spoke to them, and took Simeon from among them, and bound him before their eyes.",
           "ref": "genesis 42:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Joseph commanded to fill their vessels with corn, and to restore every man’s money into his sack, and to give them provision for the way; and thus was it done unto them."
-          },
+          "en": "Then Joseph commanded to fill their vessels with corn, and to restore every man’s money into his sack, and to give them provision for the way; and thus was it done unto them.",
           "ref": "genesis 42:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And they laded their asses with their corn, and departed thence."
-          },
+          "en": "And they laded their asses with their corn, and departed thence.",
           "ref": "genesis 42:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And as one of them opened his sack to give his ass provender in the lodging-place, he espied his money; and, behold, it was in the mouth of his sack."
-          },
+          "en": "And as one of them opened his sack to give his ass provender in the lodging-place, he espied his money; and, behold, it was in the mouth of his sack.",
           "ref": "genesis 42:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said unto his brethren: ‘My money is restored; and, lo, it is even in my sack.’ And their heart failed them, and they turned trembling one to another, saying: ‘What is this that God hath done unto us?’"
-          },
+          "en": "And he said unto his brethren: ‘My money is restored; and, lo, it is even in my sack.’ And their heart failed them, and they turned trembling one to another, saying: ‘What is this that God hath done unto us?’",
           "ref": "genesis 42:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And they came unto Jacob their father unto the land of Canaan, and told him all that had befallen them, saying:"
-          },
+          "en": "And they came unto Jacob their father unto the land of Canaan, and told him all that had befallen them, saying:",
           "ref": "genesis 42:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "’The man, the lord of the land, spoke roughly with us, and took us for spies of the country."
-          },
+          "en": "’The man, the lord of the land, spoke roughly with us, and took us for spies of the country.",
           "ref": "genesis 42:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And we said unto him: We are upright men; we are no spies."
-          },
+          "en": "And we said unto him: We are upright men; we are no spies.",
           "ref": "genesis 42:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "We are twelve brethren, sons of our father; one is not, and the youngest is this day with our father in the land of Canaan. ."
-          },
+          "en": "We are twelve brethren, sons of our father; one is not, and the youngest is this day with our father in the land of Canaan. .",
           "ref": "genesis 42:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And the man, the lord of the land, said unto us: Hereby shall I know that ye are upright men: leave one of your brethren with me, and take corn for the famine of your houses, and go your way."
-          },
+          "en": "And the man, the lord of the land, said unto us: Hereby shall I know that ye are upright men: leave one of your brethren with me, and take corn for the famine of your houses, and go your way.",
           "ref": "genesis 42:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And bring your youngest brother unto me; then shall I know that ye are no spies, but that ye are upright men; so will I deliver you your brother, and ye shall traffic in the land.’"
-          },
+          "en": "And bring your youngest brother unto me; then shall I know that ye are no spies, but that ye are upright men; so will I deliver you your brother, and ye shall traffic in the land.’",
           "ref": "genesis 42:34"
         },
         {
           "n": 35,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass as they emptied their sacks, that, behold, every man’s bundle of money was in his sack; and when they and their father saw their bundles of money, they were afraid."
-          },
+          "en": "And it came to pass as they emptied their sacks, that, behold, every man’s bundle of money was in his sack; and when they and their father saw their bundles of money, they were afraid.",
           "ref": "genesis 42:35"
         },
         {
           "n": 36,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob their father said unto them: ‘Me have ye bereaved of my children: Joseph is not, and Simeon is not, and ye will take Benjamin away; upon me are all these things come.’"
-          },
+          "en": "And Jacob their father said unto them: ‘Me have ye bereaved of my children: Joseph is not, and Simeon is not, and ye will take Benjamin away; upon me are all these things come.’",
           "ref": "genesis 42:36"
         },
         {
           "n": 37,
-          "en": {
-            "sct": null,
-            "jps1917": "And Reuben spoke unto his father, saying: ‘Thou shalt slay my two sons, if I bring him not to thee; deliver him into my hand, and I will bring him back to thee.’"
-          },
+          "en": "And Reuben spoke unto his father, saying: ‘Thou shalt slay my two sons, if I bring him not to thee; deliver him into my hand, and I will bring him back to thee.’",
           "ref": "genesis 42:37"
         },
         {
           "n": 38,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘My son shall not go down with you; for his brother is dead, and he only is left; if harm befall him by the way in which ye go, then will ye bring down my gray hairs with sorrow to the grave."
-          },
+          "en": "And he said: ‘My son shall not go down with you; for his brother is dead, and he only is left; if harm befall him by the way in which ye go, then will ye bring down my gray hairs with sorrow to the grave.",
           "ref": "genesis 42:38"
         }
       ]
@@ -10545,274 +6672,172 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And the famine was sore in the land."
-          },
+          "en": "And the famine was sore in the land.",
           "ref": "genesis 43:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when they had eaten up the corn which they had brought out of Egypt, that their father said unto them: ‘Go again, buy us a little food.’"
-          },
+          "en": "And it came to pass, when they had eaten up the corn which they had brought out of Egypt, that their father said unto them: ‘Go again, buy us a little food.’",
           "ref": "genesis 43:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Judah spoke unto him, saying: ‘The man did earnestly forewarn us, saying: Ye shall not see my face, except your brother be with you."
-          },
+          "en": "And Judah spoke unto him, saying: ‘The man did earnestly forewarn us, saying: Ye shall not see my face, except your brother be with you.",
           "ref": "genesis 43:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "If thou wilt send our brother with us, we will go down and buy thee food;"
-          },
+          "en": "If thou wilt send our brother with us, we will go down and buy thee food;",
           "ref": "genesis 43:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "but if thou wilt not send him, we will not go down, for the man said unto us: Ye shall not see my face, except your brother be with you.’"
-          },
+          "en": "but if thou wilt not send him, we will not go down, for the man said unto us: Ye shall not see my face, except your brother be with you.’",
           "ref": "genesis 43:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Israel said: ‘Wherefore dealt ye so ill with me, as to tell the man whether ye had yet a brother?’"
-          },
+          "en": "And Israel said: ‘Wherefore dealt ye so ill with me, as to tell the man whether ye had yet a brother?’",
           "ref": "genesis 43:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said: ‘The man asked straitly concerning ourselves, and concerning our kindred, saying: Is your father yet alive? have ye another brother? and we told him according to the tenor of these words; could we in any wise know that he would say: Bring your brother down?’"
-          },
+          "en": "And they said: ‘The man asked straitly concerning ourselves, and concerning our kindred, saying: Is your father yet alive? have ye another brother? and we told him according to the tenor of these words; could we in any wise know that he would say: Bring your brother down?’",
           "ref": "genesis 43:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Judah said unto Israel his father: ‘Send the lad with me, and we will arise and go, that we may live, and not die, both we, and thou, and also our little ones."
-          },
+          "en": "And Judah said unto Israel his father: ‘Send the lad with me, and we will arise and go, that we may live, and not die, both we, and thou, and also our little ones.",
           "ref": "genesis 43:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "I will be surety for him; of my hand shalt thou require him; if I bring him not unto thee, and set him before thee, then let me bear the blame for ever."
-          },
+          "en": "I will be surety for him; of my hand shalt thou require him; if I bring him not unto thee, and set him before thee, then let me bear the blame for ever.",
           "ref": "genesis 43:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "For except we had lingered, surely we had now returned a second time.’"
-          },
+          "en": "For except we had lingered, surely we had now returned a second time.’",
           "ref": "genesis 43:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And their father Israel said unto them: ‘If it be so now, do this: take of the choice fruits of the land in your vessels, and carry down the man a present, a little balm, and a little honey, spicery and ladanum, nuts, and almonds;"
-          },
+          "en": "And their father Israel said unto them: ‘If it be so now, do this: take of the choice fruits of the land in your vessels, and carry down the man a present, a little balm, and a little honey, spicery and ladanum, nuts, and almonds;",
           "ref": "genesis 43:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "and take double money in your hand; and the money that was returned in the mouth of your sacks carry back in your hand; peradventure it was an oversight;"
-          },
+          "en": "and take double money in your hand; and the money that was returned in the mouth of your sacks carry back in your hand; peradventure it was an oversight;",
           "ref": "genesis 43:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "take also your brother, and arise, go again unto the man;"
-          },
+          "en": "take also your brother, and arise, go again unto the man;",
           "ref": "genesis 43:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "and God Almighty give you mercy before the man, that he may release unto you your other brother and Benjamin. And as for me, if I be bereaved of my children, I am bereaved.’"
-          },
+          "en": "and God Almighty give you mercy before the man, that he may release unto you your other brother and Benjamin. And as for me, if I be bereaved of my children, I am bereaved.’",
           "ref": "genesis 43:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And the men took that present, and they took double money in their hand, and Benjamin; and rose up, and went down to Egypt, and stood before Joseph."
-          },
+          "en": "And the men took that present, and they took double money in their hand, and Benjamin; and rose up, and went down to Egypt, and stood before Joseph.",
           "ref": "genesis 43:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Joseph saw Benjamin with them, he said to the steward of his house: ‘Bring the men into the house, and kill the beasts, and prepare the meat; for the men shall dine with me at noon.’"
-          },
+          "en": "And when Joseph saw Benjamin with them, he said to the steward of his house: ‘Bring the men into the house, and kill the beasts, and prepare the meat; for the men shall dine with me at noon.’",
           "ref": "genesis 43:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And the man did as Joseph bade; and the man brought the men into Joseph’s house."
-          },
+          "en": "And the man did as Joseph bade; and the man brought the men into Joseph’s house.",
           "ref": "genesis 43:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And the men were afraid, because they were brought into Joseph’s house; and they said: ‘Because of the money that was returned in our sacks at the first time are we brought in; that he may seek occasion against us, and fall upon us, and take us for bondmen, and our asses.’"
-          },
+          "en": "And the men were afraid, because they were brought into Joseph’s house; and they said: ‘Because of the money that was returned in our sacks at the first time are we brought in; that he may seek occasion against us, and fall upon us, and take us for bondmen, and our asses.’",
           "ref": "genesis 43:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And they came near to the steward of Joseph’s house, and they spoke unto him at the door of the house,"
-          },
+          "en": "And they came near to the steward of Joseph’s house, and they spoke unto him at the door of the house,",
           "ref": "genesis 43:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "and said: ‘Oh my lord, we came indeed down at the first time to buy food."
-          },
+          "en": "and said: ‘Oh my lord, we came indeed down at the first time to buy food.",
           "ref": "genesis 43:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass, when we came to the lodging-place, that we opened our sacks, and, behold, every man’s money was in the mouth of his sack, our money in full weight; and we have brought it back in our hand."
-          },
+          "en": "And it came to pass, when we came to the lodging-place, that we opened our sacks, and, behold, every man’s money was in the mouth of his sack, our money in full weight; and we have brought it back in our hand.",
           "ref": "genesis 43:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And other money have we brought down in our hand to buy food. We know not who put our money in our sacks.’"
-          },
+          "en": "And other money have we brought down in our hand to buy food. We know not who put our money in our sacks.’",
           "ref": "genesis 43:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Peace be to you, fear not; your God, and the God of your father, hath given you treasure in your sacks; I had your money.’ And he brought Simeon out unto them."
-          },
+          "en": "And he said: ‘Peace be to you, fear not; your God, and the God of your father, hath given you treasure in your sacks; I had your money.’ And he brought Simeon out unto them.",
           "ref": "genesis 43:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And the man brought the men into Joseph’s house, and gave them water, and they washed their feet; and he gave their asses provender."
-          },
+          "en": "And the man brought the men into Joseph’s house, and gave them water, and they washed their feet; and he gave their asses provender.",
           "ref": "genesis 43:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And they made ready the present against Joseph’s coming at noon; for they heard that they should eat bread there."
-          },
+          "en": "And they made ready the present against Joseph’s coming at noon; for they heard that they should eat bread there.",
           "ref": "genesis 43:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Joseph came home, they brought him the present which was in their hand into the house, and bowed down to him to the earth."
-          },
+          "en": "And when Joseph came home, they brought him the present which was in their hand into the house, and bowed down to him to the earth.",
           "ref": "genesis 43:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And he asked them of their welfare, and said: ‘Is your father well, the old man of whom ye spoke? Is he yet alive?’"
-          },
+          "en": "And he asked them of their welfare, and said: ‘Is your father well, the old man of whom ye spoke? Is he yet alive?’",
           "ref": "genesis 43:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said: ‘Thy servant our father is well, he is yet alive.’ And they bowed the head, and made obeisance."
-          },
+          "en": "And they said: ‘Thy servant our father is well, he is yet alive.’ And they bowed the head, and made obeisance.",
           "ref": "genesis 43:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And he lifted up his eyes, and saw Benjamin his brother, his mother’s son, and said: ‘Is this your youngest brother of whom ye spoke unto me?’ And he said: ‘God be gracious unto thee, my son.’"
-          },
+          "en": "And he lifted up his eyes, and saw Benjamin his brother, his mother’s son, and said: ‘Is this your youngest brother of whom ye spoke unto me?’ And he said: ‘God be gracious unto thee, my son.’",
           "ref": "genesis 43:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph made haste; for his heart yearned toward his brother; and he sought where to weep; and he entered into his chamber, and wept there."
-          },
+          "en": "And Joseph made haste; for his heart yearned toward his brother; and he sought where to weep; and he entered into his chamber, and wept there.",
           "ref": "genesis 43:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And he washed his face, and came out; and he refrained himself, and said: ‘Set on bread.’"
-          },
+          "en": "And he washed his face, and came out; and he refrained himself, and said: ‘Set on bread.’",
           "ref": "genesis 43:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "And they set on for him by himself, and for them by themselves, and for the Egyptians, that did eat with him, by themselves; because the Egyptians might not eat bread with the Hebrews; for that is an abomination unto the Egyptians."
-          },
+          "en": "And they set on for him by himself, and for them by themselves, and for the Egyptians, that did eat with him, by themselves; because the Egyptians might not eat bread with the Hebrews; for that is an abomination unto the Egyptians.",
           "ref": "genesis 43:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And they sat before him, the firstborn according to his birthright, and the youngest according to his youth; and the men marvelled one with another."
-          },
+          "en": "And they sat before him, the firstborn according to his birthright, and the youngest according to his youth; and the men marvelled one with another.",
           "ref": "genesis 43:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "And portions were taken unto them from before him; but Benjamin’s portion was five times so much as any of theirs. And they drank, and were merry with him."
-          },
+          "en": "And portions were taken unto them from before him; but Benjamin’s portion was five times so much as any of theirs. And they drank, and were merry with him.",
           "ref": "genesis 43:34"
         }
       ]
@@ -10822,274 +6847,172 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And he commanded the steward of his house, saying: ‘Fill the men’s sacks with food, as much as they can carry, and put every man’s money in his sack’s mouth."
-          },
+          "en": "And he commanded the steward of his house, saying: ‘Fill the men’s sacks with food, as much as they can carry, and put every man’s money in his sack’s mouth.",
           "ref": "genesis 44:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And put my goblet, the silver goblet, in the sack’s mouth of the youngest, and his corn money.’ And he did according to the word that Joseph had spoken."
-          },
+          "en": "And put my goblet, the silver goblet, in the sack’s mouth of the youngest, and his corn money.’ And he did according to the word that Joseph had spoken.",
           "ref": "genesis 44:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "As soon as the morning was light, the men were sent away, they and their asses."
-          },
+          "en": "As soon as the morning was light, the men were sent away, they and their asses.",
           "ref": "genesis 44:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And when they were gone out of the city, and were not yet far off, Joseph said unto his steward: ‘Up, follow after the men; and when thou dost overtake them, say unto them: Wherefore have ye rewarded evil for good?"
-          },
+          "en": "And when they were gone out of the city, and were not yet far off, Joseph said unto his steward: ‘Up, follow after the men; and when thou dost overtake them, say unto them: Wherefore have ye rewarded evil for good?",
           "ref": "genesis 44:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "Is not this it in which my lord drinketh, and whereby he indeed divineth? ye have done evil in so doing.’"
-          },
+          "en": "Is not this it in which my lord drinketh, and whereby he indeed divineth? ye have done evil in so doing.’",
           "ref": "genesis 44:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And he overtook them, and he spoke unto them these words."
-          },
+          "en": "And he overtook them, and he spoke unto them these words.",
           "ref": "genesis 44:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said unto him: ‘Wherefore speaketh my lord such words as these? Far be it from thy servants that they should do such a thing."
-          },
+          "en": "And they said unto him: ‘Wherefore speaketh my lord such words as these? Far be it from thy servants that they should do such a thing.",
           "ref": "genesis 44:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "Behold, the money, which we found in our sacks’mouths, we brought back unto thee out of the land of Canaan; how then should we steal out of thy lord’s house silver or gold?"
-          },
+          "en": "Behold, the money, which we found in our sacks’mouths, we brought back unto thee out of the land of Canaan; how then should we steal out of thy lord’s house silver or gold?",
           "ref": "genesis 44:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "With whomsoever of thy servants it be found, let him die, and we also will be my lord’s bondmen.’"
-          },
+          "en": "With whomsoever of thy servants it be found, let him die, and we also will be my lord’s bondmen.’",
           "ref": "genesis 44:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Now also let it be according unto your words: he with whom it is found shall be my bondman; and ye shall be blameless.’"
-          },
+          "en": "And he said: ‘Now also let it be according unto your words: he with whom it is found shall be my bondman; and ye shall be blameless.’",
           "ref": "genesis 44:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "Then they hastened, and took down every man his sack to the ground, and opened every man his sack."
-          },
+          "en": "Then they hastened, and took down every man his sack to the ground, and opened every man his sack.",
           "ref": "genesis 44:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And he searched, beginning at the eldest, and leaving off at the youngest; and the goblet was found in Benjamin’s sack."
-          },
+          "en": "And he searched, beginning at the eldest, and leaving off at the youngest; and the goblet was found in Benjamin’s sack.",
           "ref": "genesis 44:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And they rent their clothes, and laded every man his ass, and returned to the city."
-          },
+          "en": "And they rent their clothes, and laded every man his ass, and returned to the city.",
           "ref": "genesis 44:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And Judah and his brethren came to Joseph’s house, and he was yet there; and they fell before him on the ground."
-          },
+          "en": "And Judah and his brethren came to Joseph’s house, and he was yet there; and they fell before him on the ground.",
           "ref": "genesis 44:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph said unto them: ‘What deed is this that ye have done? know ye not that such a man as I will indeed divine?’"
-          },
+          "en": "And Joseph said unto them: ‘What deed is this that ye have done? know ye not that such a man as I will indeed divine?’",
           "ref": "genesis 44:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And Judah said: ‘What shall we say unto my lord? what shall we speak? or how shall we clear ourselves? God hath found out the iniquity of thy servants; behold, we are my lord’s bondmen, both we, and he also in whose hand the cup is found.’"
-          },
+          "en": "And Judah said: ‘What shall we say unto my lord? what shall we speak? or how shall we clear ourselves? God hath found out the iniquity of thy servants; behold, we are my lord’s bondmen, both we, and he also in whose hand the cup is found.’",
           "ref": "genesis 44:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Far be it from me that I should do so; the man in whose hand the goblet is found, he shall be my bondman; but as for you, get you up in peace unto your father.’"
-          },
+          "en": "And he said: ‘Far be it from me that I should do so; the man in whose hand the goblet is found, he shall be my bondman; but as for you, get you up in peace unto your father.’",
           "ref": "genesis 44:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Judah came near unto him, and said: ‘Oh my lord, let thy servant, I pray thee, speak a word in my lord’s ears, and let not thine anger burn against thy servant; for thou art even as Pharaoh."
-          },
+          "en": "Then Judah came near unto him, and said: ‘Oh my lord, let thy servant, I pray thee, speak a word in my lord’s ears, and let not thine anger burn against thy servant; for thou art even as Pharaoh.",
           "ref": "genesis 44:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "My lord asked his servants, saying: Have ye a father, or a brother?"
-          },
+          "en": "My lord asked his servants, saying: Have ye a father, or a brother?",
           "ref": "genesis 44:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And we said unto my lord: We have a father, an old man, and a child of his old age, a little one; and his brother is dead, and he alone is left of his mother, and his father loveth him."
-          },
+          "en": "And we said unto my lord: We have a father, an old man, and a child of his old age, a little one; and his brother is dead, and he alone is left of his mother, and his father loveth him.",
           "ref": "genesis 44:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou saidst unto thy servants: Bring him down unto me, that I may set mine eyes upon him."
-          },
+          "en": "And thou saidst unto thy servants: Bring him down unto me, that I may set mine eyes upon him.",
           "ref": "genesis 44:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And we said unto my lord: The lad cannot leave his father; for if he should leave his father, his father would die."
-          },
+          "en": "And we said unto my lord: The lad cannot leave his father; for if he should leave his father, his father would die.",
           "ref": "genesis 44:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou saidst unto thy servants: Except your youngest brother come down with you, ye shall see my face no more."
-          },
+          "en": "And thou saidst unto thy servants: Except your youngest brother come down with you, ye shall see my face no more.",
           "ref": "genesis 44:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass when we came up unto thy servant my father, we told him the words of my lord."
-          },
+          "en": "And it came to pass when we came up unto thy servant my father, we told him the words of my lord.",
           "ref": "genesis 44:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And our father said: Go again, buy us a little food."
-          },
+          "en": "And our father said: Go again, buy us a little food.",
           "ref": "genesis 44:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And we said: We cannot go down; if our youngest brother be with us, then will we go down; for we may not see the man’s face, except our youngest brother be with us."
-          },
+          "en": "And we said: We cannot go down; if our youngest brother be with us, then will we go down; for we may not see the man’s face, except our youngest brother be with us.",
           "ref": "genesis 44:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And thy servant my father said unto us: Ye know that my wife bore me two sons;"
-          },
+          "en": "And thy servant my father said unto us: Ye know that my wife bore me two sons;",
           "ref": "genesis 44:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "and the one went out from me, and I said: Surely he is torn in pieces; and I have not seen him since;"
-          },
+          "en": "and the one went out from me, and I said: Surely he is torn in pieces; and I have not seen him since;",
           "ref": "genesis 44:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "and if ye take this one also from me, and harm befall him, ye will bring down my gray hairs with sorrow to the grave."
-          },
+          "en": "and if ye take this one also from me, and harm befall him, ye will bring down my gray hairs with sorrow to the grave.",
           "ref": "genesis 44:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "Now therefore when I come to thy servant my father, and the lad is not with us; seeing that his soul is bound up with the lad’s soul;"
-          },
+          "en": "Now therefore when I come to thy servant my father, and the lad is not with us; seeing that his soul is bound up with the lad’s soul;",
           "ref": "genesis 44:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "it will come to pass, when he seeth that the lad is not with us, that he will die; and thy servants will bring down the gray hairs of thy servant our father with sorrow to the grave."
-          },
+          "en": "it will come to pass, when he seeth that the lad is not with us, that he will die; and thy servants will bring down the gray hairs of thy servant our father with sorrow to the grave.",
           "ref": "genesis 44:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "For thy servant became surety for the lad unto my father, saying: If I bring him not unto thee, then shall I bear the blame to my father for ever."
-          },
+          "en": "For thy servant became surety for the lad unto my father, saying: If I bring him not unto thee, then shall I bear the blame to my father for ever.",
           "ref": "genesis 44:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "Now therefore, let thy servant, I pray thee, abide instead of the lad a bondman to my lord; and let the lad go up with his brethren."
-          },
+          "en": "Now therefore, let thy servant, I pray thee, abide instead of the lad a bondman to my lord; and let the lad go up with his brethren.",
           "ref": "genesis 44:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "For how shall I go up to my father, if the lad be not with me? lest I look upon the evil that shall come on my father.’"
-          },
+          "en": "For how shall I go up to my father, if the lad be not with me? lest I look upon the evil that shall come on my father.’",
           "ref": "genesis 44:34"
         }
       ]
@@ -11099,226 +7022,142 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Joseph could not refrain himself before all them that stood by him; and he cried: ‘Cause every man to go out from me.’ And there stood no man with him, while Joseph made himself known unto his brethren."
-          },
+          "en": "Then Joseph could not refrain himself before all them that stood by him; and he cried: ‘Cause every man to go out from me.’ And there stood no man with him, while Joseph made himself known unto his brethren.",
           "ref": "genesis 45:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And he wept aloud; and the Egyptians heard, and the house of Pharaoh heard."
-          },
+          "en": "And he wept aloud; and the Egyptians heard, and the house of Pharaoh heard.",
           "ref": "genesis 45:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph said unto his brethren: ‘I am Joseph; doth my father yet live?’ And his brethren could not answer him; for they were affrighted at his presence."
-          },
+          "en": "And Joseph said unto his brethren: ‘I am Joseph; doth my father yet live?’ And his brethren could not answer him; for they were affrighted at his presence.",
           "ref": "genesis 45:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph said unto his brethren: ‘Come near to me, I pray you.’ And they came near. And he said: ‘I am Joseph your brother, whom ye sold into Egypt."
-          },
+          "en": "And Joseph said unto his brethren: ‘Come near to me, I pray you.’ And they came near. And he said: ‘I am Joseph your brother, whom ye sold into Egypt.",
           "ref": "genesis 45:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And now be not grieved, nor angry with yourselves, that ye sold me hither; for God did send me before you to preserve life."
-          },
+          "en": "And now be not grieved, nor angry with yourselves, that ye sold me hither; for God did send me before you to preserve life.",
           "ref": "genesis 45:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "For these two years hath the famine been in the land; and there are yet five years, in which there shall be neither plowing nor harvest."
-          },
+          "en": "For these two years hath the famine been in the land; and there are yet five years, in which there shall be neither plowing nor harvest.",
           "ref": "genesis 45:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And God sent me before you to give you a remnant on the earth, and to save you alive for a great deliverance."
-          },
+          "en": "And God sent me before you to give you a remnant on the earth, and to save you alive for a great deliverance.",
           "ref": "genesis 45:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "So now it was not you that sent me hither, but God; and He hath made me a father to Pharaoh, and lord of all his house, and ruler over all the land of Egypt."
-          },
+          "en": "So now it was not you that sent me hither, but God; and He hath made me a father to Pharaoh, and lord of all his house, and ruler over all the land of Egypt.",
           "ref": "genesis 45:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "Hasten ye, and go up to my father, and say unto him: Thus saith thy son Joseph: God hath made me lord of all Egypt; come down unto me, tarry not."
-          },
+          "en": "Hasten ye, and go up to my father, and say unto him: Thus saith thy son Joseph: God hath made me lord of all Egypt; come down unto me, tarry not.",
           "ref": "genesis 45:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And thou shalt dwell in the land of Goshen, and thou shalt be near unto me, thou, and thy children, and thy children’s children, and thy flocks, and thy herds, and all that thou hast;"
-          },
+          "en": "And thou shalt dwell in the land of Goshen, and thou shalt be near unto me, thou, and thy children, and thy children’s children, and thy flocks, and thy herds, and all that thou hast;",
           "ref": "genesis 45:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "and there will I sustain thee; for there are yet five years of famine; lest thou come to poverty, thou, and thy household, and all that thou hast."
-          },
+          "en": "and there will I sustain thee; for there are yet five years of famine; lest thou come to poverty, thou, and thy household, and all that thou hast.",
           "ref": "genesis 45:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And, behold, your eyes see, and the eyes of my brother Benjamin, that it is my mouth that speaketh unto you."
-          },
+          "en": "And, behold, your eyes see, and the eyes of my brother Benjamin, that it is my mouth that speaketh unto you.",
           "ref": "genesis 45:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And ye shall tell my father of all my glory in Egypt, and of all that ye have seen; and ye shall hasten and bring down my father hither.’"
-          },
+          "en": "And ye shall tell my father of all my glory in Egypt, and of all that ye have seen; and ye shall hasten and bring down my father hither.’",
           "ref": "genesis 45:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And he fell upon his brother Benjamin’s neck, and wept; and Benjamin wept upon his neck."
-          },
+          "en": "And he fell upon his brother Benjamin’s neck, and wept; and Benjamin wept upon his neck.",
           "ref": "genesis 45:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And he kissed all his brethren, and wept upon them; and after that his brethren talked with him."
-          },
+          "en": "And he kissed all his brethren, and wept upon them; and after that his brethren talked with him.",
           "ref": "genesis 45:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And the report thereof was heard in Pharaoh’s house, saying: ‘Joseph’s brethren are come’; and it pleased Pharaoh well, and his servants."
-          },
+          "en": "And the report thereof was heard in Pharaoh’s house, saying: ‘Joseph’s brethren are come’; and it pleased Pharaoh well, and his servants.",
           "ref": "genesis 45:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh said unto Joseph: ‘Say unto thy brethren: This do ye: lade your beasts, and go, get you unto the land of Canaan;"
-          },
+          "en": "And Pharaoh said unto Joseph: ‘Say unto thy brethren: This do ye: lade your beasts, and go, get you unto the land of Canaan;",
           "ref": "genesis 45:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "and take your father and your households, and come unto me; and I will give you the good of the land of Egypt, and ye shall eat the fat of the land."
-          },
+          "en": "and take your father and your households, and come unto me; and I will give you the good of the land of Egypt, and ye shall eat the fat of the land.",
           "ref": "genesis 45:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "Now thou art commanded, this do ye: take you wagons out of the land of Egypt for your little ones, and for your wives, and bring your father, and come."
-          },
+          "en": "Now thou art commanded, this do ye: take you wagons out of the land of Egypt for your little ones, and for your wives, and bring your father, and come.",
           "ref": "genesis 45:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "Also regard not your stuff; for the good things of all the land of Egypt are yours.’"
-          },
+          "en": "Also regard not your stuff; for the good things of all the land of Egypt are yours.’",
           "ref": "genesis 45:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Israel did so; and Joseph gave them wagons, according to the commandment of Pharaoh, and gave them provision for the way."
-          },
+          "en": "And the sons of Israel did so; and Joseph gave them wagons, according to the commandment of Pharaoh, and gave them provision for the way.",
           "ref": "genesis 45:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "To all of them he gave each man changes of raiment; but to Benjamin he gave three hundred shekels of silver, and five changes of raiment."
-          },
+          "en": "To all of them he gave each man changes of raiment; but to Benjamin he gave three hundred shekels of silver, and five changes of raiment.",
           "ref": "genesis 45:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And to his father he sent in like manner ten asses laden with the good things of Egypt, and ten she-asses laden with corn and bread and victual for his father by the way."
-          },
+          "en": "And to his father he sent in like manner ten asses laden with the good things of Egypt, and ten she-asses laden with corn and bread and victual for his father by the way.",
           "ref": "genesis 45:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "So he sent his brethren away, and they departed; and he said unto them: ‘See that ye fall not out by the way.’"
-          },
+          "en": "So he sent his brethren away, and they departed; and he said unto them: ‘See that ye fall not out by the way.’",
           "ref": "genesis 45:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And they went up out of Egypt, and came into the land of Canaan unto Jacob their father."
-          },
+          "en": "And they went up out of Egypt, and came into the land of Canaan unto Jacob their father.",
           "ref": "genesis 45:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And they told him, saying: ‘Joseph is yet alive, and he is ruler over all the land of Egypt.’ And his heart fainted, for he believed them not."
-          },
+          "en": "And they told him, saying: ‘Joseph is yet alive, and he is ruler over all the land of Egypt.’ And his heart fainted, for he believed them not.",
           "ref": "genesis 45:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And they told him all the words of Joseph, which he had said unto them; and when he saw the wagons which Joseph had sent to carry him, the spirit of Jacob their father revived."
-          },
+          "en": "And they told him all the words of Joseph, which he had said unto them; and when he saw the wagons which Joseph had sent to carry him, the spirit of Jacob their father revived.",
           "ref": "genesis 45:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And Israel said: ‘It is enough; Joseph my son is yet alive; I will go and see him before I die.’"
-          },
+          "en": "And Israel said: ‘It is enough; Joseph my son is yet alive; I will go and see him before I die.’",
           "ref": "genesis 45:28"
         }
       ]
@@ -11328,274 +7167,172 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And Israel took his journey with all that he had, and came to Beer-sheba, and offered sacrifices unto the God of his father Isaac."
-          },
+          "en": "And Israel took his journey with all that he had, and came to Beer-sheba, and offered sacrifices unto the God of his father Isaac.",
           "ref": "genesis 46:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And God spoke unto Israel in the visions of the night, and said: ‘Jacob, Jacob.’ And he said: ‘Here am I.’"
-          },
+          "en": "And God spoke unto Israel in the visions of the night, and said: ‘Jacob, Jacob.’ And he said: ‘Here am I.’",
           "ref": "genesis 46:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And He said: ‘I am God, the God of thy father; fear not to go down into Egypt; for I will there make of thee a great nation."
-          },
+          "en": "And He said: ‘I am God, the God of thy father; fear not to go down into Egypt; for I will there make of thee a great nation.",
           "ref": "genesis 46:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "I will go down with thee into Egypt; and I will also surely bring thee up again; and Joseph shall put his hand upon thine eyes.’"
-          },
+          "en": "I will go down with thee into Egypt; and I will also surely bring thee up again; and Joseph shall put his hand upon thine eyes.’",
           "ref": "genesis 46:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob rose up from Beer-sheba; and the sons of Israel carried Jacob their father, and their little ones, and their wives, in the wagons which Pharaoh had sent to carry him."
-          },
+          "en": "And Jacob rose up from Beer-sheba; and the sons of Israel carried Jacob their father, and their little ones, and their wives, in the wagons which Pharaoh had sent to carry him.",
           "ref": "genesis 46:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And they took their cattle, and their goods, which they had gotten in the land of Canaan, and came into Egypt, Jacob, and all his seed with him;"
-          },
+          "en": "And they took their cattle, and their goods, which they had gotten in the land of Canaan, and came into Egypt, Jacob, and all his seed with him;",
           "ref": "genesis 46:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "his sons, and his sons’sons with him, his daughters, and his sons’daughters, and all his seed brought he with him into Egypt."
-          },
+          "en": "his sons, and his sons’sons with him, his daughters, and his sons’daughters, and all his seed brought he with him into Egypt.",
           "ref": "genesis 46:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And these are the names of the children of Israel, who came into Egypt, Jacob and his sons: Reuben, Jacob’s first-born."
-          },
+          "en": "And these are the names of the children of Israel, who came into Egypt, Jacob and his sons: Reuben, Jacob’s first-born.",
           "ref": "genesis 46:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Reuben: Hanoch, and Pallu, and Hezron, and Carmi."
-          },
+          "en": "And the sons of Reuben: Hanoch, and Pallu, and Hezron, and Carmi.",
           "ref": "genesis 46:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Simeon: Jemuel, and Jamin, and Ohad, and Jachin, and Zohar, and Shaul the son of a Canaanitish woman."
-          },
+          "en": "And the sons of Simeon: Jemuel, and Jamin, and Ohad, and Jachin, and Zohar, and Shaul the son of a Canaanitish woman.",
           "ref": "genesis 46:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Levi: Gershon, Kohath, and Merari."
-          },
+          "en": "And the sons of Levi: Gershon, Kohath, and Merari.",
           "ref": "genesis 46:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Judah: Er, and Onan, and Shelah, and Perez, and Zerah; but Er and Onan died in the land of Canaan. And the sons of Perez were Hezron and Hamul."
-          },
+          "en": "And the sons of Judah: Er, and Onan, and Shelah, and Perez, and Zerah; but Er and Onan died in the land of Canaan. And the sons of Perez were Hezron and Hamul.",
           "ref": "genesis 46:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Issachar: Tola, and Puvah, and Iob, and Shimron."
-          },
+          "en": "And the sons of Issachar: Tola, and Puvah, and Iob, and Shimron.",
           "ref": "genesis 46:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Zebulun: Sered, and Elon, and Jahleel."
-          },
+          "en": "And the sons of Zebulun: Sered, and Elon, and Jahleel.",
           "ref": "genesis 46:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the sons of Leah, whom she bore unto Jacob in Paddan-aram, with his daughter Dinah; all the souls of his sons and his daughters were thirty and three."
-          },
+          "en": "These are the sons of Leah, whom she bore unto Jacob in Paddan-aram, with his daughter Dinah; all the souls of his sons and his daughters were thirty and three.",
           "ref": "genesis 46:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Gad: Ziphion, and Haggi, Shuni, and Ezbon, Eri, and Arodi, and Areli."
-          },
+          "en": "And the sons of Gad: Ziphion, and Haggi, Shuni, and Ezbon, Eri, and Arodi, and Areli.",
           "ref": "genesis 46:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Asher: Imnah, and Ishvah, and Ishvi, and Beriah, and Serah their sister; and the sons of Beriah: Heber, and Malchiel."
-          },
+          "en": "And the sons of Asher: Imnah, and Ishvah, and Ishvi, and Beriah, and Serah their sister; and the sons of Beriah: Heber, and Malchiel.",
           "ref": "genesis 46:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the sons of Zilpah, whom Laban gave to Leah his daughter, and these she bore unto Jacob, even sixteen souls."
-          },
+          "en": "These are the sons of Zilpah, whom Laban gave to Leah his daughter, and these she bore unto Jacob, even sixteen souls.",
           "ref": "genesis 46:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "The sons of Rachel Jacob’s wife: Joseph and Benjamin."
-          },
+          "en": "The sons of Rachel Jacob’s wife: Joseph and Benjamin.",
           "ref": "genesis 46:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And unto Joseph in the land of Egypt were born Manasseh and Ephraim, whom Asenath the daughter of Poti-phera priest of On bore unto him."
-          },
+          "en": "And unto Joseph in the land of Egypt were born Manasseh and Ephraim, whom Asenath the daughter of Poti-phera priest of On bore unto him.",
           "ref": "genesis 46:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Benjamin: Bela, and Becher, and Ashbel, Gera, and Naaman, Ehi, and Rosh, Muppim, and Huppim, and Ard."
-          },
+          "en": "And the sons of Benjamin: Bela, and Becher, and Ashbel, Gera, and Naaman, Ehi, and Rosh, Muppim, and Huppim, and Ard.",
           "ref": "genesis 46:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the sons of Rachel, who were born to Jacob; all the souls were fourteen."
-          },
+          "en": "These are the sons of Rachel, who were born to Jacob; all the souls were fourteen.",
           "ref": "genesis 46:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Dan: Hushim."
-          },
+          "en": "And the sons of Dan: Hushim.",
           "ref": "genesis 46:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Naphtali: Jahzeel, and Guni, and Jezer, and Shillem."
-          },
+          "en": "And the sons of Naphtali: Jahzeel, and Guni, and Jezer, and Shillem.",
           "ref": "genesis 46:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "These are the sons of Bilhah, whom Laban gave unto Rachel his daughter, and these she bore unto Jacob; all the souls were seven."
-          },
+          "en": "These are the sons of Bilhah, whom Laban gave unto Rachel his daughter, and these she bore unto Jacob; all the souls were seven.",
           "ref": "genesis 46:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "All the souls belonging to Jacob that came into Egypt, that came out of his loins, besides Jacob’s sons’wives, all the souls were threescore and six."
-          },
+          "en": "All the souls belonging to Jacob that came into Egypt, that came out of his loins, besides Jacob’s sons’wives, all the souls were threescore and six.",
           "ref": "genesis 46:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And the sons of Joseph, who were born to him in Egypt, were two souls; all the souls of the house of Jacob, that came into Egypt, were threescore and ten."
-          },
+          "en": "And the sons of Joseph, who were born to him in Egypt, were two souls; all the souls of the house of Jacob, that came into Egypt, were threescore and ten.",
           "ref": "genesis 46:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And he sent Judah before him unto Joseph, to show the way before him unto Goshen; and they came into the land of Goshen."
-          },
+          "en": "And he sent Judah before him unto Joseph, to show the way before him unto Goshen; and they came into the land of Goshen.",
           "ref": "genesis 46:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph made ready his chariot, and went up to meet Israel his father, to Goshen; and he presented himself unto him, and fell on his neck, and wept on his neck a good while."
-          },
+          "en": "And Joseph made ready his chariot, and went up to meet Israel his father, to Goshen; and he presented himself unto him, and fell on his neck, and wept on his neck a good while.",
           "ref": "genesis 46:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "And Israel said unto Joseph: ‘Now let me die, since I have seen thy face, that thou art yet alive.’"
-          },
+          "en": "And Israel said unto Joseph: ‘Now let me die, since I have seen thy face, that thou art yet alive.’",
           "ref": "genesis 46:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph said unto his brethren, and unto his father’s house: ‘I will go up, and tell Pharaoh, and will say unto him: My brethren, and my father’s house, who were in the land of Canaan, are come unto me;"
-          },
+          "en": "And Joseph said unto his brethren, and unto his father’s house: ‘I will go up, and tell Pharaoh, and will say unto him: My brethren, and my father’s house, who were in the land of Canaan, are come unto me;",
           "ref": "genesis 46:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "and the men are shepherds, for they have been keepers of cattle; and they have brought their flocks, and their herds, and all that they have."
-          },
+          "en": "and the men are shepherds, for they have been keepers of cattle; and they have brought their flocks, and their herds, and all that they have.",
           "ref": "genesis 46:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall come to pass, when Pharaoh shall call you, and shall say: What is your occupation?"
-          },
+          "en": "And it shall come to pass, when Pharaoh shall call you, and shall say: What is your occupation?",
           "ref": "genesis 46:33"
         },
         {
           "n": 34,
-          "en": {
-            "sct": null,
-            "jps1917": "that ye shall say: Thy servants have been keepers of cattle from our youth even until now, both we, and our fathers; that ye may dwell in the land of Goshen; for every shepherd is an abomination unto the Egyptians.’"
-          },
+          "en": "that ye shall say: Thy servants have been keepers of cattle from our youth even until now, both we, and our fathers; that ye may dwell in the land of Goshen; for every shepherd is an abomination unto the Egyptians.’",
           "ref": "genesis 46:34"
         }
       ]
@@ -11605,250 +7342,157 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Joseph went in and told Pharaoh, and said: ‘My father and my brethren, and their flocks, and their herds, and all that they have, are come out of the land of Canaan; and, behold, they are in the land of Goshen.’"
-          },
+          "en": "Then Joseph went in and told Pharaoh, and said: ‘My father and my brethren, and their flocks, and their herds, and all that they have, are come out of the land of Canaan; and, behold, they are in the land of Goshen.’",
           "ref": "genesis 47:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And from among his brethren he took five men, and presented them unto Pharaoh."
-          },
+          "en": "And from among his brethren he took five men, and presented them unto Pharaoh.",
           "ref": "genesis 47:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh said unto his brethren: ‘What is your occupation?’ And they said unto Pharaoh: ‘Thy servants are shepherds, both we, and our fathers.’"
-          },
+          "en": "And Pharaoh said unto his brethren: ‘What is your occupation?’ And they said unto Pharaoh: ‘Thy servants are shepherds, both we, and our fathers.’",
           "ref": "genesis 47:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said unto Pharaoh: ‘To sojourn in the land are we come; for there is no pasture for thy servants’flocks; for the famine is sore in the land of Canaan. Now therefore, we pray thee, let thy servants dwell in the land of Goshen.’"
-          },
+          "en": "And they said unto Pharaoh: ‘To sojourn in the land are we come; for there is no pasture for thy servants’flocks; for the famine is sore in the land of Canaan. Now therefore, we pray thee, let thy servants dwell in the land of Goshen.’",
           "ref": "genesis 47:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh spoke unto Joseph, saying: ‘Thy father and thy brethren are come unto thee;"
-          },
+          "en": "And Pharaoh spoke unto Joseph, saying: ‘Thy father and thy brethren are come unto thee;",
           "ref": "genesis 47:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "the land of Egypt is before thee; in the best of the land make thy father and thy brethren to dwell; in the land of Goshen let them dwell. And if thou knowest any able men among them, then make them rulers over my cattle.’"
-          },
+          "en": "the land of Egypt is before thee; in the best of the land make thy father and thy brethren to dwell; in the land of Goshen let them dwell. And if thou knowest any able men among them, then make them rulers over my cattle.’",
           "ref": "genesis 47:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph brought in Jacob his father, and set him before Pharaoh. And Jacob blessed Pharaoh."
-          },
+          "en": "And Joseph brought in Jacob his father, and set him before Pharaoh. And Jacob blessed Pharaoh.",
           "ref": "genesis 47:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh said unto Jacob: ‘How many are the days of the years of thy life?’"
-          },
+          "en": "And Pharaoh said unto Jacob: ‘How many are the days of the years of thy life?’",
           "ref": "genesis 47:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob said unto Pharaoh: ‘The days of the years of my sojournings are a hundred and thirty years; few and evil have been the days of the years of my life, and they have not attained unto the days of the years of the life of my fathers in the days of their sojournings.’"
-          },
+          "en": "And Jacob said unto Pharaoh: ‘The days of the years of my sojournings are a hundred and thirty years; few and evil have been the days of the years of my life, and they have not attained unto the days of the years of the life of my fathers in the days of their sojournings.’",
           "ref": "genesis 47:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob blessed Pharaoh, and went out from the presence of Pharaoh."
-          },
+          "en": "And Jacob blessed Pharaoh, and went out from the presence of Pharaoh.",
           "ref": "genesis 47:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph placed his father and his brethren, and gave them a possession in the land of Egypt, in the best of the land, in the land of Rameses, as Pharaoh had commanded."
-          },
+          "en": "And Joseph placed his father and his brethren, and gave them a possession in the land of Egypt, in the best of the land, in the land of Rameses, as Pharaoh had commanded.",
           "ref": "genesis 47:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph sustained his father, and his brethren, and all his father’s household, with bread, according to the want of their little ones."
-          },
+          "en": "And Joseph sustained his father, and his brethren, and all his father’s household, with bread, according to the want of their little ones.",
           "ref": "genesis 47:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And there was no bread in all the land; for the famine was very sore, so that the land of Egypt and the land of Canaan languished by reason of the famine."
-          },
+          "en": "And there was no bread in all the land; for the famine was very sore, so that the land of Egypt and the land of Canaan languished by reason of the famine.",
           "ref": "genesis 47:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph gathered up all the money that was found in the land of Egypt, and in the land of Canaan, for the corn which they bought; and Joseph brought the money into Pharaoh’s house."
-          },
+          "en": "And Joseph gathered up all the money that was found in the land of Egypt, and in the land of Canaan, for the corn which they bought; and Joseph brought the money into Pharaoh’s house.",
           "ref": "genesis 47:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And when the money was all spent in the land of Egypt, and in the land of Canaan, all the Egyptians came unto Joseph, and said: ‘Give us bread; for why should we die in thy presence? for our money faileth.’"
-          },
+          "en": "And when the money was all spent in the land of Egypt, and in the land of Canaan, all the Egyptians came unto Joseph, and said: ‘Give us bread; for why should we die in thy presence? for our money faileth.’",
           "ref": "genesis 47:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph said: ‘Give your cattle, and I will give you [bread] for your cattle, if money fail.’"
-          },
+          "en": "And Joseph said: ‘Give your cattle, and I will give you [bread] for your cattle, if money fail.’",
           "ref": "genesis 47:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And they brought their cattle unto Joseph. And Joseph gave them bread in exchange for the horses, and for the flocks, and for the herds, and for the asses; and he fed them with bread in exchange for all their cattle for that year."
-          },
+          "en": "And they brought their cattle unto Joseph. And Joseph gave them bread in exchange for the horses, and for the flocks, and for the herds, and for the asses; and he fed them with bread in exchange for all their cattle for that year.",
           "ref": "genesis 47:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And when that year was ended, they came unto him the second year, and said unto him: ‘We will not hide from my lord, how that our money is all spent; and the herds of cattle are my lord’s; there is nought left in the sight of my lord, but our bodies, and our lands."
-          },
+          "en": "And when that year was ended, they came unto him the second year, and said unto him: ‘We will not hide from my lord, how that our money is all spent; and the herds of cattle are my lord’s; there is nought left in the sight of my lord, but our bodies, and our lands.",
           "ref": "genesis 47:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "Wherefore should we die before thine eyes, both we and our land? buy us and our land for bread, and we and our land will be bondmen unto Pharaoh; and give us seed, that we may live, and not die, and that the land be not desolate.’"
-          },
+          "en": "Wherefore should we die before thine eyes, both we and our land? buy us and our land for bread, and we and our land will be bondmen unto Pharaoh; and give us seed, that we may live, and not die, and that the land be not desolate.’",
           "ref": "genesis 47:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "So Joseph bought all the land of Egypt for Pharaoh; for the Egyptians sold every man his field, because the famine was sore upon them; and the land became Pharaoh’s."
-          },
+          "en": "So Joseph bought all the land of Egypt for Pharaoh; for the Egyptians sold every man his field, because the famine was sore upon them; and the land became Pharaoh’s.",
           "ref": "genesis 47:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And as for the people, he removed them city by city, from one end of the border of Egypt even to the other end thereof."
-          },
+          "en": "And as for the people, he removed them city by city, from one end of the border of Egypt even to the other end thereof.",
           "ref": "genesis 47:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "Only the land of the priests bought he not, for the priests had a portion from Pharaoh, and did eat their portion which Pharaoh gave them; wherefore they sold not their land."
-          },
+          "en": "Only the land of the priests bought he not, for the priests had a portion from Pharaoh, and did eat their portion which Pharaoh gave them; wherefore they sold not their land.",
           "ref": "genesis 47:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "Then Joseph said unto the people: ‘Behold, I have bought you this day and your land for Pharaoh. Lo, here is seed for you, and ye shall sow the land."
-          },
+          "en": "Then Joseph said unto the people: ‘Behold, I have bought you this day and your land for Pharaoh. Lo, here is seed for you, and ye shall sow the land.",
           "ref": "genesis 47:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And it shall come to pass at the ingatherings, that ye shall give a fifth unto Pharaoh, and four parts shall be your own, for seed of the field, and for your food, and for them of your households, and for food for your little ones.’"
-          },
+          "en": "And it shall come to pass at the ingatherings, that ye shall give a fifth unto Pharaoh, and four parts shall be your own, for seed of the field, and for your food, and for them of your households, and for food for your little ones.’",
           "ref": "genesis 47:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And they said: ‘Thou hast saved our lives. Let us find favour in the sight of my lord, and we will be Pharaoh’s bondmen.’"
-          },
+          "en": "And they said: ‘Thou hast saved our lives. Let us find favour in the sight of my lord, and we will be Pharaoh’s bondmen.’",
           "ref": "genesis 47:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph made it a statute concerning the land of Egypt unto this day, that Pharaoh should have the fifth; only the land of the priests alone became not Pharaoh’s."
-          },
+          "en": "And Joseph made it a statute concerning the land of Egypt unto this day, that Pharaoh should have the fifth; only the land of the priests alone became not Pharaoh’s.",
           "ref": "genesis 47:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "And Israel dwelt in the land of Egypt, in the land of Goshen; and they got them possessions therein, and were fruitful, and multiplied exceedingly."
-          },
+          "en": "And Israel dwelt in the land of Egypt, in the land of Goshen; and they got them possessions therein, and were fruitful, and multiplied exceedingly.",
           "ref": "genesis 47:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob lived in the land of Egypt seventeen years; so the days of Jacob, the years of his life, were a hundred forty and seven years."
-          },
+          "en": "And Jacob lived in the land of Egypt seventeen years; so the days of Jacob, the years of his life, were a hundred forty and seven years.",
           "ref": "genesis 47:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And the time drew near that Israel must die; and he called his son Joseph, and said unto him: ‘If now I have found favour in thy sight, put, I pray thee, thy hand under my thigh, and deal kindly and truly with me; bury me not, I pray thee, in Egypt."
-          },
+          "en": "And the time drew near that Israel must die; and he called his son Joseph, and said unto him: ‘If now I have found favour in thy sight, put, I pray thee, thy hand under my thigh, and deal kindly and truly with me; bury me not, I pray thee, in Egypt.",
           "ref": "genesis 47:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "But when I sleep with my fathers, thou shalt carry me out of Egypt, and bury me in their burying-place.’ And he said: ‘I will do as thou hast said.’"
-          },
+          "en": "But when I sleep with my fathers, thou shalt carry me out of Egypt, and bury me in their burying-place.’ And he said: ‘I will do as thou hast said.’",
           "ref": "genesis 47:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "And he said: ‘Swear unto me.’ And he swore unto him. And Israel bowed down upon the bed’s head."
-          },
+          "en": "And he said: ‘Swear unto me.’ And he swore unto him. And Israel bowed down upon the bed’s head.",
           "ref": "genesis 47:31"
         }
       ]
@@ -11858,178 +7502,112 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And it came to pass after these things, that one said to Joseph: ‘Behold, thy father is sick.’ And he took with him his two sons, Manasseh and Ephraim."
-          },
+          "en": "And it came to pass after these things, that one said to Joseph: ‘Behold, thy father is sick.’ And he took with him his two sons, Manasseh and Ephraim.",
           "ref": "genesis 48:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "And one told Jacob, and said: ‘Behold, thy son Joseph cometh unto thee.’ And Israel strengthened himself, and sat upon the bed."
-          },
+          "en": "And one told Jacob, and said: ‘Behold, thy son Joseph cometh unto thee.’ And Israel strengthened himself, and sat upon the bed.",
           "ref": "genesis 48:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob said unto Joseph: ‘God Almighty appeared unto me at Luz in the land of Canaan, and blessed me,"
-          },
+          "en": "And Jacob said unto Joseph: ‘God Almighty appeared unto me at Luz in the land of Canaan, and blessed me,",
           "ref": "genesis 48:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "and said unto me: Behold, I will make thee fruitful, and multiply thee, and I will make of thee a company of peoples; and will give this land to thy seed after thee for an everlasting possession."
-          },
+          "en": "and said unto me: Behold, I will make thee fruitful, and multiply thee, and I will make of thee a company of peoples; and will give this land to thy seed after thee for an everlasting possession.",
           "ref": "genesis 48:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "And now thy two sons, who were born unto thee in the land of Egypt before I came unto thee into Egypt, are mine; Ephraim and Manasseh, even as Reuben and Simeon, shall be mine."
-          },
+          "en": "And now thy two sons, who were born unto thee in the land of Egypt before I came unto thee into Egypt, are mine; Ephraim and Manasseh, even as Reuben and Simeon, shall be mine.",
           "ref": "genesis 48:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And thy issue, that thou begettest after them, shall be thine; they shall be called after the name of their brethren in their inheritance."
-          },
+          "en": "And thy issue, that thou begettest after them, shall be thine; they shall be called after the name of their brethren in their inheritance.",
           "ref": "genesis 48:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And as for me, when I came from Paddan, Rachel died unto me in the land of Canaan in the way, when there was still some way to come unto Ephrath; and I buried her there in the way to Ephrath—the same is Beth-lehem.’"
-          },
+          "en": "And as for me, when I came from Paddan, Rachel died unto me in the land of Canaan in the way, when there was still some way to come unto Ephrath; and I buried her there in the way to Ephrath—the same is Beth-lehem.’",
           "ref": "genesis 48:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "And Israel beheld Joseph’s sons, and said: ‘Who are these?’"
-          },
+          "en": "And Israel beheld Joseph’s sons, and said: ‘Who are these?’",
           "ref": "genesis 48:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph said unto his father: ‘They are my sons, whom God hath given me here.’ And he said: ‘Bring them, I pray thee, unto me, and I will bless them.’"
-          },
+          "en": "And Joseph said unto his father: ‘They are my sons, whom God hath given me here.’ And he said: ‘Bring them, I pray thee, unto me, and I will bless them.’",
           "ref": "genesis 48:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "Now the eyes of Israel were dim for age, so that he could not see. And he brought them near unto him; and he kissed them, and embraced them."
-          },
+          "en": "Now the eyes of Israel were dim for age, so that he could not see. And he brought them near unto him; and he kissed them, and embraced them.",
           "ref": "genesis 48:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And Israel said unto Joseph: ‘I had not thought to see thy face; and, lo, God hath let me see thy seed also.’"
-          },
+          "en": "And Israel said unto Joseph: ‘I had not thought to see thy face; and, lo, God hath let me see thy seed also.’",
           "ref": "genesis 48:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph brought them out from between his knees; and he fell down on his face to the earth."
-          },
+          "en": "And Joseph brought them out from between his knees; and he fell down on his face to the earth.",
           "ref": "genesis 48:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph took them both, Ephraim in his right hand toward Israel’s left hand, and Manasseh in his left hand toward Israel’s right hand, and brought them near unto him."
-          },
+          "en": "And Joseph took them both, Ephraim in his right hand toward Israel’s left hand, and Manasseh in his left hand toward Israel’s right hand, and brought them near unto him.",
           "ref": "genesis 48:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And Israel stretched out his right hand, and laid it upon Ephraim’s head, who was the younger, and his left hand upon Manasseh’s head, guiding his hands wittingly; for Manasseh was the first-born."
-          },
+          "en": "And Israel stretched out his right hand, and laid it upon Ephraim’s head, who was the younger, and his left hand upon Manasseh’s head, guiding his hands wittingly; for Manasseh was the first-born.",
           "ref": "genesis 48:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And he blessed Joseph, and said: ‘The God before whom my fathers Abraham and Isaac did walk, the God who hath been my shepherd all my life long unto this day,"
-          },
+          "en": "And he blessed Joseph, and said: ‘The God before whom my fathers Abraham and Isaac did walk, the God who hath been my shepherd all my life long unto this day,",
           "ref": "genesis 48:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "the angel who hath redeemed me from all evil, bless the lads; and let my name be named in them, and the name of my fathers Abraham and Isaac; and let them grow into a multitude in the midst of the earth.’"
-          },
+          "en": "the angel who hath redeemed me from all evil, bless the lads; and let my name be named in them, and the name of my fathers Abraham and Isaac; and let them grow into a multitude in the midst of the earth.’",
           "ref": "genesis 48:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Joseph saw that his father was laying his right hand upon the head of Ephraim, it displeased him, and he held up his father’s hand, to remove it from Ephraim’s head unto Manasseh’s head."
-          },
+          "en": "And when Joseph saw that his father was laying his right hand upon the head of Ephraim, it displeased him, and he held up his father’s hand, to remove it from Ephraim’s head unto Manasseh’s head.",
           "ref": "genesis 48:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph said unto his father: ‘Not so, my father, for this is the first-born; put thy right hand upon his head.’"
-          },
+          "en": "And Joseph said unto his father: ‘Not so, my father, for this is the first-born; put thy right hand upon his head.’",
           "ref": "genesis 48:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And his father refused, and said: ‘I know it, my son, I know it; he also shall become a people, and he also shall be great; howbeit his younger brother shall be greater than he, and his seed shall become a multitude of nations.’"
-          },
+          "en": "And his father refused, and said: ‘I know it, my son, I know it; he also shall become a people, and he also shall be great; howbeit his younger brother shall be greater than he, and his seed shall become a multitude of nations.’",
           "ref": "genesis 48:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And he blessed them that day, saying: ‘By thee shall Israel bless, saying: God make thee as Ephraim and as Manasseh.’ And he set Ephraim before Manasseh."
-          },
+          "en": "And he blessed them that day, saying: ‘By thee shall Israel bless, saying: God make thee as Ephraim and as Manasseh.’ And he set Ephraim before Manasseh.",
           "ref": "genesis 48:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "And Israel said unto Joseph: ‘Behold, I die; but God will be with you, and bring you back unto the land of your fathers."
-          },
+          "en": "And Israel said unto Joseph: ‘Behold, I die; but God will be with you, and bring you back unto the land of your fathers.",
           "ref": "genesis 48:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "Moreover I have given to thee one aportion above thy brethren, which I took out of the hand of the Amorite with my sword and with my bow.’"
-          },
+          "en": "Moreover I have given to thee one aportion above thy brethren, which I took out of the hand of the Amorite with my sword and with my bow.’",
           "ref": "genesis 48:22"
         }
       ]
@@ -12039,266 +7617,167 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": null,
-            "jps1917": "And Jacob called unto his sons, and said: ‘Gather yourselves together, that I may tell you that which shall befall you in the end of days."
-          },
+          "en": "And Jacob called unto his sons, and said: ‘Gather yourselves together, that I may tell you that which shall befall you in the end of days.",
           "ref": "genesis 49:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": null,
-            "jps1917": "Assemble yourselves, and hear, ye sons of Jacob; And hearken unto Israel your father."
-          },
+          "en": "Assemble yourselves, and hear, ye sons of Jacob; And hearken unto Israel your father.",
           "ref": "genesis 49:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": null,
-            "jps1917": "Reuben, thou art my first-born, My might, and the first-fruits of my strength; The excellency of dignity, and the excellency of power."
-          },
+          "en": "Reuben, thou art my first-born, My might, and the first-fruits of my strength; The excellency of dignity, and the excellency of power.",
           "ref": "genesis 49:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "Unstable as water, have not thou the excellency; Because thou wentest up to thy father’s bed; Then defiledst thou it—he went up to my couch."
-          },
+          "en": "Unstable as water, have not thou the excellency; Because thou wentest up to thy father’s bed; Then defiledst thou it—he went up to my couch.",
           "ref": "genesis 49:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "Simeon and Levi are brethren; Weapons of violence their kinship."
-          },
+          "en": "Simeon and Levi are brethren; Weapons of violence their kinship.",
           "ref": "genesis 49:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "Let my soul not come into their council; Unto their assembly let my glory not be not united; For in their anger they slew men, And in their self-will they houghed oxen."
-          },
+          "en": "Let my soul not come into their council; Unto their assembly let my glory not be not united; For in their anger they slew men, And in their self-will they houghed oxen.",
           "ref": "genesis 49:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "Cursed be their anger, for it was fierce, And their wrath, for it was cruel; I will divide them in Jacob, And scatter them in Israel."
-          },
+          "en": "Cursed be their anger, for it was fierce, And their wrath, for it was cruel; I will divide them in Jacob, And scatter them in Israel.",
           "ref": "genesis 49:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "Judah, thee shall thy brethren praise; Thy hand shall be on the neck of thine enemies; Thy father’s sons shall bow down before thee."
-          },
+          "en": "Judah, thee shall thy brethren praise; Thy hand shall be on the neck of thine enemies; Thy father’s sons shall bow down before thee.",
           "ref": "genesis 49:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "Judah is a lion’s whelp; From the prey, my son, thou art gone up. He stooped down, he couched as a lion, And as a lioness; who shall rouse him up?"
-          },
+          "en": "Judah is a lion’s whelp; From the prey, my son, thou art gone up. He stooped down, he couched as a lion, And as a lioness; who shall rouse him up?",
           "ref": "genesis 49:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "The sceptre shall not depart from Judah, Nor the ruler’s staff from between his feet, As long as men come to Shiloh; And unto him shall the obedience of the peoples be."
-          },
+          "en": "The sceptre shall not depart from Judah, Nor the ruler’s staff from between his feet, As long as men come to Shiloh; And unto him shall the obedience of the peoples be.",
           "ref": "genesis 49:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "Binding his foal unto the vine, And his ass’s colt unto the choice vine; He washeth his garments in wine, And his vesture in the blood of grapes;"
-          },
+          "en": "Binding his foal unto the vine, And his ass’s colt unto the choice vine; He washeth his garments in wine, And his vesture in the blood of grapes;",
           "ref": "genesis 49:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "His eyes shall be red with wine, And his teeth white with milk."
-          },
+          "en": "His eyes shall be red with wine, And his teeth white with milk.",
           "ref": "genesis 49:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "Zebulun shall dwell at the shore of the sea, And he shall be a shore for ships, And his flank shall be upon Zidon."
-          },
+          "en": "Zebulun shall dwell at the shore of the sea, And he shall be a shore for ships, And his flank shall be upon Zidon.",
           "ref": "genesis 49:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "Issachar is a large-boned ass, Couching down between the sheep-folds."
-          },
+          "en": "Issachar is a large-boned ass, Couching down between the sheep-folds.",
           "ref": "genesis 49:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "For he saw a resting-place that it was good, And the land that it was pleasant; And he bowed his shoulder to bear, And became a servant under task-work"
-          },
+          "en": "For he saw a resting-place that it was good, And the land that it was pleasant; And he bowed his shoulder to bear, And became a servant under task-work",
           "ref": "genesis 49:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "Dan shall judge his people, As one of the tribes of Israel."
-          },
+          "en": "Dan shall judge his people, As one of the tribes of Israel.",
           "ref": "genesis 49:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "Dan shall be a serpent in the way, A horned snake in the path, That biteth the horse’s heels, So that his rider falleth backward."
-          },
+          "en": "Dan shall be a serpent in the way, A horned snake in the path, That biteth the horse’s heels, So that his rider falleth backward.",
           "ref": "genesis 49:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "I wait for Thy salvation, O Lord."
-          },
+          "en": "I wait for Thy salvation, O Lord.",
           "ref": "genesis 49:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "Gad, a troop shall troop upon him; But he shall troop upon their heel."
-          },
+          "en": "Gad, a troop shall troop upon him; But he shall troop upon their heel.",
           "ref": "genesis 49:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "As for Asher, his bread shall be fat, And he shall yield royal dainties."
-          },
+          "en": "As for Asher, his bread shall be fat, And he shall yield royal dainties.",
           "ref": "genesis 49:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "Naphtali is a hind let loose: He giveth goodly words."
-          },
+          "en": "Naphtali is a hind let loose: He giveth goodly words.",
           "ref": "genesis 49:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": "A charming son is Joseph, a son charming to the eye; [of the] women, [each one] strode along to see him.",
-            "jps1917": "Joseph is a fruitful vine, A fruitful vine by a fountain; Its branches run over the wall. ."
-          },
+          "en": "Joseph is a fruitful vine, A fruitful vine by a fountain; Its branches run over the wall. .",
           "ref": "genesis 49:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "The archers have dealt bitterly with him, And shot at him, and hated him;"
-          },
+          "en": "The archers have dealt bitterly with him, And shot at him, and hated him;",
           "ref": "genesis 49:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "But his bow abode firm, And the arms of his hands were made supple, By the hands of the Mighty One of Jacob, From thence, from the Shepherd, the Stone of Israel,"
-          },
+          "en": "But his bow abode firm, And the arms of his hands were made supple, By the hands of the Mighty One of Jacob, From thence, from the Shepherd, the Stone of Israel,",
           "ref": "genesis 49:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "Even by the God of thy father, who shall help thee, And by the Almighty, who shall bless thee, With blessings of heaven above, Blessings of the deep that coucheth beneath, Blessings of the breasts, and of the womb."
-          },
+          "en": "Even by the God of thy father, who shall help thee, And by the Almighty, who shall bless thee, With blessings of heaven above, Blessings of the deep that coucheth beneath, Blessings of the breasts, and of the womb.",
           "ref": "genesis 49:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "The blessings of thy father Are mighty beyond the blessings of my progenitors Unto the utmost bound of the everlasting hills; They shall be on the head of Joseph, And on the crown of the head of the prince among his brethren."
-          },
+          "en": "The blessings of thy father Are mighty beyond the blessings of my progenitors Unto the utmost bound of the everlasting hills; They shall be on the head of Joseph, And on the crown of the head of the prince among his brethren.",
           "ref": "genesis 49:26"
         },
         {
           "n": 27,
-          "en": {
-            "sct": null,
-            "jps1917": "Benjamin is a wolf that raveneth; In the morning he devoureth the prey, And at even he divideth the spoil.’"
-          },
+          "en": "Benjamin is a wolf that raveneth; In the morning he devoureth the prey, And at even he divideth the spoil.’",
           "ref": "genesis 49:27"
         },
         {
           "n": 28,
-          "en": {
-            "sct": null,
-            "jps1917": "All these are the twelve tribes of Israel, and this is it that their father spoke unto them and blessed them; every one according to his blessing he blessed them."
-          },
+          "en": "All these are the twelve tribes of Israel, and this is it that their father spoke unto them and blessed them; every one according to his blessing he blessed them.",
           "ref": "genesis 49:28"
         },
         {
           "n": 29,
-          "en": {
-            "sct": null,
-            "jps1917": "And be charged them, and said unto them: ‘I am to be gathered unto my people; bury me with my fathers in the cave that is in the field of Ephron the Hittite,"
-          },
+          "en": "And be charged them, and said unto them: ‘I am to be gathered unto my people; bury me with my fathers in the cave that is in the field of Ephron the Hittite,",
           "ref": "genesis 49:29"
         },
         {
           "n": 30,
-          "en": {
-            "sct": null,
-            "jps1917": "in the cave that is in the field of Machpelah, which is before Mamre, in the land of Canaan, which Abraham bought with the field from Ephron the Hittite for a possession of a burying-place."
-          },
+          "en": "in the cave that is in the field of Machpelah, which is before Mamre, in the land of Canaan, which Abraham bought with the field from Ephron the Hittite for a possession of a burying-place.",
           "ref": "genesis 49:30"
         },
         {
           "n": 31,
-          "en": {
-            "sct": null,
-            "jps1917": "There they buried Abraham and Sarah his wife; there they buried Isaac and Rebekah his wife; and there I buried Leah."
-          },
+          "en": "There they buried Abraham and Sarah his wife; there they buried Isaac and Rebekah his wife; and there I buried Leah.",
           "ref": "genesis 49:31"
         },
         {
           "n": 32,
-          "en": {
-            "sct": null,
-            "jps1917": "The field and the cave that is therein, which was purchased from the children of Heth.’"
-          },
+          "en": "The field and the cave that is therein, which was purchased from the children of Heth.’",
           "ref": "genesis 49:32"
         },
         {
           "n": 33,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Jacob made an end of charging his sons, he gathered up his feet into the bed, and expired, and was gathered unto his people."
-          },
+          "en": "And when Jacob made an end of charging his sons, he gathered up his feet into the bed, and expired, and was gathered unto his people.",
           "ref": "genesis 49:33"
         }
       ]
@@ -12308,210 +7787,132 @@
       "verses": [
         {
           "n": 1,
-          "en": {
-            "sct": ".and placed in the coffin in Egypt...",
-            "jps1917": "And Joseph fell upon his father’s face, and wept upon him, and kissed him."
-          },
+          "en": "And Joseph fell upon his father’s face, and wept upon him, and kissed him.",
           "ref": "genesis 50:1"
         },
         {
           "n": 2,
-          "en": {
-            "sct": "see Chizkuni. It says \"BaAron\", not \"BeAron\". Its a preexistent and determinated coffin.",
-            "jps1917": "And Joseph commanded his servants the physicians to embalm his father. And the physicians embalmed Israel."
-          },
+          "en": "And Joseph commanded his servants the physicians to embalm his father. And the physicians embalmed Israel.",
           "ref": "genesis 50:2"
         },
         {
           "n": 3,
-          "en": {
-            "sct": "...וַיִּ֥ישֶׂם בָּאָר֖וֹן בְּמִצְרָֽיִם׃",
-            "jps1917": "And forty days were fulfilled for him; for so are fulfilled the days of embalming. And the Egyptians wept for him threescore and ten days."
-          },
+          "en": "And forty days were fulfilled for him; for so are fulfilled the days of embalming. And the Egyptians wept for him threescore and ten days.",
           "ref": "genesis 50:3"
         },
         {
           "n": 4,
-          "en": {
-            "sct": null,
-            "jps1917": "And when the days of weeping for him were past, Joseph spoke unto the house of Pharaoh, saying: ‘If now I have found favour in your eyes, speak, I pray you, in the ears of Pharaoh, saying:"
-          },
+          "en": "And when the days of weeping for him were past, Joseph spoke unto the house of Pharaoh, saying: ‘If now I have found favour in your eyes, speak, I pray you, in the ears of Pharaoh, saying:",
           "ref": "genesis 50:4"
         },
         {
           "n": 5,
-          "en": {
-            "sct": null,
-            "jps1917": "My father made me swear, saying: Lo, I die; in my grave which I have digged for me in the land of Canaan, there shalt thou bury me. Now therefore let me go up, I pray thee, and bury my father, and I will come back.’ ."
-          },
+          "en": "My father made me swear, saying: Lo, I die; in my grave which I have digged for me in the land of Canaan, there shalt thou bury me. Now therefore let me go up, I pray thee, and bury my father, and I will come back.’ .",
           "ref": "genesis 50:5"
         },
         {
           "n": 6,
-          "en": {
-            "sct": null,
-            "jps1917": "And Pharaoh said: ‘Go up, and bury thy father, according as he made thee swear.’"
-          },
+          "en": "And Pharaoh said: ‘Go up, and bury thy father, according as he made thee swear.’",
           "ref": "genesis 50:6"
         },
         {
           "n": 7,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph went up to bury his father; and with him went up all the servants of Pharaoh, the elders of his house, and all the elders of the land of Egypt,"
-          },
+          "en": "And Joseph went up to bury his father; and with him went up all the servants of Pharaoh, the elders of his house, and all the elders of the land of Egypt,",
           "ref": "genesis 50:7"
         },
         {
           "n": 8,
-          "en": {
-            "sct": null,
-            "jps1917": "and all the house of Joseph, and his brethren, and his father’s house; only their little ones, and their flocks, and their herds, they left in the land of Goshen."
-          },
+          "en": "and all the house of Joseph, and his brethren, and his father’s house; only their little ones, and their flocks, and their herds, they left in the land of Goshen.",
           "ref": "genesis 50:8"
         },
         {
           "n": 9,
-          "en": {
-            "sct": null,
-            "jps1917": "And there went up with him both chariots and horsemen; and it was a very great company."
-          },
+          "en": "And there went up with him both chariots and horsemen; and it was a very great company.",
           "ref": "genesis 50:9"
         },
         {
           "n": 10,
-          "en": {
-            "sct": null,
-            "jps1917": "And they came to the threshing-floor of Atad, which is beyond the Jordan, and there they wailed with a very great and sore wailing; and he made a mourning for his father seven days."
-          },
+          "en": "And they came to the threshing-floor of Atad, which is beyond the Jordan, and there they wailed with a very great and sore wailing; and he made a mourning for his father seven days.",
           "ref": "genesis 50:10"
         },
         {
           "n": 11,
-          "en": {
-            "sct": null,
-            "jps1917": "And when the inhabitants of the land, the Canaanites, saw the mourning in the floor of Atad, they said: ‘This is a grievous amourning to the Egyptians.’ Wherefore the name of it was called Abel-mizraim, which is beyond the Jordan."
-          },
+          "en": "And when the inhabitants of the land, the Canaanites, saw the mourning in the floor of Atad, they said: ‘This is a grievous amourning to the Egyptians.’ Wherefore the name of it was called Abel-mizraim, which is beyond the Jordan.",
           "ref": "genesis 50:11"
         },
         {
           "n": 12,
-          "en": {
-            "sct": null,
-            "jps1917": "And his sons did unto him according as he commanded them."
-          },
+          "en": "And his sons did unto him according as he commanded them.",
           "ref": "genesis 50:12"
         },
         {
           "n": 13,
-          "en": {
-            "sct": null,
-            "jps1917": "For his sons carried him into the land of Canaan, and buried him in the cave of the field of Machpelah, which Abraham bought with the field, for a possession of a burying-place, of Ephron the Hittite, in front of Mamre."
-          },
+          "en": "For his sons carried him into the land of Canaan, and buried him in the cave of the field of Machpelah, which Abraham bought with the field, for a possession of a burying-place, of Ephron the Hittite, in front of Mamre.",
           "ref": "genesis 50:13"
         },
         {
           "n": 14,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph returned into Egypt, he, and his brethren, and all that went up with him to bury his father, after he had buried his father."
-          },
+          "en": "And Joseph returned into Egypt, he, and his brethren, and all that went up with him to bury his father, after he had buried his father.",
           "ref": "genesis 50:14"
         },
         {
           "n": 15,
-          "en": {
-            "sct": null,
-            "jps1917": "And when Joseph’s brethren saw that their father was dead, they said: ‘It may be that Joseph will hate us, and will fully requite us all the evil which we did unto him.’"
-          },
+          "en": "And when Joseph’s brethren saw that their father was dead, they said: ‘It may be that Joseph will hate us, and will fully requite us all the evil which we did unto him.’",
           "ref": "genesis 50:15"
         },
         {
           "n": 16,
-          "en": {
-            "sct": null,
-            "jps1917": "And they sent a message unto Joseph, saying: ‘Thy father did command before he died, saying:"
-          },
+          "en": "And they sent a message unto Joseph, saying: ‘Thy father did command before he died, saying:",
           "ref": "genesis 50:16"
         },
         {
           "n": 17,
-          "en": {
-            "sct": null,
-            "jps1917": "So shall ye say unto Joseph: Forgive, I pray thee now, the transgression of thy brethren, and their sin, for that they did unto thee evil. And now, we pray thee, forgive the transgression of the servants of the God of thy father.’ And Joseph wept when they spoke unto him."
-          },
+          "en": "So shall ye say unto Joseph: Forgive, I pray thee now, the transgression of thy brethren, and their sin, for that they did unto thee evil. And now, we pray thee, forgive the transgression of the servants of the God of thy father.’ And Joseph wept when they spoke unto him.",
           "ref": "genesis 50:17"
         },
         {
           "n": 18,
-          "en": {
-            "sct": null,
-            "jps1917": "And his brethren also went and fell down before his face; and they said: ‘Behold, we are thy bondmen.’"
-          },
+          "en": "And his brethren also went and fell down before his face; and they said: ‘Behold, we are thy bondmen.’",
           "ref": "genesis 50:18"
         },
         {
           "n": 19,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph said unto them: ‘Fear not; for am I in the place of God?"
-          },
+          "en": "And Joseph said unto them: ‘Fear not; for am I in the place of God?",
           "ref": "genesis 50:19"
         },
         {
           "n": 20,
-          "en": {
-            "sct": null,
-            "jps1917": "And as for you, ye meant evil against me; but God meant it for good, to bring to pass, as it is this day, to save much people alive."
-          },
+          "en": "And as for you, ye meant evil against me; but God meant it for good, to bring to pass, as it is this day, to save much people alive.",
           "ref": "genesis 50:20"
         },
         {
           "n": 21,
-          "en": {
-            "sct": null,
-            "jps1917": "Now therefore fear ye not; I will sustain you, and your little ones.’ And he comforted them, and spoke kindly unto them."
-          },
+          "en": "Now therefore fear ye not; I will sustain you, and your little ones.’ And he comforted them, and spoke kindly unto them.",
           "ref": "genesis 50:21"
         },
         {
           "n": 22,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph dwelt in Egypt, he, and his father’s house; and Joseph lived a hundred and ten years."
-          },
+          "en": "And Joseph dwelt in Egypt, he, and his father’s house; and Joseph lived a hundred and ten years.",
           "ref": "genesis 50:22"
         },
         {
           "n": 23,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph saw Ephraim’s children of the third generation; the children also of Machir the son of Manasseh were born upon Joseph’s knees."
-          },
+          "en": "And Joseph saw Ephraim’s children of the third generation; the children also of Machir the son of Manasseh were born upon Joseph’s knees.",
           "ref": "genesis 50:23"
         },
         {
           "n": 24,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph said unto his brethren: ‘I die; but God will surely remember you, and bring you up out of this land unto the land which He swore to Abraham, to Isaac, and to Jacob.’"
-          },
+          "en": "And Joseph said unto his brethren: ‘I die; but God will surely remember you, and bring you up out of this land unto the land which He swore to Abraham, to Isaac, and to Jacob.’",
           "ref": "genesis 50:24"
         },
         {
           "n": 25,
-          "en": {
-            "sct": null,
-            "jps1917": "And Joseph took an oath of the children of Israel, saying: ‘God will surely remember you, and ye shall carry up my bones from hence.’"
-          },
+          "en": "And Joseph took an oath of the children of Israel, saying: ‘God will surely remember you, and ye shall carry up my bones from hence.’",
           "ref": "genesis 50:25"
         },
         {
           "n": 26,
-          "en": {
-            "sct": null,
-            "jps1917": "So Joseph died, being a hundred and ten years old. And they embalmed him, and he was put in a coffin in Egypt."
-          },
+          "en": "So Joseph died, being a hundred and ten years old. And they embalmed him, and he was put in a coffin in Egypt.",
           "ref": "genesis 50:26"
         }
       ]

--- a/app/renderer/types.ts
+++ b/app/renderer/types.ts
@@ -84,7 +84,7 @@ export interface ContentPackManifest {
 
 export interface TanakhManifestBookAvailability {
   he: boolean;
-  en: { sct: boolean; jps1917: boolean };
+  en: boolean;
   onqelos: boolean;
 }
 
@@ -120,7 +120,7 @@ export interface HebrewPackBook {
 
 export interface EnglishPackVerse {
   n: number;
-  en: { sct: string | null; jps1917: string | null };
+  en: string | null;
   ref: string;
 }
 

--- a/scripts/local-import-tanakh.mjs
+++ b/scripts/local-import-tanakh.mjs
@@ -226,7 +226,7 @@ function main() {
       chapter: ch.chapter,
       verses: ch.verses.map((v) => ({
         n: v.n,
-        en: { sct: null, jps1917: v.en ?? null },
+        en: v.en ?? null,
         ref: v.ref
       }))
     }))
@@ -262,10 +262,7 @@ function main() {
   entry.chapters = heOut.chapters.length;
   entry.available = {
     he: true,
-    en: {
-      sct: entry.available?.en?.sct ?? false,
-      jps1917: true
-    },
+    en: true,
     onqelos: !!onq
   };
   bySlug.set(slug, entry);


### PR DESCRIPTION
## Summary
- drop the Sefaria community translation option from the Tanakh loader and text views so only the JPS 1917 English remains
- normalize the Tanakh manifest and English packs to store a single English string per verse
- update the local import helper to emit the simplified English data shape going forward

## Testing
- npm run test *(fails: existing Today screen and hebrewCalendar expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68dee18d424c833386055e8084414398